### PR TITLE
warnings.push() explicit early_stop warning

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -90,7 +90,9 @@
     bad_module_name_a, bad_option_a, bad_property_a, bad_set, bitwise, block,
     body, browser, c, calls, catch, charCodeAt, closer, closure, code, column,
     complex, concat, constant, context, convert, couch, create, d, dead,
-    default, devel, directive, directives, disrupt, dot, duplicate_a, edition,
+    default, devel, directive, directives, disrupt, dot, duplicate_a,
+    early_stop,
+    edition,
     ellipsis, else, empty_block, escape_mega, eval, every, expected_a,
     expected_a_at_b_c, expected_a_b, expected_a_b_from_c_d, expected_a_before_b,
     expected_a_next_at_b, expected_digits_after_a, expected_four_digits,
@@ -254,6 +256,7 @@ const bundle = {
     bad_property_a: "Bad property name '{a}'.",
     bad_set: "A set function takes one parameter.",
     duplicate_a: "Duplicate '{a}'.",
+    early_stop: "JSLint was unable to finish.",
     empty_block: "Empty block.",
     escape_mega: "Unexpected escapement in mega literal.",
     expected_a: "Expected '{a}'.",
@@ -4894,6 +4897,7 @@ export default function jslint(
         if (e.name !== "JSLintError") {
             warnings.push(e);
         }
+        warn_at(bundle.early_stop, e.line || 0, e.column || 0);
     }
     return {
         directives,
@@ -4918,7 +4922,11 @@ export default function jslint(
         tokens,
         tree,
         warnings: warnings.sort(function (a, b) {
-            return a.line - b.line || a.column - b.column;
+            return a.code === bundle.early_stop
+            ? -1
+            : b.code === bundle.early_stop
+            ? 1
+            : a.line - b.line || a.column - b.column;
         })
     };
 };

--- a/report.js
+++ b/report.js
@@ -8,7 +8,7 @@
     closure, column, context, edition, error, exports, filter, forEach, froms,
     fudge, function, functions, global, id, isArray, join, json, keys, length,
     level, line, lines, message, module, name, names, option, parameters,
-    parent, property, push, replace, role, signature, sort, stop, warnings
+    parent, property, push, replace, role, signature, sort, warnings
 */
 
 const rx_amp = /&/g;
@@ -43,9 +43,6 @@ export default {
 
         let fudge = Number(Boolean(data.option.fudge));
         let output = [];
-        if (data.stop) {
-            output.push("<center>JSLint was unable to finish.</center>");
-        }
         data.warnings.forEach(function (warning) {
             output.push(
                 "<cite><address>",


### PR DESCRIPTION
this patch will add an explicit warning to "warnings" list, when jslint early_stop's.  its intended to give better notification to people who use cli-tooling that jslint failed to parse a script (see screenshot of cli-usage).

live web-demo of this patch available at: https://kaizhu256.github.io/JSLint/branch.warning_early_stop/index.html

<img width="758" alt="screen shot 2018-10-03 at 1 44 35 am" src="https://user-images.githubusercontent.com/280571/46369721-fc56f800-c6ad-11e8-845d-230a2d783850.png">


![screen shot 2018-10-03 at 1 26 42 am](https://user-images.githubusercontent.com/280571/46369246-90c05b00-c6ac-11e8-9c2b-504f13ae0667.png)
