### PR TITLE
Fix issue with new option.predef feature

### DIFF
--- a/fulljslint.js
+++ b/fulljslint.js
@@ -5419,7 +5419,7 @@ loop:   for (;;) {
                     }
                 } else if (typeof a === 'object') {
                     k = Object.keys(a);
-                    for (i = 0; i < a.length; i += 1) {
+                    for (i = 0; i < k.length; i += 1) {
                         predefined[k[i]] = !!a[k];
                     }
                 }


### PR DESCRIPTION
This could be the smallest patch I've ever submitted. :) In the code for the new `option.predef` feature, I think you meant to check `k.length` instead of `a.length`.

Thanks!
