### PR TITLE
warn against using browser's window.event

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -151,7 +151,7 @@ const allowed_option = {
     bitwise: true,
     browser: [
         "caches", "clearInterval", "clearTimeout", "document", "DOMException",
-        "Element", "Event", "event", "FileReader", "FormData", "history",
+        "Element", "Event", "FileReader", "FormData", "history",
         "localStorage", "location", "MutationObserver", "name", "navigator",
         "screen", "sessionStorage", "setInterval", "setTimeout", "Storage",
         "TextDecoder", "TextEncoder", "URL", "window", "Worker",


### PR DESCRIPTION
```window.event``` doesn't exist in firefox.

for example, jslint failed to catch this real-world browser-compat regression:

```
/*jslint browser devel*/
document.querySelector(
    "#foo"
).addEventListener("click", function (/*event*/) { // forgot to pass "event" arg
    console.log(event.type);  // works in chrome but throws in firefox
});
```