### PR TITLE
- jslint - Relax warning on multiline-method-chaining.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 # Todo
-- jslint - Relax warning on multi-line method-chaining.
+- jslint - Add ability to auto-fix whitespace.
 - jslint - bugfix - Fix false-positive Unused-variable when variable is used in function argument-default.
 - doc - Document supported/unsupported es6+ features
 - jslint - Add html and css linting back into jslint.
@@ -9,6 +9,7 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.6.1-beta
+- jslint - Relax warning on multi-line-method-chaining.
 - jslint - Replace all non-return "stop(...);" with "return stop(...)".
 - jslint - Unify ES2018-syntax-spread-operator with function prefix_ellipsis().
 - jslint - Add ES2018-syntax for object-literal-spread-operator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.6.1-beta
-- jslint - Relax warning on multi-line-method-chaining.
+- jslint - Relax warning on multiline-method-chaining.
 - jslint - Replace all non-return "stop(...);" with "return stop(...)".
 - jslint - Unify ES2018-syntax-spread-operator with function prefix_ellipsis().
 - jslint - Add ES2018-syntax for object-literal-spread-operator.

--- a/README.md
+++ b/README.md
@@ -954,7 +954,7 @@ if (false) {
 - `git push upstream alpha -f`
     - verify ci-success for upstream-branch-alpha
     - https://github.com/jslint-org/jslint/actions
-- goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.6.22
+- goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.6.23
 - click `Create pull request`
 - input `Add your description here...` with:
 ```

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -92,48 +92,309 @@
 
 /*jslint beta, node*/
 /*property
-    JSLINT_BETA, NODE_V8_COVERAGE, a, all, argv, arity, artifact,
-    assertErrorThrownAsync, assertJsonEqual, assertOrThrow, assign, async, b,
-    beta, bitwise, block, body, browser, c, calls, catch, catch_list,
-    catch_stack, causes, char, children, clear, closer, closure, code, column,
-    concat, consoleError, console_error, console_log, constant, context,
-    convert, count, coverageDir, create, cwd, d, dead, debugInline, default,
-    delta, devel, directive, directive_ignore_line, directive_list, directives,
-    dirname, disrupt, dot, edition, elem_list, ellipsis, else, end, endOffset,
-    endsWith, entries, env, error, eval, every, example_list, excludeList, exec,
-    execArgv, exit, exitCode, export_dict, exports, expression, extra, fart,
-    file, fileList, fileURLToPath, filter, finally, flag, floor, for, forEach,
-    formatted_message, free, freeze, from, froms, fsWriteFileWithParents,
-    fud_stmt, functionName, function_list, function_stack, functions, get,
-    getset, github_repo, globExclude, global, global_dict, global_list,
-    holeList, htmlEscape, id, identifier, ignoreLine, import, import_list,
-    import_meta_url, inc, includeList, indent2, index, indexOf, init, initial,
-    isArray, isBlockCoverage, isHole, isNaN, is_equal, is_weird, join, jslint,
-    jslint_apidoc, jslint_assert, jslint_charset_ascii, jslint_cli,
-    jslint_edition, jslint_phase1_split, jslint_phase2_lex, jslint_phase3_parse,
-    jslint_phase4_walk, jslint_phase5_whitage, jslint_report, json,
-    jstestDescribe, jstestIt, jstestOnExit, keys, label, lbp, led_infix, length,
-    level, line, lineList, line_list, line_offset, line_source, lines,
-    linesCovered, linesTotal, live, log, long, loop, m, map, margin, match, max,
-    message, meta, min, mkdir, modeCoverageIgnoreFile, modeIndex, mode_cli,
-    mode_conditional, mode_json, mode_module, mode_noop, mode_property,
-    mode_shebang, mode_stop, module, moduleFsInit, moduleName, module_list,
-    name, names, node, nomen, noop, now, nr, nud_prefix,
-    objectDeepCopyWithKeysSorted, ok, on, open, opening, option, option_dict,
-    order, package_name, padEnd, padStart, parameters, parent, parentIi, parse,
-    pathname, pathnameList, platform, pop, processArgv, process_argv,
-    process_env, process_exit, promises, property, property_dict, push, quote,
-    ranges, readFile, readdir, readonly, recursive, reduce, repeat, replace,
-    resolve, result, reverse, role, round, scriptId, search, set, shebang,
-    shell, shift, signature, single, slice, some, sort, source, spawn, splice,
-    split, stack, stack_trace, start, startOffset, startsWith, statement,
-    statement_prv, stdio, stop, stop_at, stringify, subscript, switch,
-    syntax_dict, tenure, test, test_cause, test_internal_error, this, thru,
-    toLocaleString, toString, token, token_global, token_list, token_nxt,
-    token_tree, tokens, trace, tree, trim, trimEnd, trimRight, try, type,
-    unlink, unordered, unshift, url, used, v8CoverageListMerge,
-    v8CoverageReportCreate, value, variable, version, versions, warn, warn_at,
-    warning, warning_list, warnings, white, wrapped, writeFile
+    JSLINT_BETA,
+    NODE_V8_COVERAGE,
+    a,
+    all,
+    argv,
+    arity,
+    artifact,
+    assertErrorThrownAsync,
+    assertJsonEqual,
+    assertOrThrow,
+    assign,
+    async,
+    b,
+    beta,
+    bitwise,
+    block,
+    body,
+    browser,
+    c,
+    calls,
+    catch,
+    catch_list,
+    catch_stack,
+    causes,
+    char,
+    children,
+    clear,
+    closer,
+    closure,
+    code,
+    column,
+    concat,
+    consoleError,
+    console_error,
+    console_log,
+    constant,
+    context,
+    convert,
+    count,
+    coverageDir,
+    create,
+    cwd,
+    d,
+    dead,
+    debugInline,
+    default,
+    delta,
+    devel,
+    directive,
+    directive_ignore_line,
+    directive_list,
+    directives,
+    dirname,
+    disrupt,
+    dot,
+    edition,
+    elem_list,
+    ellipsis,
+    else,
+    end,
+    endOffset,
+    endsWith,
+    entries,
+    env,
+    error,
+    eval,
+    every,
+    example_list,
+    excludeList,
+    exec,
+    execArgv,
+    exit,
+    exitCode,
+    export_dict,
+    exports,
+    expression,
+    extra,
+    fart,
+    file,
+    fileList,
+    fileURLToPath,
+    filter,
+    finally,
+    flag,
+    floor,
+    for,
+    forEach,
+    formatted_message,
+    free,
+    freeze,
+    from,
+    froms,
+    fsWriteFileWithParents,
+    fud_stmt,
+    functionName,
+    function_list,
+    function_stack,
+    functions,
+    get,
+    getset,
+    github_repo,
+    globExclude,
+    global,
+    global_dict,
+    global_list,
+    holeList,
+    htmlEscape,
+    id,
+    identifier,
+    ignoreLine,
+    import,
+    import_list,
+    import_meta_url,
+    inc,
+    includeList,
+    indent2,
+    indent_method,
+    index,
+    indexOf,
+    init,
+    initial,
+    isArray,
+    isBlockCoverage,
+    isHole,
+    isNaN,
+    is_equal,
+    is_weird,
+    join,
+    jslint,
+    jslint_apidoc,
+    jslint_assert,
+    jslint_charset_ascii,
+    jslint_cli,
+    jslint_edition,
+    jslint_phase1_split,
+    jslint_phase2_lex,
+    jslint_phase3_parse,
+    jslint_phase4_walk,
+    jslint_phase5_whitage,
+    jslint_report,
+    json,
+    jstestDescribe,
+    jstestIt,
+    jstestOnExit,
+    keys,
+    label,
+    lbp,
+    led_infix,
+    length,
+    level,
+    line,
+    lineList,
+    line_list,
+    line_offset,
+    line_source,
+    lines,
+    linesCovered,
+    linesTotal,
+    live,
+    log,
+    long,
+    loop,
+    m,
+    map,
+    margin,
+    match,
+    max,
+    message,
+    meta,
+    min,
+    mkdir,
+    modeCoverageIgnoreFile,
+    modeIndex,
+    mode_cli,
+    mode_conditional,
+    mode_json,
+    mode_module,
+    mode_noop,
+    mode_property,
+    mode_shebang,
+    mode_stop,
+    module,
+    moduleFsInit,
+    moduleName,
+    module_list,
+    name,
+    names,
+    node,
+    nomen,
+    noop,
+    now,
+    nr,
+    nud_prefix,
+    objectDeepCopyWithKeysSorted,
+    ok,
+    on,
+    open,
+    opening,
+    option,
+    option_dict,
+    order,
+    package_name,
+    padEnd,
+    padStart,
+    parameters,
+    parent,
+    parentIi,
+    parse,
+    pathname,
+    pathnameList,
+    platform,
+    pop,
+    processArgv,
+    process_argv,
+    process_env,
+    process_exit,
+    promises,
+    property,
+    property_dict,
+    push,
+    quote,
+    ranges,
+    readFile,
+    readdir,
+    readonly,
+    recursive,
+    reduce,
+    repeat,
+    replace,
+    resolve,
+    result,
+    reverse,
+    role,
+    round,
+    scriptId,
+    search,
+    set,
+    shebang,
+    shell,
+    shift,
+    signature,
+    single,
+    slice,
+    some,
+    sort,
+    source,
+    spawn,
+    splice,
+    split,
+    stack,
+    stack_trace,
+    start,
+    startOffset,
+    startsWith,
+    statement,
+    statement_prv,
+    stdio,
+    stop,
+    stop_at,
+    stringify,
+    subscript,
+    switch,
+    syntax_dict,
+    tenure,
+    test,
+    test_cause,
+    test_internal_error,
+    this,
+    thru,
+    toLocaleString,
+    toString,
+    token,
+    token_global,
+    token_list,
+    token_nxt,
+    token_tree,
+    tokens,
+    trace,
+    tree,
+    trim,
+    trimEnd,
+    trimRight,
+    try,
+    type,
+    unlink,
+    unordered,
+    unshift,
+    url,
+    used,
+    v8CoverageListMerge,
+    v8CoverageReportCreate,
+    value,
+    variable,
+    version,
+    versions,
+    warn,
+    warn_at,
+    warning,
+    warning_list,
+    warnings,
+    white,
+    wrapped,
+    writeFile
 */
 
 // init debugInline
@@ -8843,6 +9104,8 @@ function jslint_phase5_whitage(state) {
 // "switch(){}"
 // "while(){}"
 
+    let indent_method_dict = {};
+    let indentage;
     let left = token_global;
     let margin = 0;
     let mode_indent = (
@@ -9037,25 +9300,6 @@ function jslint_phase5_whitage(state) {
         }
     }
 
-    function pop() {
-        const previous = function_stack.pop();
-        closer = previous.closer;
-        free = previous.free;
-        margin = previous.margin;
-        open = previous.open;
-        opening = previous.opening;
-    }
-
-    function push() {
-        function_stack.push({
-            closer,
-            free,
-            margin,
-            open,
-            opening
-        });
-    }
-
     function whitage_case() {
 
 // test_cause:
@@ -9112,7 +9356,14 @@ function jslint_phase5_whitage(state) {
 
             test_cause("opener_operand");
             opening = left.open || (left.line !== right.line);
-            push();
+            indentage = {
+                closer,
+                free,
+                margin,
+                open,
+                opening
+            };
+            function_stack.push(indentage);
             switch (left.id) {
             case "${":
                 closer = "}";
@@ -9140,6 +9391,13 @@ function jslint_phase5_whitage(state) {
                 free = closer === ")" && left.free;
                 open = true;
                 margin += mode_indent;
+                if (indent_method_dict[left.line]) {
+
+// PR-xxx - Relax warning on multiline-method-chaining.
+
+                    margin += mode_indent;
+                    indentage.indent_method = true;
+                }
                 if (right.role === "label") {
                     if (right.from !== 0) {
 
@@ -9229,9 +9487,21 @@ function jslint_phase5_whitage(state) {
 // If right is a closer, then pop the previous state.
 
         if (right.id === closer) {
-            pop();
+            indentage = function_stack.pop();
+            closer = indentage.closer;
+            free = indentage.free;
+            margin = indentage.margin;
+            open = indentage.open;
+            opening = indentage.opening;
             if (opening && right.id !== ";") {
-                at_margin(0);
+                at_margin(
+                    indentage.indent_method
+
+// PR-xxx - Relax warning on multiline-method-chaining.
+
+                    ? mode_indent
+                    : 0
+                );
             } else {
                 no_space_only();
             }
@@ -9344,14 +9614,28 @@ function jslint_phase5_whitage(state) {
                 right.arity === "function"
                 && left.id !== "function"
             )
-            || (right.id === "." || right.id === "?.")
         ) {
 
 // test_cause:
 // ["let aa = 0 ;", "no_space_only", "unexpected_space_a_b", ";", 12]
-// ["let aa = aa ?.aa;", "no_space_only", "unexpected_space_a_b", "?.", 13]
 
             no_space_only();
+            return;
+        }
+        if (right.id === "." || right.id === "?.") {
+            if (left.line === right.line) {
+
+// test_cause:
+// ["let aa = aa ?.aa;", "no_space_only", "unexpected_space_a_b", "?.", 13]
+
+                no_space_only();
+            } else {
+
+// PR-xxx - Relax warning on multiline-method-chaining.
+
+                indent_method_dict[right.line] = true;
+                at_margin(mode_indent);
+            }
             return;
         }
         if (left.id === ";") {

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -9056,6 +9056,376 @@ function jslint_phase5_whitage(state) {
         });
     }
 
+    function whitage_case() {
+
+// test_cause:
+// ["let aa=[];", "whitage_case", "opener", "", 0]
+// ["let aa=`${0}`;", "whitage_case", "opener", "", 0]
+// ["let aa=aa();", "whitage_case", "opener", "", 0]
+// ["let aa={};", "whitage_case", "opener", "", 0]
+
+        test_cause("opener");
+
+// Probably deadcode.
+// case "${}":
+
+        jslint_assert(
+            !(left.id + right.id === "${}"),
+            "Expected !(left.id + right.id === \"${}\")."
+        );
+        switch (left.id + right.id) {
+        case "()":
+        case "[]":
+        case "{}":
+
+// If left and right are opener and closer, then the placement of right depends
+// on the openness. Illegal pairs (like '{]') have already been detected.
+
+// test_cause:
+// ["let aa=[];", "whitage_case", "opener_closer", "", 0]
+// ["let aa=aa();", "whitage_case", "opener_closer", "", 0]
+// ["let aa={};", "whitage_case", "opener_closer", "", 0]
+
+            test_cause("opener_closer");
+            if (left.line === right.line) {
+
+// test_cause:
+// ["let aa = aa( );", "no_space", "unexpected_space_a_b", ")", 14]
+
+                no_space();
+            } else {
+
+// test_cause:
+// ["let aa = aa(\n );", "expected_at", "expected_a_at_b_c", "1", 2]
+
+                at_margin(0);
+            }
+            break;
+        default:
+
+// test_cause:
+// ["let aa=(0);", "whitage_case", "opener_operand", "", 0]
+// ["let aa=[0];", "whitage_case", "opener_operand", "", 0]
+// ["let aa=`${0}`;", "whitage_case", "opener_operand", "", 0]
+// ["let aa=aa(0);", "whitage_case", "opener_operand", "", 0]
+// ["let aa={aa:0};", "whitage_case", "opener_operand", "", 0]
+
+            test_cause("opener_operand");
+            opening = left.open || (left.line !== right.line);
+            push();
+            switch (left.id) {
+            case "${":
+                closer = "}";
+                break;
+            case "(":
+                closer = ")";
+                break;
+            case "[":
+                closer = "]";
+                break;
+            case "{":
+                closer = "}";
+                break;
+            }
+            if (opening) {
+
+// test_cause:
+// ["function aa(){\nreturn;\n}", "whitage_case", "opening", "", 0]
+// ["let aa=(\n0\n);", "whitage_case", "opening", "", 0]
+// ["let aa=[\n0\n];", "whitage_case", "opening", "", 0]
+// ["let aa=`${\n0\n}`;", "whitage_case", "opening", "", 0]
+// ["let aa={\naa:0\n};", "whitage_case", "opening", "", 0]
+
+                test_cause("opening");
+                free = closer === ")" && left.free;
+                open = true;
+                margin += mode_indent;
+                if (right.role === "label") {
+                    if (right.from !== 0) {
+
+// test_cause:
+// ["
+// function aa() {
+//  bb:
+//     while (aa) {
+//         if (aa) {
+//             break bb;
+//         }
+//     }
+// }
+// ", "expected_at", "expected_a_at_b_c", "1", 2]
+
+                        expected_at(0);
+                    }
+                } else if (right.switch) {
+                    at_margin(-mode_indent);
+                } else {
+                    at_margin(0);
+                }
+            } else {
+                if (right.statement || right.role === "label") {
+
+// test_cause:
+// ["
+// function aa() {bb:
+//     while (aa) {
+//         aa();
+//     }
+// }
+// ", "whitage_case", "expected_line_break_a_b", "bb", 16]
+
+                    warn(
+                        "expected_line_break_a_b",
+                        right,
+                        artifact(left),
+                        artifact(right)
+                    );
+                }
+
+// test_cause:
+// ["let aa=(0);", "whitage_case", "not_free", "", 0]
+// ["let aa=[0];", "whitage_case", "not_free", "", 0]
+// ["let aa=`${0}`;", "whitage_case", "not_free", "", 0]
+// ["let aa={aa:0};", "whitage_case", "not_free", "", 0]
+
+                test_cause("not_free");
+                free = false;
+                open = false;
+
+// test_cause:
+// ["let aa = ( 0 );", "no_space_only", "unexpected_space_a_b", "0", 12]
+
+                no_space_only();
+            }
+        }
+    }
+
+    function whitage_default() {
+        if (right.statement === true) {
+            if (left.id === "else") {
+
+// test_cause:
+// ["
+// let aa = 0;
+// if (aa) {
+//     aa();
+// } else  if (aa) {
+//     aa();
+// }
+// ", "one_space_only", "expected_space_a_b", "if", 9]
+
+                one_space_only();
+            } else {
+
+// test_cause:
+// [" let aa = 0;", "expected_at", "expected_a_at_b_c", "1", 2]
+
+                at_margin(0);
+                open = false;
+            }
+
+// If right is a closer, then pop the previous state.
+
+        } else if (right.id === closer) {
+            pop();
+            if (opening && right.id !== ";") {
+                at_margin(0);
+            } else {
+                no_space_only();
+            }
+        } else {
+
+// Left is not an opener, and right is not a closer.
+// The nature of left and right will determine the space between them.
+
+// If left is ',' or ';' or right is a statement then if open,
+// right must go at the margin, or if closed, a space between.
+
+            if (right.switch) {
+                at_margin(-mode_indent);
+            } else if (right.role === "label") {
+                if (right.from !== 0) {
+
+// test_cause:
+// ["
+// function aa() {
+//     aa();cc:
+//     while (aa) {
+//         if (aa) {
+//             break cc;
+//         }
+//     }
+// }
+// ", "expected_at", "expected_a_at_b_c", "1", 10]
+
+                    expected_at(0);
+                }
+            } else if (left.id === ",") {
+                if (!open || (
+                    (free || closer === "]")
+                    && left.line === right.line
+                )) {
+
+// test_cause:
+// ["let {aa,bb} = 0;", "one_space", "expected_space_a_b", "bb", 9]
+
+                    one_space();
+                } else {
+
+// test_cause:
+// ["
+// function aa() {
+//     aa(
+//         0,0
+//     );
+// }
+// ", "expected_at", "expected_a_at_b_c", "9", 11]
+
+                    at_margin(0);
+                }
+
+// If right is a ternary operator, line it up on the margin.
+
+            } else if (right.arity === "ternary") {
+                if (open) {
+
+// test_cause:
+// ["
+// let aa = (
+//     aa
+//     ? 0
+// : 1
+// );
+// ", "expected_at", "expected_a_at_b_c", "5", 1]
+
+                    at_margin(0);
+                } else {
+
+// test_cause:
+// ["let aa = (aa ? 0 : 1);", "whitage_default", "use_open", "?", 14]
+
+                    warn("use_open", right);
+                }
+            } else if (
+                right.arity === "binary"
+                && right.id === "("
+                && free
+            ) {
+
+// test_cause:
+// ["let aa = aa(\naa ()\n);", "no_space", "unexpected_space_a_b", "(", 4]
+
+                no_space();
+            } else if (
+                left.id === "."
+                || left.id === "?."
+                || left.id === "..."
+                || right.id === ","
+                || right.id === ";"
+                || right.id === ":"
+                || (
+                    right.arity === "binary"
+                    && (right.id === "(" || right.id === "[")
+                )
+                || (
+                    right.arity === "function"
+                    && left.id !== "function"
+                )
+                || (right.id === "." || right.id === "?.")
+            ) {
+
+// test_cause:
+// ["let aa = 0 ;", "no_space_only", "unexpected_space_a_b", ";", 12]
+// ["let aa = aa ?.aa;", "no_space_only", "unexpected_space_a_b", "?.", 13]
+
+                no_space_only();
+            } else if (left.id === ";") {
+
+// test_cause:
+// ["
+// /*jslint for*/
+// function aa() {
+//     for (
+//         aa();
+// aa;
+//         aa()
+//     ) {
+//         aa();
+//     }
+// }
+// ", "expected_at", "expected_a_at_b_c", "9", 1]
+
+                if (open) {
+                    at_margin(0);
+                }
+            } else if (
+                left.arity === "ternary"
+                || left.id === "case"
+                || left.id === "catch"
+                || left.id === "else"
+                || left.id === "finally"
+                || left.id === "while"
+                || left.id === "await"
+                || right.id === "catch"
+                || right.id === "else"
+                || right.id === "finally"
+                || (right.id === "while" && !right.statement)
+                || (left.id === ")" && right.id === "{")
+            ) {
+
+// test_cause:
+// ["
+// function aa() {
+//     do {
+//         aa();
+//     } while(aa());
+// }
+// ", "one_space_only", "expected_space_a_b", "(", 12]
+
+                one_space_only();
+            } else if (
+
+// There is a space between left and right.
+
+                spaceop[left.id] === true
+                || spaceop[right.id] === true
+                || (
+                    left.arity === "binary"
+                    && (left.id === "+" || left.id === "-")
+                )
+                || (
+                    right.arity === "binary"
+                    && (right.id === "+" || right.id === "-")
+                )
+                || left.id === "function"
+                || left.id === ":"
+                || left.id === "async"
+                || (
+                    (
+                        left.identifier
+                        || left.id === "(string)"
+                        || left.id === "(number)"
+                    )
+                    && (
+                        right.identifier
+                        || right.id === "(string)"
+                        || right.id === "(number)"
+                    )
+                )
+                || (left.arity === "statement" && right.id !== ";")
+            ) {
+
+// test_cause:
+// ["let aa=0;", "one_space", "expected_space_a_b", "0", 8]
+// ["let aa={\naa:\n0\n};", "expected_at", "expected_a_at_b_c", "5", 1]
+
+                one_space();
+            } else if (left.arity === "unary" && left.id !== "`") {
+                no_space_only();
+            }
+        }
+    }
+
 // uninitialized_and_unused();
 // Delve into the functions looking for variables that were not initialized
 // or used. If the file imports or exports, then its global object is also
