### PR TITLE
IW: Node.js no longer defines querystring as a global module

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -550,7 +550,7 @@ var JSLINT = (function () {
         lookahead,
         node = array_to_object([
             'Buffer', 'clearImmediate', 'clearInterval', 'clearTimeout',
-            'console', 'exports', 'global', 'module', 'process', 'querystring',
+            'console', 'exports', 'global', 'module', 'process',
             'require', 'setImmediate', 'setInterval', 'setTimeout',
             '__dirname', '__filename'
         ], false),


### PR DESCRIPTION
As of node.js 10.21, it seems that `querystring` is no longer defined as a global. What is stranger is that querystring is loaded in the repl, but not in the module scope. 

The node.js manual also does not seem to list querystring as a global. 

http://nodejs.org/api/globals.html#globals_global

Please let me know if you would rather have a patch file. 

Thank you. 
