### PR TITLE
Mixed tabs and spaces.

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -1195,11 +1195,7 @@ var JSLINT = (function () {
             character = 1;
             source_row = lines[line];
             line += 1;
-            at = source_row.search(/ \t/);
-            if (at >= 0) {
-                warn_at('mixed', line, at + 1);
-            }
-            at = source_row.search(/\t /);
+            at = source_row.search(/( \t|\t )/);
             if (at >= 0) {
                 warn_at('mixed', line, at + 1);
             }


### PR DESCRIPTION
Previously we were checking for only space and then for tab.
I am using 4 spaces for a tab and in my code in other project JSLint was not showing any errors.
After pushing to github the source code alignment was breaking where there was a tab and then a space.

So, thought that it will be better to check for space and tab in any combination.

Fixed for the same.
