### PR TITLE
bug-fix - as a developer, i expect return-statements to have the same "use_open" warning as var/let/const-statements for ternary-operators

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -4719,6 +4719,7 @@ function whitage() {
                         left.id === "var"
                         || left.id === "const"
                         || left.id === "let"
+                        || left.id === "return"
                     ) {
                         stack.push({
                             closer: closer,


### PR DESCRIPTION
according to jslint's comments:  "Statement blocks are always in open form"

the following is a statement block, so jslint should give a ```use_open``` warning for the ternary-operator.
```
function f2(a) {
    "use strict";
    return a
    ? 123
    : 456;
}
```

this patch enforces the prescribed behavior.  live web-demo available at: https://kaizhu256.github.io/JSLint/branch.bug_ternary_use_open/index.html

![screen shot 2018-10-03 at 3 54 55 am](https://user-images.githubusercontent.com/280571/46376445-36c99080-c6c0-11e8-8d52-47cc90ed6a92.png)

![screen shot 2018-10-03 at 3 57 20 am](https://user-images.githubusercontent.com/280571/46376591-8f992900-c6c0-11e8-84e4-c5db4306d498.png)
