### PR TITLE
ignore shebang at line=0 common in node-scripts

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -395,6 +395,8 @@ const rx_mega = /[`\\]|\$\{/;
 const rx_JSON_number = /^-?\d+(?:\.\d*)?(?:e[\-+]?\d+)?$/i;
 // initial cap
 const rx_cap = /^[A-Z]/;
+// shebang common in node scripts
+const rx_shebang = /^#!/;
 
 function is_letter(string) {
     return (
@@ -596,6 +598,10 @@ function tokenize(source) {
         line += 1;
         source_line = lines[line];
         if (source_line !== undefined) {
+            // ignore shebang at line=0 common in node scripts
+            if (line === 0 && rx_shebang.test(source_line)) {
+                source_line = "";
+            }
             at = source_line.search(rx_tab);
             if (at >= 0) {
                 if (!option.white) {


### PR DESCRIPTION
this simple-patch will ignore the first-line shebang common in many command-line-tool nodejs scripts.  intended to make jslint easier-to-use for nodejs-developers

live web-demo of this patch available at: https://kaizhu256.github.io/JSLint/branch.ignore_shebang/index.html

screenshot of jslint ignoring first-line shebang, but properly linting the second-line
![image](https://user-images.githubusercontent.com/280571/45597555-4a0a0a00-b9f8-11e8-8cd1-5d6e63346296.png)
