### PR TITLE
Exposing JSLint as a CommonJS module

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -4250,3 +4250,11 @@ klass:              do {
 
     return itself;
 }());
+
+// If CommonJS is available then export the JSLINT function. This then
+// allows JSLint to be loaded via CommonJS modules e.g.:
+// jslint = require("jslint.js").JSLINT;
+
+if (exports !== undefined) {
+    exports.JSLINT = JSLINT;
+}


### PR DESCRIPTION
I thought that it might be useful to expose the JSLINT function as a [CommonJS module export](http://wiki.commonjs.org/wiki/Modules/1.1.1). This same code should also allow [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD) loaders such as [RequireJS](http://requirejs.org/) to function.

Given the change JSLint can be loaded thus:

```
var jslint = require("/path/to/jslint.js").JSLINT;
```

The support for CommonJS modules would also make JSLint available to [Node](http://nodejs.org/).

Finally we are building an [sbt plugin](http://www.scala-sbt.org/) for the [Play web development framework](http://www.playframework.com/) that uses JSLint and it would be easier for us to have CommonJS supported.
