### PR TITLE
typo fix

### DIFF
--- a/fulljslint.js
+++ b/fulljslint.js
@@ -4096,7 +4096,7 @@ loop:   for (;;) {
 // then we have an undefined variable.
 
             } else if (funct['(global)']) {
-                if (option.undef && predefined[v] !== 'boolean') {
+                if (option.undef && typeof predefined[v] !== 'boolean') {
                     warning("'{a}' is not defined.", token, v);
                 }
                 note_implied(token);


### PR DESCRIPTION
I think there should be typeof predefined[v] !== 'boolean' instead of "predefined[v] !== 'boolean'" because predefined is a hash with boolean values :)
