### PR TITLE
CommonJS wrapper

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -6957,5 +6957,5 @@ klass:              do {
 
 // CommonJS wrapper
 if (typeof exports !== "undefined") {
-	exports.JSLINT = JSLINT;
+    exports.JSLINT = JSLINT;
 }


### PR DESCRIPTION
This patch makes JSLint usable as a CommonJS module.
