### PR TITLE
Add option to allow unnamed parameters

### DIFF
--- a/jslint.html
+++ b/jslint.html
@@ -294,6 +294,7 @@ div#JSLINT_ dl.level8 {
           <div title=sloppy><button></button><var></var> missing&nbsp;'use strict'&nbsp;pragma</div>
           <div title=stupid><button></button><var></var> stupidity</div>
           <div title=sub><button></button><var></var> inefficient subscripting</div>
+          <div title=unnamed><button></button><var></var> unnamed parameters</div>
         </div>
         <div class=tristate>Tolerate...
           <div title=todo><button></button><var></var> TODO comments</div>

--- a/jslint.js
+++ b/jslint.js
@@ -219,6 +219,7 @@
 //     sloppy     true, if the 'use strict'; pragma is optional
 //     stupid     true, if really stupid practices are tolerated
 //     sub        true, if all forms of subscript notation are tolerated
+//     unnamed    true, if unnamed parameters should be alllowed (e.g. arguments[0])
 //     todo       true, if TODO comments are tolerated
 //     vars       true, if multiple var statements per function should be allowed
 //     white      true, if sloppy whitespace is tolerated
@@ -388,6 +389,7 @@ var JSLINT = (function () {
             sloppy    : true,
             stupid    : true,
             sub       : true,
+            unnamed   : true,
             todo      : true,
             vars      : true,
             white     : true,
@@ -2133,6 +2135,7 @@ klass:              do {
                 option.rhino   =
                 option.sloppy  =
                 option.sub     =
+                option.unnamed =
                 option.undef   =
                 option.windows = false;
 
@@ -3792,7 +3795,7 @@ klass:              do {
         e = expression(0);
         switch (e.id) {
         case '(number)':
-            if (e.id === '(number)' && left.id === 'arguments') {
+            if (!option.unnamed && e.id === '(number)' && left.id === 'arguments') {
                 warn('use_param', left);
             }
             break;

--- a/lint.html
+++ b/lint.html
@@ -684,6 +684,12 @@ options are selected with several checkboxes and two fields. </p>
       better expressed in dot notation.</td>
   </tr>
   <tr>
+    <td>Tolerate unnamed parameters<br>
+    </td>
+    <td><code>unnamed</code></td>
+    <td><code>true</code> if unnamed parameters, such as <code>argument[0]</code>, should be allowed.</td>
+  </tr>
+  <tr>
     <td>Tolerate TODO comments<br>
     </td>
     <td><code>todo</code></td>


### PR DESCRIPTION
This commit adds a new option, 'unnamed', which allows the user to suppress "use named parameters" warnings.
