### PR TITLE
# v2021.10.20 - add cli-command v8_coverage_report - and - npm publish to @jslint-org/jslint

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,9 @@ on:
       - master
       - sandbox
 jobs:
+
+
+# npm publish - start
   build:
     strategy:
       matrix:
@@ -32,9 +35,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v2
 
       # Setup .npmrc file to publish to GitHub Packages
+      - run: rm -f /home/runner/work/_temp/.npmrc
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node_version }}
@@ -42,20 +46,23 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           # Defaults to the user or organization that owns the workflow file
           # scope: '@octocat'
-      - run: npm install
       # Publish to GitHub Packages
-      - run: npm publish
+      - run: npm install
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup .npmrc file to publish to npm
+      - run: rm -f /home/runner/work/_temp/.npmrc
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node_version }}
           architecture: ${{ matrix.architecture }}
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install
       # Publish to npm
+      - run: npm install
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+# npm publish - end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 
-# v2021.10.1-beta
+# v2021.10.20
 - ci - add release-trigger to publish to `@jslint-org/jslint`
 - bugfix - fix coverage-report having incorrect http-link to index.html
 - bugfix - fix false warning `uninitialized 'bb'` in code `/*jslint node*/\nlet {aa:bb} = {}; bb();`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2021.9.20)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2021.10.20)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/index.html) |

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -162,7 +162,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2021.10.1-beta";
+let jslint_edition = "v2021.10.20";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -1202,6 +1202,16 @@ import moduleFs from "fs";
 ' "$@" # '
 )}
 
+shNpmPublishV0() {(set -e
+# this function will npm-publish name $1 with bare package.json
+    local DIR
+    DIR=/tmp/shNpmPublishV0
+    rm -rf "$DIR" && mkdir -p "$DIR" && cd "$DIR"
+    printf "{\"name\":\"$1\",\"version\":\"0.0.1\"}\n" > package.json
+    shift
+    npm publish "$@"
+)}
+
 shRawLibFetch() {(set -e
 # this function will fetch raw-lib from $1
     node --input-type=module -e '

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "counter": 7,
     "description": "JSLint, The JavaScript Code Quality and Coverage Tool",
-    "fileCount": 26,
+    "fileCount": 27,
     "license": "UNLICENSE",
     "name": "@jslint-org/jslint",
     "repository": {
@@ -12,5 +12,5 @@
         "test": "node jslint.mjs v8_coverage_report=.artifact/coverage node test.mjs",
         "test2": "sh jslint_ci.sh shCiBase"
     },
-    "version": "2021.10.1-beta"
+    "version": "2021.10.20"
 }


### PR DESCRIPTION
- ci - add release-trigger to publish to `@jslint-org/jslint`
- bugfix - fix coverage-report having incorrect http-link to index.html
- bugfix - fix false warning `uninitialized bb` in code `/*jslint node*/\nlet {aa:bb} = {}; bb();`
- bugfix - fix issue #358 - switch-statement crashes jslint
- ci - cache coverage-example node-sqlite3 to speed up ci
- ci - rename dir .build/ to .artifact/
- ci - update shell-function shRunWithCoverage() to reduce size of string/argument passed to nodejs by using 2-space-indent
- cli - add cli-command jslint_plugin_vim
- cli - add cli-command v8_coverage_report
- cli - change cli-option `--mode-report` to cli-command `jslint_report=<filename>`
- coverage - relax requirement for coverageDir to be in cwd
- deprecated - cli - add cli-option `--mode-report`
- doc - add api-documentation
- fs - merge file asset_codemirror_rollup.css into index.html
- fs - merge file browser.mjs into index.html
- fs - merge file function.html into help.html
- fs - remove little-used font asset_font_programma_bold.woff2
- fs - rename files with dashes to files with underscore
- jslint - disable linting of embedded javascript in markdown-files
- jslint - relax regexp-warning against using space
- npm - add file package.json and command `npm test`
- style - change naming-convention for non-jslint-core code from underscore to camelCase
- test - add mocha-like test-functions jstestDescribe, jstestIt