### PR TITLE
Typo in comments

### DIFF
--- a/fulljslint.js
+++ b/fulljslint.js
@@ -189,7 +189,7 @@ SOFTWARE.
     rhino      true, if the Rhino environment globals should be predefined
     undef      true, if variables should be declared before used
     safe       true, if use of some browser features should be restricted
-    windows    true, if MS Windows-specigic globals should be predefined
+    windows    true, if MS Windows-specific globals should be predefined
     strict     true, require the "use strict"; pragma
     sub        true, if all forms of subscript notation are tolerated
     white      true, if strict whitespace rules apply


### PR DESCRIPTION
This is a one-line commit that fixes a typo in comments: specigic instead of specific.

Anton
