### PR TITLE
Add function link_errors_to_source setting caret in source from error.

### DIFF
--- a/init_ui.js
+++ b/init_ui.js
@@ -195,6 +195,49 @@ ADSAFE.lib("init_ui", function (lib) {
             show_jslint_directive();
         }
 
+        function link_errors_to_source() {
+            var citeError = errors_div.q('>cite').___nodes___,
+                source_node = source_str.___nodes___[0],
+                sourceLines = source_str.getValue().split(/\n/),
+                getOffsetFromLineChar = function(line, char) {
+                    var line0 = line - 1,
+                        char0 = char - 1,
+                        offset = 0,
+                        i;
+                    for (i = 0; i < line0; i += 1) {
+                        offset += sourceLines[i].length + 1;
+                    }
+                    offset += char0;
+                    return offset;
+                },
+                makeErrorSelector = function(i) {
+                    var err = JSLINT.errors[i],
+                        offset = getOffsetFromLineChar(err.line, err.character),
+                        closeToBottom = err.line - source_node.rows;
+                    // TODO Please note this event listener does not need the event argument.
+                    return function() {
+                        // TODO Please note this calculation needs to be adjusted for 1-based line numbers.
+                        var firstVisibleLine = Math.ceil(source_node.scrollTop * source_node.rows / source_node.clientHeight) + 1;
+                        source_node.setSelectionRange(offset, offset);
+                        // source_node.setSelectionRange(offset, offset+1);
+                        if (err.line < firstVisibleLine) {
+                            source_node.scrollTop = 0;
+                            if (err.line > source_node.rows) {
+                                source_node.scrollByLines(closeToBottom);
+                            }
+                        }
+                        if (err.line > firstVisibleLine + source_node.rows) {
+                            source_node.scrollTop = 0;
+                            source_node.scrollByLines(closeToBottom);
+                        }
+                    };
+                },
+                i;
+            for (i = 0; i < citeError.length; i += 1) {
+                citeError[i].addEventListener('click', makeErrorSelector(i), false);
+            }
+        };
+        
 
 // Restore the options from a JSON cookie.
 
@@ -208,6 +251,7 @@ ADSAFE.lib("init_ui", function (lib) {
             if (lib.jslint(source_str.getValue(), option,
                     errors_div, report_div, properties_str, edition)) {
                 errors.style('display', 'block');
+                link_errors_to_source();
             }
             report.style('display', 'block');
             if (properties_str.getValue().length > 21) {


### PR DESCRIPTION
The function adds a click listener to each error cite which sets caret
in the source textarea and scrolls it into view (only when necessary).

Hello Douglas, here is my first try at integrating the functionality I suggested in
https://plus.google.com/u/0/114973624116584041537/posts/FkZPaDapNcZ

As you will quickly notice even I can tell it is not quite ready to be pulled in.

I am accessing via `___nodes___` in places and using `addEventListener` because I could not get the on method to work.

But it should be good enough for you to play with it and see whether you like the functionality and general implementation.

I tested it locally in an eclipse orion site I created from my local JSLint git clone.
All I have to do is place a copy of web_jslint.js in the same directory (which I made sure not to add to git).

Looking forward to your feedback what I need to fix, if you are interested to pull this feature in an improved form.

Regards,
Adrian
