### PR TITLE
Allow `predef` option to be an object

### DIFF
--- a/fulljslint.js
+++ b/fulljslint.js
@@ -5408,6 +5408,12 @@ loop:   for (;;) {
                 for (i = 0; i < a.length; i += 1) {
                     predefined[a[i]] = true;
                 }
+            } else if (a instanceof Object) {
+                for (i in a) {
+                    if (a.hasOwnProperty(i)) {
+                        predefined[i] = (a[i] === true);
+                    }
+                }
             }
             if (o.adsafe) {
                 o.safe = true;


### PR DESCRIPTION
When calling `JSLINT(input, options)`, you aren't currently able to specify the read-only status of predefined global variables unless you use the `/*globals foo:true */` in-code comment. The `options.predef` option is currently restricted to an array of predefined globals, each of which is assumed to be read-only.

This commit adds the ability to specify the `predef` option as an object, with the variable name as the key and the read-only status as a boolean:

```
JSLINT(input, {predef: {foo: true, bar: false}});
// Equivalent to having the following comment in the input:
/*globals foo:true, bar */
```
