### PR TITLE
update function jslint() to use experimental-feature option.autofix=true, ...

### DIFF
--- a/autofix.js
+++ b/autofix.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/*jslint node */
+/*property
+    argv,
+    assert,
+    autofix,
+    basename,
+    error,
+    exit,
+    fs,
+    join,
+    jslint,
+    main,
+    message,
+    option,
+    readFile,
+    replace,
+    runInNewContext,
+    source_autofixed,
+    writeFile
+*/
+"use strict";
+let fs;
+let local;
+let modeNext;
+let onNext;
+let path;
+let vm;
+onNext = function (error, data) {
+    if (error) {
+        console.error(error.message);
+        return;
+    }
+    modeNext += 1;
+    switch (modeNext) {
+    case 1:
+        // run this program only in cli-mode
+        if (module !== require.main) {
+            console.error(
+                "jslint-autofix can only be run from the command-line"
+            );
+            return;
+        }
+        // require builtins
+        fs = require("fs");
+        path = require("path");
+        vm = require("vm");
+        // init local namespace
+        local = {};
+        if (!process.argv[2]) {
+            console.error(
+                "error:   no <file> specified\n"
+                + "usage:   " + path.basename(__filename) + " <file>\n"
+                + "example: " + path.basename(__filename) + " example.js"
+            );
+            process.exit(1);
+        }
+        fs.readFile(path.join(__dirname, "jslint.js"), "utf8", onNext);
+        break;
+    case 2:
+        // bug-workaround - nodejs does not widely support es-modules
+        vm.runInNewContext(
+            data.replace("export default function", "function"),
+            local
+        );
+        // read file-data
+        fs.readFile(process.argv[2], "utf8", onNext);
+        break;
+    case 3:
+        // autofix file-data
+        console.error(
+            "jslint-autofix - autofixing file " + process.argv[2] + " ..."
+        );
+        data = local.jslint(data, {autofix: true});
+        if (typeof data.source_autofixed !== "string") {
+            onNext(new Error(
+                "jslint-autofix - could not autofix file " + process.argv[2]
+            ));
+            return;
+        }
+        // save autofixed file-data
+        fs.writeFile(
+            process.argv[2] + ".autofixed.js",
+            data.source_autofixed,
+            onNext
+        );
+        break;
+    case 4:
+        console.error(
+            "jslint-autofix - saved autofixed file - " + process.argv[2]
+            + ".autofixed.js"
+        );
+        break;
+    }
+};
+modeNext = 0;
+onNext();

--- a/browser.js
+++ b/browser.js
@@ -7,6 +7,7 @@
 */
 
 /*property
+    autofix, currentTarget, name, source_autofixed,
     checked, create, disable, display, error, focus, forEach, function,
     getElementById, innerHTML, join, length, map, onchange, onclick, onscroll,
     property, querySelectorAll, scrollTop, select, split, style, title, value
@@ -69,7 +70,7 @@ function clear_options() {
     global.innerHTML = "";
 }
 
-function call_jslint() {
+function call_jslint(event) {
 
 // First build the option object.
 
@@ -79,6 +80,11 @@ function call_jslint() {
             option[node.title] = true;
         }
     });
+
+// Init autofix option
+    if (event.currentTarget.name === "autofix") {
+        option.autofix = true;
+    }
 
 // Call JSLint with the source text, the options, and the predefined globals.
 
@@ -121,6 +127,14 @@ function call_jslint() {
     }
     aux.style.display = "block";
     source.select();
+
+// Replace input source-code with autofixed result
+    if (option.autofix) {
+        document.getElementById("JSLINT_SOURCE").value =
+                result.source_autofixed;
+    }
+
+    return result;
 }
 
 fudge.onchange = fudge_change;
@@ -145,6 +159,10 @@ document.querySelectorAll("[name='JSLint']").forEach(function (node) {
 
 document.querySelectorAll("[name='clear']").forEach(function (node) {
     node.onclick = clear;
+});
+
+document.querySelectorAll("[name='autofix']").forEach(function (node) {
+    node.onclick = call_jslint;
 });
 
 document.getElementById("JSLINT_SELECT").onclick = function () {

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
   <div class="center">
       <button name=JSLint>JSLint</button>
       <button name=clear>clear</button>
+      <button name=autofix>autofix warnings (experimental)</button>
   </div>
   <fieldset id="JSLINT_WARNINGS" class="none">
     <legend>Warnings</legend>


### PR DESCRIPTION
which will try to autofix most of the tedious whitespace, single-quote, and regexp warnings.
also added cli-tool autofix.js, which will try to inplace autofix javascript-files.

this feature is intended to make it easier for user unhappy with eslint and other inferior linters to migrate back to jslint, and help jslint reclaim its world-domination as the one-and-only true linter.

here's a real-world case-study, where jslint-autofix was used to migrate ~5,000 lines-of-code from a pre-es6 version of jslint (v2014-07-08) to the latest master: https://github.com/kaizhu256/node-utility2/commit/5c48bc6765f2274d3e9dcbabea8abb1fc208eb6c

live web-demo of patch available at: https://kaizhu256.github.io/JSLint/branch.autofix/index.html

here are screenshots explaining feature

- before and after autofixing example-code
![image](https://user-images.githubusercontent.com/280571/45587312-7d806200-b92e-11e8-969d-a6d434acb414.png)
![image](https://user-images.githubusercontent.com/280571/45587311-7bb69e80-b92e-11e8-91d5-de5546edafcc.png)

- autofix whitespaces in a pre-es6 version of jslint
![screen shot 2018-09-15 at 3 27 50 pm](https://user-images.githubusercontent.com/280571/45584692-6e83ba80-b902-11e8-982a-f74554735ca8.png)

- using cli-tool ./autofix.js to do the same thing (note autofixed indents in the diff result)
<img width="710" alt="screen shot 2018-09-15 at 3 31 05 pm" src="https://user-images.githubusercontent.com/280571/45587269-f3d09480-b92d-11e8-838a-eb0c490dbf9c.png">


