### PR TITLE
export jslint for commonjs

### DIFF
--- a/fulljslint.js
+++ b/fulljslint.js
@@ -5784,3 +5784,8 @@ loop:   for (;;) {
     return itself;
 
 }());
+
+// export JSLINT if in commonjs env
+if (typeof exports !== 'undefined') {
+    exports.JSLINT = JSLINT;
+}


### PR DESCRIPTION
To avoid ugly evals of jslint in any commonjs env. like nodejs, would be nice to export jslint.
