### PR TITLE
Permit trailing commas.

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -3071,10 +3071,6 @@ klass:              do {
             that.first.push(expression(10));
             if (next_token.id === ',') {
                 comma();
-                if (next_token.id === ']') {
-                    token.warn('unexpected_a');
-                    break;
-                }
             } else {
                 break;
             }
@@ -3261,9 +3257,6 @@ klass:              do {
                     break;
                 }
                 next_token.warn('unexpected_a');
-            }
-            if (next_token.id === '}') {
-                token.warn('unexpected_a');
             }
         }
         step_out('}', that);


### PR DESCRIPTION
Since `option.es5` was removed, JSLint appears to assume an ES5 environment by default. One would expect that ES5 syntax would now be tolerated. However, it isn't. Trailing commas in array and object literals are still advised against.

Considering that trailing commas are now part of the standard ([\#11.1.4](http://www.ecma-international.org/ecma-262/5.1/#sec-11.1.4) & [\#11.1.5](http://www.ecma-international.org/ecma-262/5.1/#sec-11.1.5)), and considering that JSLint is not concerned with ES3 backwards compatibility (as it no longer warns against reserved words as key names, etc), trailing commas need not be considered "dangerous" any longer.

As for whether they should be used at all, that may be a matter of opinion:

- On one hand:
  - They could be considered "superfluous."
  - Their intolerance in function parameter lists may make their allowance elsewhere seem "inconsistent."
  - We are used to writing this way; though maybe we were only writing that way because we had to.
  - They are not allowed in JSON; but JSON is not JavaScript.
  - Lists in English are not written with trailing commas; but programming languages aren't English.
- On the other hand:
  - They improve maintainability by allowing a list to be appended-to or reordered without additional rearrangement of commas. For developers who rely on diffs to assess code, this is one less noise to filter.
  - It could be argued that the "error" should not be "one too many commas," but rather "one too few."

We have decided to always use semicolons because it is easier to remember that they go everywhere, rather than only at the start of lines which happen to begin with a particular ambiguous token, as that could lead to a "hard to spot" error as a result of the language's parsing rules.

The same logic can be applied to trailing commas. It is easier to remember that they go after every list element, rather than everywhere except the last list element, because that could lead to "hard to spot" errors.

Consider the following scenario, which could be cited as a shortcoming of automatic semicolon insertion:

Day 1: Sam writes the following code:

```js
var options = [1, 2, 3]
```

Day 2: Bob maintains the code:

```js
var options = [1, 2, 3]

['a', 'b', 'c'].forEach(function (letter) { console.log(letter) })
```

His addition throws `Uncaught TypeError: Cannot read property 'forEach' of undefined`. Until he remembers the special rule (`;['a', 'b', 'c']`) he will be stuck scratching his head. The oft-cited answer to this problem is "he should have used semicolons everywhere."

The same logic applies to trailing commas, except the enforcement against them seems to directly contradict the semicolon logic.

Day 1: Sam writes the following code:

```js
var options = [
    [1, 2, 3]
];
// Returns `[[1, 2, 3]]`
```

Day 2: Bob maintains the code:

```js
var options = [
    [1, 2, 3]
    ['a', 'b', 'c']
];
// Returns `[undefined]`
```

Choosing to omit the comma where it is not needed results in us needing to remember the special case where it must be restored, lest we encounter unusual errors. If we had just remembered to "always use commas," these syntactic ambiguities would not occur.

Hence this PR, which relieves JSLint of its trailing-comma detection duties (except for JSON, of course). It might even be worthwhile for JSLint to enforce this style, considering that it helps prevent bugs.

Test cases:

```js
/*global JSLINT */
(function () {
    'use strict';
    var find = function find(array, predicate) {
            var found;
            array.some(function (element) {
                if (predicate(element)) {
                    found = element;
                    return true;
                }
            });
            return found;
        },
        unexpectedComma = function unexpectedComma(error) {
            return error && error.reason === 'Unexpected \',\'.';
        };
    JSLINT('var a = [1,];');
    if (find(JSLINT.data().errors, unexpectedComma)) {
        throw new Error('arrays forbid trailing comma');
    }
    JSLINT('var a = {a: 1,};');
    if (find(JSLINT.data().errors, unexpectedComma)) {
        throw new Error('objects forbid trailing comma');
    }
    JSLINT('[1,]');
    if (!find(JSLINT.data().errors, unexpectedComma)) {
        throw new Error('json arrays permit trailing comma');
    }
    JSLINT('{a: 1,}');
    if (!find(JSLINT.data().errors, unexpectedComma)) {
        throw new Error('json objects permit trailing comma');
    }
}());
```