### PR TITLE
json_mode - ignore long lines

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -619,7 +619,12 @@ function tokenize(source) {
                     source_line.length - 1
                 );
             }
-            if (!option.long && source_line.length > 80) {
+            if (
+                first
+                && !json_mode
+                && !option.long
+                && source_line.length > 80
+            ) {
                 warn_at("too_long", line, 80);
             }
         }


### PR DESCRIPTION
this patch will ignore long lines in json_mode.  see live-demo screenshots of it in json and js mode:

live demo of this patch: https://kaizhu256.github.io/JSLint/branch.json_mode_ignore_long_lines/index.html

json-mode (ignore long-lines)
![screen shot 2018-09-14 at 12 38 01 pm](https://user-images.githubusercontent.com/280571/45532080-dbbd2000-b81c-11e8-91c4-be8dbf5ba865.png)

js-mode (warn long-lines)
![screen shot 2018-09-14 at 12 37 35 pm](https://user-images.githubusercontent.com/280571/45532099-f1324a00-b81c-11e8-99dc-a4f12f262099.png)
