### PR TITLE
add option.debug - as a jslint-contributor, an optional stack-trace for each warning would help in identifying and fixing bugs.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -4,9 +4,13 @@
 
 /*jslint
     browser
+    devel
 */
 
 /*property
+    debug,
+    stack,
+    warnings,
     checked, create, disable, display, error, focus, forEach, function,
     getElementById, innerHTML, join, length, map, onchange, onclick, onscroll,
     property, querySelectorAll, scrollTop, select, split, style, title, value
@@ -80,6 +84,10 @@ function call_jslint() {
         }
     });
 
+// Enable debug
+
+    option.debug = true;
+
 // Call JSLint with the source text, the options, and the predefined globals.
 
     let global_string = global.value;
@@ -92,6 +100,13 @@ function call_jslint() {
             : global_string.split(rx_separator)
         )
     );
+
+// Debug warnings
+
+    result.warnings.forEach(function (warning) {
+        console.error(warning);
+        console.error(warning.stack);
+    });
 
 // Generate the reports.
 

--- a/jslint.js
+++ b/jslint.js
@@ -86,6 +86,8 @@
 // WARNING: JSLint will hurt your feelings.
 
 /*property
+    debug,
+    stack,
     a, and, arity, assign, b, bad_assignment_a, bad_directive_a, bad_get,
     bad_module_name_a, bad_option_a, bad_property_a, bad_set, bitwise, block,
     body, browser, c, calls, catch, charCodeAt, closer, closure, code, column,
@@ -500,6 +502,12 @@ function warn_at(code, line, column, a, b, c, d) {
         warning.d = d;
     }
     warning.message = supplant(bundle[code] || code, warning);
+
+// Debug stack-trace of warning.
+
+    if (option.debug) {
+        warning.stack = new Error().stack;
+    }
     warnings.push(warning);
     return warning;
 }


### PR DESCRIPTION
live web-demo of this feature available at: https://kaizhu256.github.io/JSLint/branch.option_debug/index.html

![screen shot 2018-10-03 at 9 01 09 am](https://user-images.githubusercontent.com/280571/46387485-15cd6380-c6f1-11e8-87b7-3e220799cafe.png)

<img width="602" alt="screen shot 2018-10-03 at 9 11 57 am" src="https://user-images.githubusercontent.com/280571/46386618-b705eb00-c6ec-11e8-94ac-70d7cb7d7432.png">
