### PR TITLE
"Suppress messages" feature for JSLint

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -1116,6 +1116,9 @@ var JSLINT = (function () {
 
     function do_warn(message, offender, a, b, c, d) {
         var character, line, warning;
+        if (JSLINT.suppressed_messages[message] === true) {
+            return false;
+        }
         offender = offender || next_token;  // ~~
         line = offender.line || 0;
         character = offender.from || 0;
@@ -1157,7 +1160,9 @@ var JSLINT = (function () {
 
     function stop(message, offender, a, b, c, d) {
         var warning = do_warn(message, offender, a, b, c, d);
-        quit(bundle.stopping, warning.line, warning.character);
+        if (warning !== false) {
+            quit(bundle.stopping, warning.line, warning.character);
+        }
     }
 
     function stop_at(message, line, character, a, b, c, d) {


### PR DESCRIPTION
In the current JSLint version, not everything is configurable; some checks are impossible to disable. This patch provides user with workaround for this limitation, allowing to disable specific warning messages (as opposed to checks that triggered the warning).

Allows to write code like this:

``` javascript
options: {
    suppress: { unnecessary_use: true }
}
```

or

``` javascript
"use strict";

var itWillBeStringifiedAndSentToBrowser = function () {
    /*suppress unnecessary_use: true */
    "use strict"; //so that the function will be executed in strict environment in browser
}
```
- Implemented `suppress` setting in `options`, in the fashion similar to `predef` setting (e.g. `suppress: ['some_message', 'some_other_message']` or `suppress: { some_message: true, some_other_message: true }`). `true` means that the message should be suppressed, false is the default.
- Implemented setting `suppress` setting inline, in the fashion similar to `/*jslint ... */` and `/*global ... */` (e.g. `/*suppress some_message, some_other_message */` or `/*suppress some_message: true, other_message_suppressed_in_an_external_scope: false */`).
- Changed JSLint processing source code files to respect `suppress` setting; if the error JSLint is about to report is suppressed, it won't report about the error nor include it in its report.
- In order to make this with as less pain as possible, some additional modifications were performed. Namely,
  - Previously `warn` always returned some return value. `warn` is used everywhere, but we only cared about the return value in `stop`. Now, only `do_warn` returns a return value, and `do_warn` is only called from `warn` and `stop`. In case error passed to `do_warn` should be suppressed, `do_warn` returns false instead of the detailed error info object.
  - In order for `do_warn` to check whether the message should be suppressed, `suppressed_messages` property added to JSLint object.
