### PR TITLE
JSLint will enforce camelCase coding style by disallowing underscores ("...

### DIFF
--- a/intercept.js
+++ b/intercept.js
@@ -13,7 +13,7 @@
 
 // And it provides access to the syntax tree that JSLint constructed.
 
-/*jslint nomen: true, unparam: true */
+/*jslint nomen: true, undersc: true, unparam: true */
 
 /*global ADSAFE, document, JSLINT */
 

--- a/jslint.html
+++ b/jslint.html
@@ -297,6 +297,7 @@ div#JSLINT_ dl.level8 {
           <div title=forin><button></button><var></var> <a href="http://yuiblog.com/blog/2006/09/26/for-in-intrigue/">unfiltered</a> for  in </div>
           <div title=newcap><button></button><var></var> uncapitalized constructors</div>
           <div title=nomen><button></button><var></var> dangling _ in identifiers</div>
+          <div title=undersc><button></button><var></var> _ in identifiers</div>
           <div title=plusplus><button></button><var></var> ++&nbsp;and&nbsp;-- </div>
           <div title=regexp><button></button><var></var> .&nbsp;and&nbsp;[^ ... ]&nbsp;in&nbsp;/RegExp/</div>
           <div title=unparam><button></button><var></var> unused parameters</div>

--- a/jslint.js
+++ b/jslint.js
@@ -172,7 +172,7 @@
 // For example:
 
 /*jslint
-    evil: true, nomen: true, regexp: true, todo: true
+    evil: true, nomen: true, undersc: true, regexp: true, todo: true
 */
 
 // The current option set is
@@ -193,6 +193,7 @@
 //     newcap     true, if constructor names capitalization is ignored
 //     node       true, if Node.js globals should be predefined
 //     nomen      true, if names may have dangling _
+//     undersc    true, if names may have _ (false requires camelCase)
 //     passfail   true, if the scan should stop on first error
 //     plusplus   true, if increment/decrement should be allowed
 //     properties true, if all property names must be declared with /*properties*/
@@ -221,7 +222,7 @@
     bad_number, bad_operand, bad_wrap, bitwise, block, break, breakage, browser,
     c, call, charAt, charCodeAt, character, closure, code, color, combine_var,
     comments, conditional_assignment, confusing_a, confusing_regexp,
-    constructor_name_a, continue, control_a, couch, create, d, dangling_a, data,
+    constructor_name_a, continue, control_a, couch, create, d, dangling_a, underscore_a, data,
     dead, debug, deleted, devel, disrupt, duplicate_a, edge, edition, elif,
     else, empty_block, empty_case, empty_class, entityify, eqeq, error_report,
     errors, evidence, evil, exception, exec, expected_a_at_b_c, expected_a_b,
@@ -237,7 +238,7 @@
     level, line, loopage, master, match, maxerr, maxlen, message, missing_a,
     missing_a_after_b, missing_property, missing_space_a_b, missing_use_strict,
     mode, move_invocation, move_var, n, name, name_function, nested_comment,
-    newcap, node, nomen, not, not_a_constructor, not_a_defined, not_a_function,
+    newcap, node, nomen, undersc, not, not_a_constructor, not_a_defined, not_a_function,
     not_a_label, not_a_scope, not_greater, nud, number, octal_a, open, outer,
     parameter, parameter_a_get_b, parameter_arguments_a, parameter_set_a,
     params, paren, passfail, plusplus, pop, postscript, predef, properties,
@@ -302,6 +303,7 @@ var JSLINT = (function () {
             newcap    : true,
             node      : true,
             nomen     : true,
+            undersc   : true,
             passfail  : true,
             plusplus  : true,
             properties: true,
@@ -376,6 +378,7 @@ var JSLINT = (function () {
                 "an uppercase letter.",
             control_a: "Unexpected control character '{a}'.",
             dangling_a: "Unexpected dangling '_' in '{a}'.",
+            underscore_a: "Unexpected '_' in '{a}'.",
             deleted: "Only properties should be deleted.",
             duplicate_a: "Duplicate '{a}'.",
             empty_block: "Empty block.",
@@ -808,6 +811,9 @@ var JSLINT = (function () {
                         (value.charAt(0) === '_' ||
                         value.charAt(value.length - 1) === '_')) {
                     warn('dangling_a', line, from, value);
+                } else if (!option.undersc &&
+                        (value.indexOf('_') !== -1)) {
+                    warn('underscore_a', line, from, value);
                 }
             }
             if (type === '(number)') {


### PR DESCRIPTION
I've made a version of JSLint that enforces "camelCase" coding style.

Rationale:

When I show code I've written to other JavaScript developers, they've frequently reacted with instant horror upon seeing the underscores. "Don't you know camelCase is THE STANDARD for JavaScript?" they always ask me. I've done Google searches on "underscores vs camelCase" and polled every developer I know to find out their opinion on the issue. Only one programmer, a grizzled C programmer, has told me he likes underscores, and can't get used to camelCase. All the others have either told me underscores look "ugly" and that if I cared at all about the aesthetics of my code, I would make it camelCase (I always thought camelCase looked unaesthetic with the lower case first letter, and then upper case letters later on, but I'm getting used to that bit of weirdness) or that it simply didn't matter whether everyone used underscores or camelCase _as long as everyone does the same thing_.

It also looks to me like the direction the software development world is going, in general, is towards camelCase -- new languages like Go explicitly state that camelCase is the standard (though it is still convention, not actually enforced by the Go compiler), and with older languages like PHP that used to use underscores, almost all the new code written seems to be in camelCase. The biggest holdout seems to be Python, which, due to decree by benevolent dictator Guido Van Rossum, still uses underscores as the standard coding style, and it seems this is only because that is his personal preference and he happens by historical accident to be the benevolent dictator. But all other major languages, and especially Java and JavaScript, seem to use camelCase as their coding style.

So I decided to convert my code to camelCase. At first I pondered doing search-and-replace willy-nilly, but that seemed likely to introduce a lot of errors. I quickly came up with a better way: modify JSLint to throw an error every time it sees an underscore in any token name. I got the source code and hacked together a version that did this. Using this, I was able to convert my code to camelCase, which, while tedious and boring, was entirely error-free.

Since then I have been using my private copy of JSLint to lint all my code including the camelCase requirement. But of course, you have continued to make improvements to the master version of JSLint. So, today, I decided to integrate this feature _properly_ into JSLint, so I don't have to continually resync your improvements with my private copy, and also to make the change available to all developers.

This seems to be in keeping with the philosophy of JSLint, which enforces _lots_ of stylistic conventions. Surprisingly, camelCase is not one of the stylistic conventions that it enforces, even though it appears a well-established standard. However, since it appears to be THE convention for JavaScript and several developers have dinged me and told me they would simply never contribute to my project since it didn't use camelCase, it makes sense to me that JSLint should enforce the camelCase convention also.

The way I did it was to make camelCase enforced by default, but can be disabled by a new option, "Tolerate... _ in identifiers" which appears right under "dangling _ in identifiers" in the UI. In code, enforcement of camelCase can be disabled with

/*jslint undersc: true */

("undersc" indicating to allow underscores).

I modified the JSLint source code itself to include /*jslint undersc: true */ because it looked like JSLint was designed to pass itself. (The JSLint source code uses underscores and not camelCase and I did not convert it! But I did add the directive so it would continue to pass itself.)

It's up to you whether to accept the pull request or not. You can:
- Accept it,
- Accept it and make changes, (for example if you didn't  like "undersc" for the directive name -- very simple to just change it to whatever you want -- I chose "undersc" because it seemed to be the JSLint style to give the directive options terse names),
- Demand I make further changes, such as reversing it so underscores are permitted by default (in which case I guess it would have to be moved to the "Assume..." column, more on that below), or
- Do nothing.

The rationale for enforcing camelCase by default is that it seems to be the philosophy of JSLint that JSLint does what makes the most possible sense regardless of whether the changes "break" existing code.

Furthermore since existing code can be grandfathered in with a directive if developers don't want to fix it, (as I did with the JSLint code itself), "breaking" existing code doesn't seem to serious.

Still, I recognize that this is a major change to JSLint as it affects every single identifier name in a program. Making this feature enabled by default would require additional documentation on other pages on the jslint.com site (and possibly warrant a notification on the home page?).

But if it's a big enough issue that JavaScript developers recoil with horror upon seeing my code and tell me they won't contribute to my project if it uses underscores instead of camelCase, and insist it is THE standard for JavaScript ("didn't you ever notice the built-in functions?" -- and it's true, it's not just DOM functions like getElementById but built-in JavaScript functions like charAt and indexOf that are camelCase), then camelCase seems important enough to justify JSLint enforcing by default. My guess is the majority of JavaScript developers are already doing everything in camelCase and their code will pass with few modifications, and they will appreciate the addition of this new check.

Also: I added the /*jslint undersc: true */ directive to ADsafe (one of JSLint's dependencies). So  there is a pull request for you for that also, should you choose to accept it.

I validated the change with the following script ("validate" is the directory name where the validation set is assembled):

copy JSLint\JSLint.js validate
copy ADsafe\adsafe.js validate
copy JSON-js\json2.js validate
copy JSLint\intercept.js validate

type validate\jslint.js validate\adsafe.js validate\json2.js validate\intercept.js >> validate\web_jslint.js

copy JSLint\init_ui.js validate

copy JSLint\jslint.html validate
copy JSLint\title.png validate

copy run-jslint\1and1pill.gif validate
copy run-jslint\adsafepill.gif validate
copy run-jslint\github.gif validate
copy run-jslint\jslintpill.gif validate
copy run-jslint\jsonpill.gif validate

and then verified that the feature works, no run-time JavaScript errors occur, and that running web_jslint.js through JSLint itself produced the same errors as before. (It is not actually error free -- it gives 'Redefinition of' and 'Read only' errors.)

I hope this can be merged back into the main version, since I don't want to be continually out of step with the latest improvements to the main version.

P.S. THANK YOU so much for a) creating JSLint, which is a godsend for creating high-quality web code, and b) for making the source code sufficiently comprehensible that a person such as myself who has no background in parsers is able to make a change such as this.
