### PR TITLE
indent of 0 should ignore indenting, default indent should be 4

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -6531,7 +6531,10 @@ klass:              do {
         } else {
             option = {};
         }
-        option.indent = +option.indent || 0;
+        option.indent = +option.indent;
+        if (!isFinite(option.indent)) {
+            option.indent = 4;
+        }
         option.maxerr = option.maxerr || 50;
         adsafe_id = '';
         adsafe_may = adsafe_top = adsafe_went = false;


### PR DESCRIPTION
Thank you for creating this very useful tool.  

While trying to update https://github.com/reid/node-jslint to use a newer version of the jslint, I found that jslint complained about every indentation in the file.  After spending some time tracking down what had changed, I realized that the new version no longer tolerates messy while space, and this had unmasked an issue with the indentation defaults.  The current defaults seem to require code with no indentation at all, which causes problems with readability.  

The documentation at http://www.jslint.com/lint.html describes the indent parameter as "The number of spaces used for indentation (default is 4). If 0, then no indentation checking takes place."  In the current code the default indent seems to be zero, and indent checking is happening even when indent is set to zero.  This patch changes the code's behavior to match the documentation, so that it ignores indentation when indent is set to 0 and by default sets indent to 4.  
