### PR TITLE
Include all Node.js globals

### DIFF
--- a/global_extractors/node.js
+++ b/global_extractors/node.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+"use strict";
+
+function caseInsensitiveCompare(a, b) {
+    return a.toLowerCase().localeCompare(b.toLowerCase());
+}
+
+function getGlobals() {
+    var values = [],
+        value;
+
+    for (value in global) {
+        if (global.hasOwnProperty(value)) {
+            values.push(value);
+        }
+    }
+    return values;
+}
+
+function printGlobals() {
+    var sortedValues = getGlobals().sort(caseInsensitiveCompare);
+    console.log(sortedValues);
+}
+
+printGlobals();

--- a/jslint.js
+++ b/jslint.js
@@ -549,10 +549,13 @@ var JSLINT = (function () {
         lines,
         lookahead,
         node = array_to_object([
-            'Buffer', 'clearImmediate', 'clearInterval', 'clearTimeout',
-            'console', 'exports', 'global', 'module', 'process',
-            'require', 'setImmediate', 'setInterval', 'setTimeout',
-            '__dirname', '__filename'
+            'ArrayBuffer', 'Buffer','clearImmediate', 'clearInterval',
+            'clearTimeout', 'console', 'DataView', 'exports', 'Float32Array',
+            'Float64Array', 'global', 'GLOBAL', 'Int16Array', 'Int32Array',
+            'Int8Array', 'module', 'process', 'require', 'root',
+            'setImmediate', 'setInterval', 'setTimeout', 'Uint16Array',
+            'Uint32Array', 'Uint8Array', 'Uint8ClampedArray', '__dirname',
+            '__filename'
         ], false),
         node_js,
         numbery = array_to_object(['indexOf', 'lastIndexOf', 'search'], true),


### PR DESCRIPTION
This fixes an [issue](https://stackoverflow.com/questions/26531836/how-to-make-jslint-happy-about-references-to-uint8array-in-node-js-code) where `Uint8Array` and other Node.js globals are not recognized as such. Includes the utility script to get the globals.
