### PR TITLE
fix bug where function-call: jslint(undefined) will return previous state

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -4780,6 +4780,9 @@ function whitage() {
 
 export default function jslint(source, option_object, global_array) {
     try {
+        if (typeof source !== "string") {
+            source = String(source || "");
+        }
         warnings = [];
         option = Object.assign(empty(), option_object);
         anon = "anonymous";


### PR DESCRIPTION
this simple patch mitigates early initialization-errors in jslint which would cause it to leak its previous state.  here are live-demo screenshots of before and after patch:

before (https://kaizhu256.github.io/JSLint/branch.master/index.html)
![screen shot 2018-09-14 at 12 17 46 pm](https://user-images.githubusercontent.com/280571/45531318-73207400-b819-11e8-9713-eb67196d6581.png)

after (https://kaizhu256.github.io/JSLint/branch.replay_bug_when_source_is_undefined/index.html)
![screen shot 2018-09-14 at 12 24 29 pm](https://user-images.githubusercontent.com/280571/45531321-7582ce00-b819-11e8-9ba5-37ed110609bc.png)

