### PR TITLE
jslint crashes when linting expression `aa(); function aa() {     return; }`

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -3906,7 +3906,9 @@ function lookup(thing) {
             the_variable.dead
             && (
                 the_variable.calls === undefined
-                || the_variable.calls[functionage.name.id] === undefined
+                || the_variable.calls[
+                    functionage.name && functionage.name.id
+                ] === undefined
             )
         ) {
             warn("out_of_scope_a", thing);


### PR DESCRIPTION
this patch keeps jslint from crashing when linting the expression

```js
aa();
function aa() {
    return;
}
```

![image](https://user-images.githubusercontent.com/280571/86327583-2a61c700-bc09-11ea-962a-514baa3f55b7.png)
