### PR TITLE
node.js and CommonJS module support

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -6930,3 +6930,8 @@ klass:              do {
     return itself;
 
 }());
+
+/*properties JSLINT: function */
+if (exports !== undefined) {
+    exports.JSLINT = JSLINT;
+}


### PR DESCRIPTION
Thanks for writing this useful utility.  Currently the jslint.js file needs to be modified to use it with CommonJS module based systems, like node.js.  Would it be possible to have a few lines added to export the JSLint function?

Several of us are using this in node.js instead of the browser.  It would be great to use a git submodule to directly use your official version of jslint.js in these projects.  Unfortunately we need to modify the official version before using it in node.js because files only share symbols that have been exported and the official version of jslint.js doesn't export any symbols.  While we could use a makefile to append the needed code, many of these projects don't need makefiles for anything else.  

If you're willing to add a tiny bit of code to support this use case, adding the following three lines to the end of jslint.js should be sufficient:

/*properties JSLINT: function */
if (exports !== undefined) {
    exports.JSLINT = JSLINT;
}
