### PR TITLE
Spaces instead of tabs

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -543,7 +543,7 @@ var JSLINT = (function () {
             missing_url: "Missing url.",
             missing_use_strict: "Missing 'use strict' statement.",
             mixed: "Mixed spaces and tabs.",
-            spaces_intead_of_tabs: "Use spaces instead of tabs.",
+            spaces_instead_of_tabs: "Use spaces instead of tabs.",
             move_invocation: "Move the invocation into the parens that " +
                 "contain the function.",
             move_var: "Move 'var' declarations to the top of the function.",
@@ -1196,13 +1196,13 @@ var JSLINT = (function () {
             character = 1;
             source_row = lines[line];
             line += 1;
+            at = source_row.search(/^\t/);
+            if (at >= 0) {
+                warn_at('spaces_instead_of_tabs', line, at + 1);
+            }
             at = source_row.search(/( \t|\t )/);
             if (at >= 0) {
                 warn_at('mixed', line, at + 1);
-            }
-            at = source_row.search(/\t/);
-            if (at >= 0) {
-                warn_at('spaces_intead_of_tabs', line, at + 1);
             }
             source_row = source_row.replace(/\t/g, tab);
             at = source_row.search(cx);


### PR DESCRIPTION
How about checking for "Spaces instead of Tabs"?

Many editors support "Use spaces instead of tabs".

In one of my project, one line has two tabs and another line has eight spaces. It was looking fine in my editor. But when it was pushed to github.com, the indentation was not good.

If we use spaces instead of tabs, then there is no chance of this improper indentation at any place.

Thought of this and updated JSLint.
