### PR TITLE
add new jslint-rule - expected_newlines: "Expected 2 or 4 newlines between code-sections instead of {a}."

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -105,7 +105,7 @@
     function_in_loop, functions, g, getset, global, i, id, identifier,
     import, inc, indexOf, infix_in, init, initial, isArray, isNaN, join,
     json, keys, label, label_a, lbp, led, length, level, line, lines,
-    live, long, loop, m, margin, match, message, misplaced_a,
+    live, long, loop, m, margin, match, max, message, misplaced_a,
     misplaced_directive_a, missing_browser, missing_m, module, multivar,
     naked_block, name, names, nested_comment, new, node, not_label_a,
     nr, nud, number_isNaN, ok, open, option, out_of_scope_a, parameters,

--- a/jslint.js
+++ b/jslint.js
@@ -105,7 +105,7 @@
     function_in_loop, functions, g, getset, global, i, id, identifier,
     import, inc, indexOf, infix_in, init, initial, isArray, isNaN, join,
     json, keys, label, label_a, lbp, led, length, level, line, lines,
-    live, long, loop, m, margin, match, max, message, misplaced_a,
+    live, long, loop, m, margin, match, message, misplaced_a,
     misplaced_directive_a, missing_browser, missing_m, module, multivar,
     naked_block, name, names, nested_comment, new, node, not_label_a,
     nr, nud, number_isNaN, ok, open, option, out_of_scope_a, parameters,
@@ -610,7 +610,9 @@ function tokenize(source) {
                 ) {
                     warn_at(
                         "expected_newlines",
-                        Math.max(line - newlines_streak, 0),
+                        line >= newlines_streak
+                        ? line - newlines_streak
+                        : 0,
                         0,
                         newlines_streak
                     );


### PR DESCRIPTION
this screenshot from online-demo best explains the new rule (https://kaizhu256.github.io/JSLint/index.html):
![image](https://user-images.githubusercontent.com/280571/45402284-18ebab80-b67f-11e8-8654-c0216f5ba324.png)



jslint.js has one violation of this rule, which is fixed in this pull-request as well:
![image](https://user-images.githubusercontent.com/280571/45402479-08880080-b680-11e8-8d4a-c22e40aa9d1b.png)

