### PR TITLE
Warn on encountering an invocation of JSON

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -2867,7 +2867,7 @@ klass:              do {
             if (left.string.match(/^[A-Z]([A-Z0-9_$]*[a-z][A-Za-z0-9_$]*)?$/)) {
                 if (left.string !== 'Number' && left.string !== 'String' &&
                         left.string !== 'Boolean' && left.string !== 'Date') {
-                    if (left.string === 'Math' || left.string === 'JSON') {
+                    if (left.string === 'Math') {
                         left.warn('not_a_function');
                     } else if (left.string === 'Object') {
                         token.warn('use_object');
@@ -2875,6 +2875,8 @@ klass:              do {
                         left.warn('missing_a', 'new');
                     }
                 }
+            } else if (left.string === 'JSON') {
+                left.warn('not_a_function');
             }
         } else if (left.id === '.') {
             if (left.second.string === 'split' &&


### PR DESCRIPTION
JSLint is meant to warn when it encounters an invocation of `JSON`, but fails to do so since "JSON" does not match the regex (which looks as if it is meant to match JSLint's format for constructor identifiers).

This fix adds an extra case that will catch the use of `JSON` as a function.
