### PR TITLE
lint invalid negative numbers in json

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -1738,6 +1738,9 @@ function json_value() {
         negative.arity = "unary";
         advance("-");
         advance("(number)");
+        if (!rx_JSON_number.test(token.value)) {
+            warn("unexpected_a");
+        }
         negative.expression = token;
         return negative;
     }


### PR DESCRIPTION
jslint currently allows the invalid json `{"aa":-0x1}`.  this patch rectifies that.