### PR TITLE
fix json-number regression were `[0x0]` is valid json

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -444,7 +444,7 @@ const rx_bits = /^[01]*/;
 // mega
 const rx_mega = /[`\\]|\$\{/;
 // JSON number
-const rx_JSON_number = tag_regexp ` -? \d+ (?: \. \d* )? (?:
+const rx_JSON_number = tag_regexp ` ^ -? \d+ (?: \. \d* )? (?:
     [ e E ] [ \- + ]? \d+
 )? $ `;
 // initial cap


### PR DESCRIPTION
here's screenshot of regression:

![image](https://user-images.githubusercontent.com/280571/96609123-cb12ea00-12bf-11eb-8ed6-90e2a4b3584d.png)
