### PR TITLE
Google Fonts over HTTPS

### DIFF
--- a/function.html
+++ b/function.html
@@ -18,7 +18,7 @@
 <link
     rel="stylesheet"
     type="text/css"
-    href="http://fonts.googleapis.com/css?family=Patua+One"
+    href="https://fonts.googleapis.com/css?family=Patua+One"
 />
 <link
     rel="icon"

--- a/help.html
+++ b/help.html
@@ -17,7 +17,7 @@ ECMAScript Programming Language Standard, Sixth Edition [ES6]."
 <link
     rel="stylesheet"
     type="text/css"
-    href="http://fonts.googleapis.com/css?family=Patua+One"
+    href="https://fonts.googleapis.com/css?family=Patua+One"
 >
 <link
     rel="icon"

--- a/jslint.html
+++ b/jslint.html
@@ -19,7 +19,7 @@
 <link
     rel="stylesheet"
     type="text/css"
-    href="http://fonts.googleapis.com/css?family=Patua+One"
+    href="https://fonts.googleapis.com/css?family=Patua+One"
 />
 <link
     rel="icon"


### PR DESCRIPTION
This fixes an insecure content warning when viewing JSLint over HTTPS,
such resource may be blocked in future versions of web browsers.