### PR TITLE
Disallows the use of reserved words as variable or function declaration ...

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -2857,12 +2857,12 @@ klass:              do {
     }
 
 
-    function optional_identifier() {
+    function optional_identifier(p) {
         if (next_token.identifier) {
             advance();
             if (option.safe && banned[token.string]) {
                 warn('adsafe_a', token);
-            } else if (token.reserved && !option.es5) {
+            } else if (token.reserved && (!p || !option.es5)) {
                 warn('expected_identifier_a_reserved', token);
             }
             return token.string;


### PR DESCRIPTION
...identifiers. Currently, no warning is given for such use of reserved words when the es5 option is set to true. See https://github.com/jshint/jshint/issues/744 for more details
