### PR TITLE
avoiding warning about wrongly placed invocation parenthesis under Closu...

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -2974,7 +2974,9 @@ klass:              do {
         if (value.id === 'function') {
             switch (next_token.id) {
             case '(':
-                next_token.warn('move_invocation');
+                if (!option.closure || !that.comments) {
+                    next_token.warn('move_invocation');
+                }
                 break;
             case '.':
             case '[':


### PR DESCRIPTION
To fully type the code for Closure compiler it is necessary sometimes to annotate immediate closure call like in:

``` javascript
/*jslint closure: true */

/** @return {void} */
(function () {
    'use strict';
    return;
})();
```

JSLint currently complains about this and suggests to "move the invocation into the parens that contain the function". Unfortunately with Closure it is not possible. The constructs like:

``` javascript
/** @return {void} */
(function () {
    'use strict';
    return;
}());

// or even 

(/** @return {void} */
function () {
    'use strict';
    return;
}());
```

apply the annotations to the result of the the function call, not to the function itself.

The patch fixes that making it possible to have the code where both JSLinit and Closure no longer complains. The change is similar to the check in current code, https://github.com/douglascrockford/JSLint/blob/master/jslint.js#L2987, that disables the warning about unnecessary parenthesis due to Closure constructs for cases like:

``` javascript
foo = /** @type {SomeType} */(bar);
```
