### PR TITLE
as a user, i do not want jslint to crash from excessive-recursion

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -1247,18 +1247,19 @@ function tokenize(source) {
         let last;
         let result;
         let the_token;
-        if (!source_line) {
+        // bug-workaround
+        // mitigate v8 RangeError("Maximum call stack size exceeded"),
+        // by avoiding unnecessary recursion
+        while (!source_line) {
             source_line = next_line();
             from = 0;
-            return (
-                source_line === undefined
-                ? (
+            if (source_line === undefined) {
+                return (
                     mega_mode
                     ? stop_at("unclosed_mega", mega_line, mega_from)
                     : make("(end)")
-                )
-                : lex()
-            );
+                );
+            }
         }
         from = column;
         result = source_line.match(rx_token);


### PR DESCRIPTION
sometimes in nodejs, when async/simultaneous linting multiple-files with large number of _[machine-generated]_ leading-newlines, jslint will crash with a ```RangeError("Maximum call stack size exceeded")```

this patch mitigates the above scenario by avoiding unnecessary-recursion while parsing leading-emptylines.

live web-demo of patch available at https://kaizhu256.github.io/JSLint/branch.remove_unnecessary_recursion/

1. screenshot - jslint crashing from recursing through excessive leading-emptylines
<img width="842" alt="screen shot 2018-11-04 at 6 09 25 pm" src="https://user-images.githubusercontent.com/280571/47962836-a2a36e00-e05d-11e8-9c1f-01d7c02af05a.png">


2. screenshot - patched jslint no longer crashes
<img width="842" alt="screen shot 2018-11-04 at 6 11 42 pm" src="https://user-images.githubusercontent.com/280571/47962838-a6cf8b80-e05d-11e8-90f7-14e3fb02eb3c.png">
