### PR TITLE
Fix issue causing `/*jslint white:false */` to have no effect

### DIFF
--- a/fulljslint.js
+++ b/fulljslint.js
@@ -2458,9 +2458,17 @@ loop:   for (;;) {
                     }
                     obj.maxlen = b;
                 } else if (nexttoken.id === 'true') {
-                    obj[n.value] = true;
+                    if (n.value === 'white' && o === '/*jslint') {
+                        w = obj.white = true;
+                    } else {
+                        obj[n.value] = true;
+                    }
                 } else if (nexttoken.id === 'false') {
-                    obj[n.value] = false;
+                    if (n.value === 'white' && o === '/*jslint') {
+                        w = obj.white = false;
+                    } else {
+                        obj[n.value] = false;
+                    }
                 } else {
                     error(bundle.unexpected_a);
                 }


### PR DESCRIPTION
It appears that after commit cac64ef7b4a3ee353c92824ef7c6e24102af4d82, `option.white` cannot be set to false using the `/*jslint white:false */` comment. The commit in this pull request fixes the issue.
