### PR TITLE
* allow 'false' condition in do{}while()

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -3648,7 +3648,10 @@ klass:              do {
         step_in();
         no_space();
         edge();
-        this.first = expected_condition(expected_relation(expression(0)), 'unexpected_a');
+        this.first = expected_relation(expression(0));
+        if (this.first.id !== 'false') {
+            this.first = expected_condition(this.first, 'unexpected_a');
+        }
         no_space();
         step_out(')', paren);
         funct.loopage -= 1;


### PR DESCRIPTION
There are special exceptions made in checking while(){} and for(){}, to allow 'true' as a condition. However, for a do{}while(), a 'false' condition is also reasonable, when the loop is used to avoid multiple nested if() statements.
