### PR TITLE
Exposed 'allowed_option' for programatic reporting purposes

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -4282,6 +4282,8 @@ klass:              do {
 
     itself.jslint = itself;
 
+    itself.allowed_option = allowed_option;
+
     itself.edition = '2014-07-08';
 
     return itself;


### PR DESCRIPTION
Hello.  I was curious if you would entertain this pull request to automatically expose "allowed_option" to JSLINT so that the available list of options could be determined programatically.

Many thanks in advance!

~Marshall