@@ -9074,11 +9444,12 @@ function jslint_phase5_whitage(state) {
 // whitage();
 // Go through the token list, looking at usage of whitespace.
 
-    token_list.forEach(function whitage(the_token) {
+    token_list.forEach(function (the_token) {
         right = the_token;
         if (right.id === "(comment)" || right.id === "(end)") {
             nr_comments_skipped += 1;
-        } else {
+            return;
+        }
 
 // If left is an opener and right is not the closer, then push the previous
 // state. If the token following the opener is on the next line, then this is
@@ -9089,387 +9460,24 @@ function jslint_phase5_whitage(state) {
 
 // The open and close pairs.
 
-            switch (left.id) {
-            case "${":
-            case "(":
-            case "[":
-            case "{":
-
-// test_cause:
-// ["let aa=[];", "whitage", "opener", "", 0]
-// ["let aa=`${0}`;", "whitage", "opener", "", 0]
-// ["let aa=aa();", "whitage", "opener", "", 0]
-// ["let aa={};", "whitage", "opener", "", 0]
-
-                test_cause("opener");
-
-// Probably deadcode.
-// case "${}":
-
-                jslint_assert(
-                    !(left.id + right.id === "${}"),
-                    "Expected !(left.id + right.id === \"${}\")."
-                );
-                switch (left.id + right.id) {
-                case "()":
-                case "[]":
-                case "{}":
-
-// If left and right are opener and closer, then the placement of right depends
-// on the openness. Illegal pairs (like '{]') have already been detected.
-
-// test_cause:
-// ["let aa=[];", "whitage", "opener_closer", "", 0]
-// ["let aa=aa();", "whitage", "opener_closer", "", 0]
-// ["let aa={};", "whitage", "opener_closer", "", 0]
-
-                    test_cause("opener_closer");
-                    if (left.line === right.line) {
-
-// test_cause:
-// ["let aa = aa( );", "no_space", "unexpected_space_a_b", ")", 14]
-
-                        no_space();
-                    } else {
-
-// test_cause:
-// ["let aa = aa(\n );", "expected_at", "expected_a_at_b_c", "1", 2]
-
-                        at_margin(0);
-                    }
-                    break;
-                default:
-
-// test_cause:
-// ["let aa=(0);", "whitage", "opener_operand", "", 0]
-// ["let aa=[0];", "whitage", "opener_operand", "", 0]
-// ["let aa=`${0}`;", "whitage", "opener_operand", "", 0]
-// ["let aa=aa(0);", "whitage", "opener_operand", "", 0]
-// ["let aa={aa:0};", "whitage", "opener_operand", "", 0]
-
-                    test_cause("opener_operand");
-                    opening = left.open || (left.line !== right.line);
-                    push();
-                    switch (left.id) {
-                    case "${":
-                        closer = "}";
-                        break;
-                    case "(":
-                        closer = ")";
-                        break;
-                    case "[":
-                        closer = "]";
-                        break;
-                    case "{":
-                        closer = "}";
-                        break;
-                    }
-                    if (opening) {
-
-// test_cause:
-// ["function aa(){\nreturn;\n}", "whitage", "opening", "", 0]
-// ["let aa=(\n0\n);", "whitage", "opening", "", 0]
-// ["let aa=[\n0\n];", "whitage", "opening", "", 0]
-// ["let aa=`${\n0\n}`;", "whitage", "opening", "", 0]
-// ["let aa={\naa:0\n};", "whitage", "opening", "", 0]
-
-                        test_cause("opening");
-                        free = closer === ")" && left.free;
-                        open = true;
-                        margin += mode_indent;
-                        if (right.role === "label") {
-                            if (right.from !== 0) {
-
-// test_cause:
-// ["
-// function aa() {
-//  bb:
-//     while (aa) {
-//         if (aa) {
-//             break bb;
-//         }
-//     }
-// }
-// ", "expected_at", "expected_a_at_b_c", "1", 2]
-
-                                expected_at(0);
-                            }
-                        } else if (right.switch) {
-                            at_margin(-mode_indent);
-                        } else {
-                            at_margin(0);
-                        }
-                    } else {
-                        if (right.statement || right.role === "label") {
-
-// test_cause:
-// ["
-// function aa() {bb:
-//     while (aa) {
-//         aa();
-//     }
-// }
-// ", "whitage", "expected_line_break_a_b", "bb", 16]
-
-                            warn(
-                                "expected_line_break_a_b",
-                                right,
-                                artifact(left),
-                                artifact(right)
-                            );
-                        }
-
-// test_cause:
-// ["let aa=(0);", "whitage", "not_free", "", 0]
-// ["let aa=[0];", "whitage", "not_free", "", 0]
-// ["let aa=`${0}`;", "whitage", "not_free", "", 0]
-// ["let aa={aa:0};", "whitage", "not_free", "", 0]
-
-                        test_cause("not_free");
-                        free = false;
-                        open = false;
-
-// test_cause:
-// ["let aa = ( 0 );", "no_space_only", "unexpected_space_a_b", "0", 12]
-
-                        no_space_only();
-                    }
-                }
-                break;
-            default:
-                if (right.statement === true) {
-                    if (left.id === "else") {
-
-// test_cause:
-// ["
-// let aa = 0;
-// if (aa) {
-//     aa();
-// } else  if (aa) {
-//     aa();
-// }
-// ", "one_space_only", "expected_space_a_b", "if", 9]
-
-                        one_space_only();
-                    } else {
-
-// test_cause:
-// [" let aa = 0;", "expected_at", "expected_a_at_b_c", "1", 2]
-
-                        at_margin(0);
-                        open = false;
-                    }
-
-// If right is a closer, then pop the previous state.
-
-                } else if (right.id === closer) {
-                    pop();
-                    if (opening && right.id !== ";") {
-                        at_margin(0);
-                    } else {
-                        no_space_only();
-                    }
-                } else {
-
-// Left is not an opener, and right is not a closer.
-// The nature of left and right will determine the space between them.
-
-// If left is ',' or ';' or right is a statement then if open,
-// right must go at the margin, or if closed, a space between.
-
-                    if (right.switch) {
-                        at_margin(-mode_indent);
-                    } else if (right.role === "label") {
-                        if (right.from !== 0) {
-
-// test_cause:
-// ["
-// function aa() {
-//     aa();cc:
-//     while (aa) {
-//         if (aa) {
-//             break cc;
-//         }
-//     }
-// }
-// ", "expected_at", "expected_a_at_b_c", "1", 10]
-
-                            expected_at(0);
-                        }
-                    } else if (left.id === ",") {
-                        if (!open || (
-                            (free || closer === "]")
-                            && left.line === right.line
-                        )) {
-
-// test_cause:
-// ["let {aa,bb} = 0;", "one_space", "expected_space_a_b", "bb", 9]
-
-                            one_space();
-                        } else {
-
-// test_cause:
-// ["
-// function aa() {
-//     aa(
-//         0,0
-//     );
-// }
-// ", "expected_at", "expected_a_at_b_c", "9", 11]
-
-                            at_margin(0);
-                        }
-
-// If right is a ternary operator, line it up on the margin.
-
-                    } else if (right.arity === "ternary") {
-                        if (open) {
-
-// test_cause:
-// ["
-// let aa = (
-//     aa
-//     ? 0
-// : 1
-// );
-// ", "expected_at", "expected_a_at_b_c", "5", 1]
-
-                            at_margin(0);
-                        } else {
-
-// test_cause:
-// ["let aa = (aa ? 0 : 1);", "whitage", "use_open", "?", 14]
-
-                            warn("use_open", right);
-                        }
-                    } else if (
-                        right.arity === "binary"
-                        && right.id === "("
-                        && free
-                    ) {
-
-// test_cause:
-// ["let aa = aa(\naa ()\n);", "no_space", "unexpected_space_a_b", "(", 4]
-
-                        no_space();
-                    } else if (
-                        left.id === "."
-                        || left.id === "?."
-                        || left.id === "..."
-                        || right.id === ","
-                        || right.id === ";"
-                        || right.id === ":"
-                        || (
-                            right.arity === "binary"
-                            && (right.id === "(" || right.id === "[")
-                        )
-                        || (
-                            right.arity === "function"
-                            && left.id !== "function"
-                        )
-                        || (right.id === "." || right.id === "?.")
-                    ) {
-
-// test_cause:
-// ["let aa = 0 ;", "no_space_only", "unexpected_space_a_b", ";", 12]
-// ["let aa = aa ?.aa;", "no_space_only", "unexpected_space_a_b", "?.", 13]
-
-                        no_space_only();
-                    } else if (left.id === ";") {
-
-// test_cause:
-// ["
-// /*jslint for*/
-// function aa() {
-//     for (
-//         aa();
-// aa;
-//         aa()
-//     ) {
-//         aa();
-//     }
-// }
-// ", "expected_at", "expected_a_at_b_c", "9", 1]
-
-                        if (open) {
-                            at_margin(0);
-                        }
-                    } else if (
-                        left.arity === "ternary"
-                        || left.id === "case"
-                        || left.id === "catch"
-                        || left.id === "else"
-                        || left.id === "finally"
-                        || left.id === "while"
-                        || left.id === "await"
-                        || right.id === "catch"
-                        || right.id === "else"
-                        || right.id === "finally"
-                        || (right.id === "while" && !right.statement)
-                        || (left.id === ")" && right.id === "{")
-                    ) {
-
-// test_cause:
-// ["
-// function aa() {
-//     do {
-//         aa();
-//     } while(aa());
-// }
-// ", "one_space_only", "expected_space_a_b", "(", 12]
-
-                        one_space_only();
-                    } else if (
-
-// There is a space between left and right.
-
-                        spaceop[left.id] === true
-                        || spaceop[right.id] === true
-                        || (
-                            left.arity === "binary"
-                            && (left.id === "+" || left.id === "-")
-                        )
-                        || (
-                            right.arity === "binary"
-                            && (right.id === "+" || right.id === "-")
-                        )
-                        || left.id === "function"
-                        || left.id === ":"
-                        || left.id === "async"
-                        || (
-                            (
-                                left.identifier
-                                || left.id === "(string)"
-                                || left.id === "(number)"
-                            )
-                            && (
-                                right.identifier
-                                || right.id === "(string)"
-                                || right.id === "(number)"
-                            )
-                        )
-                        || (left.arity === "statement" && right.id !== ";")
-                    ) {
-
-// test_cause:
-// ["let aa=0;", "one_space", "expected_space_a_b", "0", 8]
-// ["let aa={\naa:\n0\n};", "expected_at", "expected_a_at_b_c", "5", 1]
-
-                        one_space();
-                    } else if (left.arity === "unary" && left.id !== "`") {
-                        no_space_only();
-                    }
-                }
-            }
-            nr_comments_skipped = 0;
-            delete left.calls;
-            delete left.dead;
-            delete left.free;
-            delete left.init;
-            delete left.open;
-            delete left.used;
-            left = right;
+        switch (left.id) {
+        case "${":
+        case "(":
+        case "[":
+        case "{":
+            whitage_case();
+            break;
+        default:
+            whitage_default();
         }
+        nr_comments_skipped = 0;
+        delete left.calls;
+        delete left.dead;
+        delete left.free;
+        delete left.init;
+        delete left.open;
+        delete left.used;
+        left = right;
     });
 }
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -836,13 +836,10 @@ function htmlEscape(str) {
 
 // This function will make <str> html-safe by escaping & < >.
 
-    return String(str).replace((
-        /&/g
-    ), "&amp;").replace((
-        /</g
-    ), "&lt;").replace((
-        />/g
-    ), "&gt;");
+    return String(str)
+        .replace((/&/g), "&amp;")
+        .replace((/</g), "&lt;")
+        .replace((/>/g), "&gt;");
 }
 
 function jslint(
@@ -1083,22 +1080,24 @@ function jslint(
 // This function will instrument <cause> to <cause_dict> for test-purposes.
 
         if (option_dict.test_cause) {
-            cause_dict[JSON.stringify([
-                String(new Error().stack).replace((
-                    /^    at (?:file|stop|stop_at|test_cause|warn|warn_at)\b.*?\n/gm
-                ), "").match(
-                    /\n    at ((?:Object\.\w+?_)?\w+?) /
-                )[1].replace((
-                    /^Object\./
-                ), ""),
-                code,
-                String(
-                    (aa === undefined || aa === token_global)
-                    ? ""
-                    : aa
-                ),
-                column || 0
-            ])] = true;
+            cause_dict[
+                JSON.stringify([
+                    String(new Error().stack)
+                        .replace(
+                            (/^    at (?:file|stop|stop_at|test_cause|warn|warn_at)\b.*?\n/gm),
+                            ""
+                        )
+                        .match(/\n    at ((?:Object\.\w+?_)?\w+?) /)[1]
+                        .replace((/^Object\./), ""),
+                    code,
+                    String(
+                        (aa === undefined || aa === token_global)
+                        ? ""
+                        : aa
+                    ),
+                    column || 0
+                ])
+            ] = true;
         }
     }
 
@@ -1740,13 +1739,10 @@ ${name}
             /(\([\S\s]*?\)) \{/
         ), function (match0, match1) {
             signature = htmlEscape(
-                match1.replace((
-                    / *?\/\*[\S\s]*?\*\/ */g
-                ), "").replace((
-                    / *?\/\/.*/g
-                ), "").replace((
-                    /\n{2,}/g
-                ), "\n")
+                match1
+                    .replace((/ *?\/\*[\S\s]*?\*\/ */g), "")
+                    .replace((/ *?\/\/.*/g), "")
+                    .replace((/\n{2,}/g), "\n")
             );
             return match0;
         });
@@ -11758,13 +11754,9 @@ function sentinel() {}
 // Coverage-hack - Ugly-hack to get test-coverage under both win32 and linux.
 
             if (processArgv0 === "npm") {
-                processArgv0 = process.platform.replace(
-                    "win32",
-                    "npm.cmd"
-                ).replace(
-                    process.platform,
-                    "npm"
-                );
+                processArgv0 = process.platform
+                    .replace("win32", "npm.cmd")
+                    .replace(process.platform, "npm");
             }
             moduleChildProcess.spawn(
                 processArgv0,

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -9162,8 +9162,9 @@ function jslint_phase5_whitage(state) {
                 } else {
                     at_margin(0);
                 }
-            } else {
-                if (right.statement || right.role === "label") {
+                break;
+            }
+            if (right.statement || right.role === "label") {
 
 // test_cause:
 // ["
@@ -9174,13 +9175,13 @@ function jslint_phase5_whitage(state) {
 // }
 // ", "whitage_case", "expected_line_break_a_b", "bb", 16]
 
-                    warn(
-                        "expected_line_break_a_b",
-                        right,
-                        artifact(left),
-                        artifact(right)
-                    );
-                }
+                warn(
+                    "expected_line_break_a_b",
+                    right,
+                    artifact(left),
+                    artifact(right)
+                );
+            }
 
 // test_cause:
 // ["let aa=(0);", "whitage_case", "not_free", "", 0]
@@ -9188,15 +9189,14 @@ function jslint_phase5_whitage(state) {
 // ["let aa=`${0}`;", "whitage_case", "not_free", "", 0]
 // ["let aa={aa:0};", "whitage_case", "not_free", "", 0]
 
-                test_cause("not_free");
-                free = false;
-                open = false;
+            test_cause("not_free");
+            free = false;
+            open = false;
 
 // test_cause:
 // ["let aa = ( 0 );", "no_space_only", "unexpected_space_a_b", "0", 12]
 
-                no_space_only();
-            }
+            no_space_only();
         }
     }
 
@@ -9223,17 +9223,20 @@ function jslint_phase5_whitage(state) {
                 at_margin(0);
                 open = false;
             }
+            return;
+        }
 
 // If right is a closer, then pop the previous state.
 
-        } else if (right.id === closer) {
+        if (right.id === closer) {
             pop();
             if (opening && right.id !== ";") {
                 at_margin(0);
             } else {
                 no_space_only();
             }
-        } else {
+            return;
+        }
 
 // Left is not an opener, and right is not a closer.
 // The nature of left and right will determine the space between them.
@@ -9241,10 +9244,12 @@ function jslint_phase5_whitage(state) {
 // If left is ',' or ';' or right is a statement then if open,
 // right must go at the margin, or if closed, a space between.
 
-            if (right.switch) {
-                at_margin(-mode_indent);
-            } else if (right.role === "label") {
-                if (right.from !== 0) {
+        if (right.switch) {
+            at_margin(-mode_indent);
+            return;
+        }
+        if (right.role === "label") {
+            if (right.from !== 0) {
 
 // test_cause:
 // ["
@@ -9258,19 +9263,21 @@ function jslint_phase5_whitage(state) {
 // }
 // ", "expected_at", "expected_a_at_b_c", "1", 10]
 
-                    expected_at(0);
-                }
-            } else if (left.id === ",") {
-                if (!open || (
-                    (free || closer === "]")
-                    && left.line === right.line
-                )) {
+                expected_at(0);
+            }
+            return;
+        }
+        if (left.id === ",") {
+            if (!open || (
+                (free || closer === "]")
+                && left.line === right.line
+            )) {
 
 // test_cause:
 // ["let {aa,bb} = 0;", "one_space", "expected_space_a_b", "bb", 9]
 
-                    one_space();
-                } else {
+                one_space();
+            } else {
 
 // test_cause:
 // ["
@@ -9281,13 +9288,15 @@ function jslint_phase5_whitage(state) {
 // }
 // ", "expected_at", "expected_a_at_b_c", "9", 11]
 
-                    at_margin(0);
-                }
+                at_margin(0);
+            }
+            return;
+        }
 
 // If right is a ternary operator, line it up on the margin.
 
-            } else if (right.arity === "ternary") {
-                if (open) {
+        if (right.arity === "ternary") {
+            if (open) {
 
 // test_cause:
 // ["
@@ -9298,48 +9307,54 @@ function jslint_phase5_whitage(state) {
 // );
 // ", "expected_at", "expected_a_at_b_c", "5", 1]
 
-                    at_margin(0);
-                } else {
+                at_margin(0);
+            } else {
 
 // test_cause:
 // ["let aa = (aa ? 0 : 1);", "whitage_default", "use_open", "?", 14]
 
-                    warn("use_open", right);
-                }
-            } else if (
-                right.arity === "binary"
-                && right.id === "("
-                && free
-            ) {
+                warn("use_open", right);
+            }
+            return;
+        }
+        if (
+            right.arity === "binary"
+            && right.id === "("
+            && free
+        ) {
 
 // test_cause:
 // ["let aa = aa(\naa ()\n);", "no_space", "unexpected_space_a_b", "(", 4]
 
-                no_space();
-            } else if (
-                left.id === "."
-                || left.id === "?."
-                || left.id === "..."
-                || right.id === ","
-                || right.id === ";"
-                || right.id === ":"
-                || (
-                    right.arity === "binary"
-                    && (right.id === "(" || right.id === "[")
-                )
-                || (
-                    right.arity === "function"
-                    && left.id !== "function"
-                )
-                || (right.id === "." || right.id === "?.")
-            ) {
+            no_space();
+            return;
+        }
+        if (
+            left.id === "."
+            || left.id === "?."
+            || left.id === "..."
+            || right.id === ","
+            || right.id === ";"
+            || right.id === ":"
+            || (
+                right.arity === "binary"
+                && (right.id === "(" || right.id === "[")
+            )
+            || (
+                right.arity === "function"
+                && left.id !== "function"
+            )
+            || (right.id === "." || right.id === "?.")
+        ) {
 
 // test_cause:
 // ["let aa = 0 ;", "no_space_only", "unexpected_space_a_b", ";", 12]
 // ["let aa = aa ?.aa;", "no_space_only", "unexpected_space_a_b", "?.", 13]
 
-                no_space_only();
-            } else if (left.id === ";") {
+            no_space_only();
+            return;
+        }
+        if (left.id === ";") {
 
 // test_cause:
 // ["
@@ -9355,23 +9370,25 @@ function jslint_phase5_whitage(state) {
 // }
 // ", "expected_at", "expected_a_at_b_c", "9", 1]
 
-                if (open) {
-                    at_margin(0);
-                }
-            } else if (
-                left.arity === "ternary"
-                || left.id === "case"
-                || left.id === "catch"
-                || left.id === "else"
-                || left.id === "finally"
-                || left.id === "while"
-                || left.id === "await"
-                || right.id === "catch"
-                || right.id === "else"
-                || right.id === "finally"
-                || (right.id === "while" && !right.statement)
-                || (left.id === ")" && right.id === "{")
-            ) {
+            if (open) {
+                at_margin(0);
+            }
+            return;
+        }
+        if (
+            left.arity === "ternary"
+            || left.id === "case"
+            || left.id === "catch"
+            || left.id === "else"
+            || left.id === "finally"
+            || left.id === "while"
+            || left.id === "await"
+            || right.id === "catch"
+            || right.id === "else"
+            || right.id === "finally"
+            || (right.id === "while" && !right.statement)
+            || (left.id === ")" && right.id === "{")
+        ) {
 
 // test_cause:
 // ["
@@ -9382,47 +9399,51 @@ function jslint_phase5_whitage(state) {
 // }
 // ", "one_space_only", "expected_space_a_b", "(", 12]
 
-                one_space_only();
-            } else if (
+            one_space_only();
+            return;
+        }
+        if (
 
 // There is a space between left and right.
 
-                spaceop[left.id] === true
-                || spaceop[right.id] === true
-                || (
-                    left.arity === "binary"
-                    && (left.id === "+" || left.id === "-")
+            spaceop[left.id] === true
+            || spaceop[right.id] === true
+            || (
+                left.arity === "binary"
+                && (left.id === "+" || left.id === "-")
+            )
+            || (
+                right.arity === "binary"
+                && (right.id === "+" || right.id === "-")
+            )
+            || left.id === "function"
+            || left.id === ":"
+            || left.id === "async"
+            || (
+                (
+                    left.identifier
+                    || left.id === "(string)"
+                    || left.id === "(number)"
                 )
-                || (
-                    right.arity === "binary"
-                    && (right.id === "+" || right.id === "-")
+                && (
+                    right.identifier
+                    || right.id === "(string)"
+                    || right.id === "(number)"
                 )
-                || left.id === "function"
-                || left.id === ":"
-                || left.id === "async"
-                || (
-                    (
-                        left.identifier
-                        || left.id === "(string)"
-                        || left.id === "(number)"
-                    )
-                    && (
-                        right.identifier
-                        || right.id === "(string)"
-                        || right.id === "(number)"
-                    )
-                )
-                || (left.arity === "statement" && right.id !== ";")
-            ) {
+            )
+            || (left.arity === "statement" && right.id !== ";")
+        ) {
 
 // test_cause:
 // ["let aa=0;", "one_space", "expected_space_a_b", "0", 8]
 // ["let aa={\naa:\n0\n};", "expected_at", "expected_a_at_b_c", "5", 1]
 
-                one_space();
-            } else if (left.arity === "unary" && left.id !== "`") {
-                no_space_only();
-            }
+            one_space();
+            return;
+        }
+        if (left.arity === "unary" && left.id !== "`") {
+            no_space_only();
+            return;
         }
     }
 

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -2395,13 +2395,10 @@ function globExclude({
  };
 }
 function htmlEscape(str) {
- return String(str).replace((
-  /&/g
- ), "&amp;").replace((
-  /</g
- ), "&lt;").replace((
-  />/g
- ), "&gt;");
+ return String(str)
+  .replace((/&/g), "&amp;")
+  .replace((/</g), "&lt;")
+  .replace((/>/g), "&gt;");
 }
 async function moduleFsInit() {
 
@@ -3345,13 +3342,9 @@ function sentinel() {}
   exitCode = await new Promise(function (resolve) {
    let processArgv0 = processArgv[0];
    if (processArgv0 === "npm") {
-    processArgv0 = process.platform.replace(
-     "win32",
-     "npm.cmd"
-    ).replace(
-     process.platform,
-     "npm"
-    );
+    processArgv0 = process.platform
+     .replace("win32", "npm.cmd")
+     .replace(process.platform, "npm");
    }
    moduleChildProcess.spawn(
     processArgv0,

--- a/test.mjs
+++ b/test.mjs
@@ -725,6 +725,9 @@ jstestDescribe((
             import: [
                 `import aa from "aa" with {"type": "json"};\naa();`
             ],
+            indent_method: [
+                "let aa = 0;\naa\n    .bb\n    .cc(\n        0\n    );"
+            ],
             jslint_disable: [
                 "/*jslint-disable*/\n0\n/*jslint-enable*/"
             ],


### PR DESCRIPTION
- This PR will relax jslint-warning against line-wrapping multiple method-chains.
- e.g., the following common idiom for chaining string-methods is now valid in jslint:

```js
/*jslint devel*/
function htmlEscape(str) {

// This function will make <str> html-safe by escaping & < >.

    return String(str)
        .replace((/&/g), "&amp;")
        .replace((/</g), "&lt;")
        .replace((/>/g), "&gt;");
}
console.log(htmlEscape("aa < bb"));
```

<img width="646" height="1036" alt="image" src="https://github.com/user-attachments/assets/0b266238-928d-4622-87e3-3afef98a000c" />
