### PR TITLE
CommonJS module env validation

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -195,7 +195,7 @@
 // For example:
 
 /*jslint
-    evil: true, nomen: true, regexp: true
+    evil: true, nomen: true, regexp: true, commonjs: true
 */
 
 // The properties directive declares an exclusive list of property names.


### PR DESCRIPTION
Would this patch be acceptable to validate scripts as CommonJS modules?

If not, I suppose you desire that:
- Users pass in the CommonJS module globals via `predef` and
- Users patch jslint.js if they wish to use it as a CommonJS module?

Given the number of CommonJS modules out there I think it make sense to support the CommonJS env natively.
