### PR TITLE
Fix data() function.param

### DIFF
--- a/fulljslint.js
+++ b/fulljslint.js
@@ -6279,6 +6279,14 @@ loop:   for (;;) {
             }
             function_data.name = the_function['(name)'];
             function_data.param = the_function['(params)'];
+            if (function_data.param) {
+                for (j = 0; j < function_data.param.length; j += 1) {
+                    if (function_data.param[j]
+                            && typeof function_data.param[j] == 'object') {
+                        function_data.param[j] = function_data.param[j].value;
+                    }
+                }
+            }
             function_data.line = the_function['(line)'];
             data.functions.push(function_data);
         }


### PR DESCRIPTION
I was updating jslint4java to the latest JSLint, and noticed that the data structure returned by data() isn't as it used to be.  In particular, it looks like the parameter listing of a function is no longer a list of strings.

This patch fixes it for me, though it may be handled better earlier in the code.
