### PR TITLE
revert commit 62cf4a63 (2016-08-30) - case " "

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -1041,7 +1041,7 @@ function tokenize(source) {
                     return true;
                 }
                 if (char === "\\") {
-                    escape("BbDdSsWw^${}[]():=!.-|*+?");
+                    escape("BbDdSsWw^${}[]():=!.- |*+?");
                     return true;
                 }
                 if (
@@ -1063,13 +1063,7 @@ function tokenize(source) {
                         warn_at("unexpected_a", line, column - 1, "`");
                     }
                 } else if (char === " ") {
-                    warn_at(
-                        "expected_a_b",
-                        line,
-                        column - 1,
-                        "\\s",
-                        " "
-                    );
+                    warn_at("expected_a_before_b", line, column, "\\", " ");
                 } else if (char === "$") {
                     if (source_line[0] !== "/") {
                         multi_mode = true;


### PR DESCRIPTION
while migrating my code to comply to latest jslint [1],
i have regexp readability-issues after converting regexp-whitespace to unicode "\\ " -> ```\u0020```:

[1] migration https://github.com/kaizhu256/node-utility2/commit/84f4f9ddfd5c69f9d2b07823b90015134f9b7294?diff=unified#diff-fad71605abfa73de7bd87d70853267b2L4124

```diff
diff --git a/lib.utility2.js b/lib.utility2.js
index 12bebf0..a14ed0c 100755
--- a/lib.utility2.js
+++ b/lib.utility2.js
@@ -4121,21 +4121,21 @@ local.buildReadme = function (options, onError) {
     // search-and-replace - customize dataTo
     [
@@ non-jslint-compliant regexp
-        // customize name and description
-        (/.*?\n.*?\n/),
-        // customize cdn-download
-        (/\n#\ cdn\ download\n[\S\s]*?\n\n\n\n/),
-        // customize live web demo
-        (/\n#\ live\ web\ demo\n[\S\s]*?\n\n\n\n/),
-        // customize to-do
-        (/\n####\ todo\n[\S\s]*?\n\n\n\n/),
-        // customize quickstart-example-js
-        (/\nlocal\.global\.local\ =\ local;\n[^`]*?\n\/\/\ run\ browser\ js\-env\ code\ -\ init-test\n/),
-        (/\nlocal\.testRunBrowser\ =\ function\ \(event\)\ \{\n[^`]*?^\ {4}if\ \(!event\ \|\|\ \(event\ &&\n/m),
-        (/\n\ {4}\/\/\ custom-case\n[^`]*?\n\ {4}\}\n/),
-        // customize quickstart-html-body
-        (/\nutility2-comment\ -->(?:\\n\\\n){4}[^`]*?^<!--\ utility2-comment\\n\\\n/m),
-        // customize build script
-        (/\n#\ internal\ build\ script\n[\S\s]*?^-\ build_ci\.sh\n/m),
-        (/\nshBuildCiAfter\ \(\)\ \{\(set\ -e\n[\S\s]*?\n\)\}\n/),
-        (/\nshBuildCiBefore\ \(\)\ \{\(set\ -e\n[\S\s]*?\n\)\}\n/)
@@ jslint-compliant regexp, but hard-to-read
+        // customize name and description
+        (/.*?\n.*?\n/),
+        // customize cdn-download
+        (/\n#\u0020cdn\u0020download\n[\S\s]*?\n\n\n\n/),
+        // customize live web demo
+        (/\n#\u0020live\u0020web\u0020demo\n[\S\s]*?\n\n\n\n/),
+        // customize to-do
+        (/\n####\u0020todo\n[\S\s]*?\n\n\n\n/),
+        // customize quickstart-example-js
+        (/\nlocal\.global\.local\u0020=\u0020local;\n[^`]*?\n\/\/\u0020run\u0020browser\u0020js\-env\u0020code\u0020-\u0020init-test\n/),
+        (/\nlocal\.testRunBrowser\u0020=\u0020function\u0020\(event\)\u0020\{\n[^`]*?^\u0020{4}if\u0020\(!event\u0020\|\|\u0020\(event\u0020&&\n/m),
+        (/\n\u0020{4}\/\/\u0020custom-case\n[^`]*?\n\u0020{4}\}\n/),
+        // customize quickstart-html-body
+        (/\nutility2-comment\u0020-->(?:\\n\\\n){4}[^`]*?^<!--\u0020utility2-comment\\n\\\n/m),
+        // customize build script
+        (/\n#\u0020internal\u0020build\u0020script\n[\S\s]*?^-\u0020build_ci\.sh\n/m),
+        (/\nshBuildCiAfter\u0020\(\)\u0020\{\(set\u0020-e\n[\S\s]*?\n\)\}\n/),
+        (/\nshBuildCiBefore\u0020\(\)\u0020\{\(set\u0020-e\n[\S\s]*?\n\)\}\n/)
     ].forEach(function (rgx) {
         options.dataTo = local.stringMerge(options.dataTo, options.dataFrom, rgx);
     });
```

i can't follow jslint's recommendation of " " -> "\\s", because it breaks regexp's like
```(/\n\ {4}\/\/\ custom-case\n[^`]*?\n\ {4}\}\n/)```, which *must* match specific left-margins/indentations.

this patch reverts regexp-whitespace warnings to commit 62cf4a63 (warns " " -> "\\ ").

live web-demo of this pull-request available at: https://kaizhu256.github.io/JSLint/branch.revert_regexp_single_whitespace/index.html

screenshot showing patched-jslint properly linting "\\ " inside regexp-unicode-ranges, but otherwise ignoring it for readability-purposes.

![screen shot 2018-09-26 at 5 24 40 am](https://user-images.githubusercontent.com/280571/46046856-d204b800-c14c-11e8-9d7c-8a4bcbeec2fc.png)
