### PR TITLE
Add option to tolerate the 'in' operator.

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -205,6 +205,7 @@
 //     todo       true, if TODO comments are tolerated
 //     vars       true, if multiple var statements per function should be allowed
 //     white      true, if sloppy whitespace is tolerated
+//     in         true, if use of the 'in' operator is tolerated
 
 // The properties directive declares an exclusive list of property names.
 // Any properties named in the program that are not in the list will
@@ -232,7 +233,7 @@
     fromCharCode, fud, function, function_block, function_eval, function_loop,
     function_statement, function_strict, functions, global, hasOwnProperty, id,
     identifier, identifier_function, immed, implied_evil, indent, indexOf,
-    infix_in, init, insecure_a, isAlpha, isArray, isDigit, isNaN, join, jslint,
+    infix_in, in, init, insecure_a, isAlpha, isArray, isDigit, isNaN, join, jslint,
     json, keys, kind, label, labeled, lbp, leading_decimal_a, led, left, length,
     level, line, loopage, master, match, maxerr, maxlen, message, missing_a,
     missing_a_after_b, missing_property, missing_space_a_b, missing_use_strict,
@@ -313,7 +314,8 @@ var JSLINT = (function () {
             sub       : true,
             todo      : true,
             vars      : true,
-            white     : true
+            white     : true,
+            in        : true
         },
         anonname,       // The guessed name for anonymous functions.
 
@@ -2624,7 +2626,9 @@ klass:              do {
     bitwise('>>>', 120);
 
     infix('in', 120, function (left, that) {
-        that.warn('infix_in');
+        if (!option.in) {
+            that.warn('infix_in');
+        }
         that.left = left;
         that.right = expression(130);
         return that;


### PR DESCRIPTION
Consider the following code:
```javascript
(function () {
    'use strict';
    /*jslint devel: true */
    /*globals Array, Object */
    /*properties
        '0', '1', '2', '3', '4', '6', '7', call, create, forEach, hasOwnProperty,
        length, log, prototype
    */

    var arrayLike = {
            0: 'a',
            1: 'b',
            2: null,
            3: 'd',
            4: undefined,
            6: 'f',
            7: NaN,
            length: 8
        },
        anArrayLike = Object.create(arrayLike, {}),
        length = anArrayLike.length,
        index,
        item;

    console.log('Using Array.prototype.forEach');
    // Correct: output matches the expected input
    Array.prototype.forEach.call(anArrayLike, function (item, index) {
        console.log('forEach', index, item);
    });

    console.log('\nIterate based on length, no filter');
    // Incorrect: outputs everything, even 'holes'
    for (index = 0; index < length; index += 1) {
        item = anArrayLike[index];
        console.log('length', index, item);
    }

    console.log('\nIterate based on length, hasOwnProperty filter');
    // Incorrect: nothing logged
    for (index = 0; index < length; index += 1) {
        if (anArrayLike.hasOwnProperty(index)) {
            item = anArrayLike[index];
            console.log('hasOwnProperty', index, item);
        }
    }

    console.log('\nIterate based on length, filter based on comparison with undefined');
    // Incorrect: everything output except index 4 and the 'hole' at index 5
    for (index = 0; index < length; index += 1) {
        item = anArrayLike[index];
        if (item !== undefined) {
            console.log('undefined', index, item);
        }
    }

    console.log('\nIterate based on length, in filter');
    // Correct: output matches the expected input, but fails jslint because of 'in'
    for (index = 0; index < length; index += 1) {
        if (index in anArrayLike) {
            item = anArrayLike[index];
            console.log('in', item);
        }
    }
}());
```
http://jsfiddle.net/Xotic750/rLj4e1a7/

```
Using Array.prototype.forEach
forEach 0 a
forEach 1 b
forEach 2 null
forEach 3 d
forEach 4 undefined
forEach 6 f
forEach 7 NaN

Iterate based on length, no filter
length 0 a
length 1 b
length 2 null
length 3 d
length 4 undefined
length 5 undefined
length 6 f
length 7 NaN

Iterate based on length, hasOwnProperty filter

Iterate based on length, filter based on comparison with undefined
undefined 0 a
undefined 1 b
undefined 2 null
undefined 3 d
undefined 6 f
undefined 7 NaN

Iterate based on length, in filter
in 0 a
in 1 b
in 2 null
in 3 d
in 4 undefined
in 6 f
in 7 NaN
```

Nothing too odd about that code, but it doesn't pass JSLint.
>Unexpected 'in'. Compare with undefined, or use the hasOwnProperty method instead.
>        if (index in anArrayLike) { 

You can see that the suggestions do not produce the same expected result, on by using `in` are the results correct.

I can't see any reason for this warning, `in` seems very clear in it's purpose? How else can you get the expected result?

That's pretty annoying when all points to it being the correct solution, other than using the ES5 `Array#forEach`. 

My projects use the `'for' with 'in' filtering` in numerous places, but will not pass JSLint and my IDE throws up the warnings. 

comparing the `in` method with the `Array#forEach` it appears faster too, as it has a little less work to do. So I can get a little more performance by tailoring my code in this way.

http://jsperf.com/jslint-in-warning

I'd like to suggest an option:

`/*jslint in: true */`

Thanks.
