### PR TITLE
Add `fudge' to the warning object.

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -483,8 +483,8 @@ var jslint = (function JSLint() {
 
         var warning = {         // ~~
             name: 'JSLintError',
-            column: column,
-            line: line,
+            column: column + fudge,
+            line: line + fudge,
             code: code
         };
         if (a !== undefined) {


### PR DESCRIPTION
"fudge" seems to be applied to artifacts in calls to `warn(code, the_token, a, b, c, d)` at lines 1680, 1707, 4011, but never seems to be applied to the column/line no. of the Warning Object pushed into Warnings array as part of `warn_at(...)`.  Lines 486/87 seem like the most logical place to do it.

