### PR TITLE
- jslint-ecma - Update README.md, documenting supported ES2015+ features.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 # v2026.6.1-beta
 - jslint-ecma - Update README.md, documenting supported ES2015+ features.
+- jslint-ecma - Add ES2018-feature Rest/Spread Properties.
+- jslint-ecma - Add ES2018-feature s (dotall) flag for regular expressions.
 - jslint-ecma - Expand ES2015-feature-support for es-module-import-statement.
 - jslint-ecma - Add ES2023-feature ShadowRealm to global-scope.
 - jslint-ecma - Add ES2024-feature .isWellFormed(), .toWellFormed() for literal string.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 # Todo
 - jslint - Add ability to auto-fix whitespace.
 - jslint - bugfix - Fix false-positive Unused-variable when variable is used in function argument-default.
-- doc - Document supported/unsupported es6+ features
 - jslint - Add html and css linting back into jslint.
 - jslint - Add new warning requiring paren around plus-separated concatenations.
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.6.1-beta
+- doc - Update README.md, documenting supported/unsupported es6+ features.
+- jslint - Add ES2021-feature WeakRef.
+- jslint - Update ES2021-feature arrow, to continue parsing unwrapped-form with warning, instead of stopping.
 - jslint - Relax warning on multiline-method-chaining.
 - jslint - Replace all non-return "stop(...);" with "return stop(...)".
 - jslint - Unify ES2018-syntax-spread-operator with function prefix_ellipsis().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 # Todo
+- jslint-ecma - Unify ES2015-destructure-logic into function prefix_destructure.
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
 - jslint - Relax warning expected_line_break_a_b for ternary-operator inside template-literal.
 - jslint - Add ability to auto-fix whitespace.
@@ -11,6 +12,7 @@
 
 # v2026.6.1-beta
 - jslint-ecma - Update README.md, documenting supported ES2015+ features.
+- jslint-ecma - Expand ES2015-feature-support for destructuring.
 - jslint-ecma - Add ES2018-feature Rest/Spread Properties.
 - jslint-ecma - Add ES2018-feature s (dotall) flag for regular expressions.
 - jslint-ecma - Expand ES2015-feature-support for es-module-import-statement.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 # Todo
-- jslint-ecma - Unify ES2015-destructure-logic into function prefix_destructure.
+- jslint-ecma - Unify ES2015-destructure-logic into function prefix_destructure().
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
 - jslint - Relax warning expected_line_break_a_b for ternary-operator inside template-literal.
 - jslint - Add ability to auto-fix whitespace.
@@ -12,6 +12,11 @@
 
 # v2026.6.1-beta
 - jslint-ecma - Update README.md, documenting supported ES2015+ features.
+- jslint - Update warning infix_in to recommend Object.hasOwn() over hasOwnProperty().
+- jslint-ecma - Add ES2025-feature RegExp Modifiers.
+- jslint-ecma - Add ES2022-feature RegExp Match Indices.
+- jslint-ecma - Add ES2021-feature Logical Assignment Operators.
+- jslint-ecma - Add ES2027-feature Temporal.
 - jslint-ecma - Expand ES2015-feature-support for destructuring.
 - jslint-ecma - Add ES2018-feature Rest/Spread Properties.
 - jslint-ecma - Add ES2018-feature s (dotall) flag for regular expressions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.6.1-beta
-- doc - Update README.md, documenting supported/unsupported es6+ features.
-- jslint - Add ES2021-feature WeakRef.
-- jslint - Update ES2021-feature arrow, to continue parsing unwrapped-form with warning, instead of stopping.
+- jslint-ecma - Update README.md documenting supported ES2015+ features.
+- jslint-ecma - Add ES2023-feature ShadowRealm to global-scope.
+- jslint-ecma - Add ES2024-feature .isWellFormed(), .toWellFormed() for literal string.
+- jslint-ecma - Add ES2022-feature .at() for literal string/array.
+- jslint-ecma - Add ES2025-feature Float16Array to global-scope.
+- jslint-ecma - Relax warning for ES2025-feature RegExp.escape().
+- jslint-ecma - Add ES2021-feature WeakRef to global-scope.
+- jslint-ecma - Update ES2015-feature arrow, to continue parsing unwrapped-form with warning, instead of stopping.
 - jslint - Relax warning on multiline-method-chaining.
 - jslint - Replace all non-return "stop(...);" with "return stop(...)".
 - jslint - Unify ES2018-syntax-spread-operator with function prefix_ellipsis().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 # Todo
+- jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
+- jslint - Relax warning expected_line_break_a_b for ternary-operator inside template-literal.
 - jslint - Add ability to auto-fix whitespace.
 - jslint - bugfix - Fix false-positive Unused-variable when variable is used in function argument-default.
 - jslint - Add html and css linting back into jslint.
@@ -8,7 +10,8 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.6.1-beta
-- jslint-ecma - Update README.md documenting supported ES2015+ features.
+- jslint-ecma - Update README.md, documenting supported ES2015+ features.
+- jslint-ecma - Expand ES2015-feature-support for es-module-import-statement.
 - jslint-ecma - Add ES2023-feature ShadowRealm to global-scope.
 - jslint-ecma - Add ES2024-feature .isWellFormed(), .toWellFormed() for literal string.
 - jslint-ecma - Add ES2022-feature .at() for literal string/array.

--- a/README.md
+++ b/README.md
@@ -966,7 +966,7 @@ if (false) {
 |  20. | &#x274c; | ES2015 | [`classes`](https://github.com/lukehoban/es6features#classes) |
 |  19. | &#x274c; | ES2015 | [`enhanced object literals`](https://github.com/lukehoban/es6features#enhanced-object-literals) |
 |  18. | &#x2705; | ES2015 | [`template strings`](https://github.com/lukehoban/es6features#template-strings) |
-|  17. | &#x26a0; | ES2015 | [`destructuring`](https://github.com/lukehoban/es6features#destructuring) |
+|  17. | &#x2705; | ES2015 | [`destructuring`](https://github.com/lukehoban/es6features#destructuring) |
 |  16. | &#x2705; | ES2015 | [`default + rest + spread`](https://github.com/lukehoban/es6features#default--rest--spread) |
 |  15. | &#x2705; | ES2015 | [`let + const`](https://github.com/lukehoban/es6features#let--const) |
 |  14. | &#x274c; | ES2015 | [`iterators + for..of`](https://github.com/lukehoban/es6features#iterators--forof) |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Douglas Crockford <douglas@crockford.com>
     - [Directive `//jslint-ignore-line`](#directive-jslint-ignore-line)
     - [Directive `/*coverage-disable*/.../*coverage-enable*/`](#directive-coverage-disablecoverage-enable)
     - [Directive `//coverage-ignore-line`](#directive-coverage-ignore-line)
+    - [ECMAScript Feature Support](#ecmascript-feature-support)
 
 10. [Package Listing](#package-listing)
 
@@ -922,6 +923,114 @@ if (false) {
 
 
 <br><br>
+### ECMAScript Feature Support
+- https://github.com/tc39/proposals/blob/main/finished-proposals.md
+- https://github.com/lukehoban/es6features
+
+| JSLint Support | ES Version | ES Feature |
+|:--|:--|:--|
+| &#x274c; | ES2027 | [`Explicit Resource Management`](https://github.com/tc39/proposal-explicit-resource-management) |
+| &#x2705; | ES2027 | [`Atomics.pause`](https://github.com/tc39/proposal-atomics-microwait) |
+| &#x274c; | ES2027 | [`Joint Iteration`](https://github.com/tc39/proposal-joint-iteration) |
+| &#x274c; | ES2027 | [`Temporal`](https://github.com/tc39/proposal-temporal) |
+| &#x274c; | ES2026 | [`Upsert`](https://github.com/tc39/proposal-upsert) |
+| &#x2705; | ES2026 | [`JSON.parse source text access`](https://github.com/tc39/proposal-json-parse-with-source) |
+| &#x274c; | ES2026 | [`Iterator Sequencing`](https://github.com/tc39/proposal-iterator-sequencing) |
+| &#x2705; | ES2026 | [`Uint8Array to/from Base64`](https://github.com/tc39/proposal-arraybuffer-base64) |
+| &#x2705; | ES2026 | [`Math.sumPrecise`](https://github.com/tc39/proposal-math-sum) |
+| &#x2705; | ES2026 | [`Error.isError`](https://github.com/tc39/proposal-is-error) |
+| &#x2705; | ES2026 | [`Array.fromAsync`](https://github.com/tc39/proposal-array-from-async) |
+| &#x26a0; | ES2025 | [`RegExp.escape`](https://github.com/tc39/proposal-regex-escaping) |
+| &#x2705; | ES2025 | [`Redeclarable global eval-introduced vars`](https://github.com/tc39/proposal-redeclarable-global-eval-vars) |
+| &#x26a0; | ES2025 | [`Float16 on TypedArrays, DataView, Math.f16round`](https://github.com/tc39/proposal-float16array) |
+| &#x2705; | ES2025 | [`Promise.try`](https://github.com/tc39/proposal-promise-try) |
+| &#x274c; | ES2025 | [`Sync Iterator helpers`](https://github.com/tc39/proposal-iterator-helpers) |
+| &#x2705; | ES2025 | [`JSON Modules`](https://github.com/tc39/proposal-json-modules) |
+| &#x2705; | ES2025 | [`Import Attributes`](https://github.com/tc39/proposal-import-attributes) |
+| &#x274c; | ES2025 | [`RegExp Modifiers`](https://github.com/tc39/proposal-regexp-modifiers) |
+| &#x2705; | ES2025 | [`New Set methods`](https://github.com/tc39/proposal-set-methods) |
+| &#x274c; | ES2025 | [`Duplicate named capture groups`](https://github.com/tc39/proposal-duplicate-named-capturing-groups) |
+| &#x2705; | ES2024 | [`ArrayBuffer transfer`](https://github.com/tc39/proposal-arraybuffer-transfer) |
+| &#x2705; | ES2024 | [`Promise.withResolvers`](https://github.com/tc39/proposal-promise-with-resolvers) |
+| &#x2705; | ES2024 | [`Array Grouping`](https://github.com/tc39/proposal-array-grouping) |
+| &#x2705; | ES2024 | [`Resizable and growable ArrayBuffers`](https://github.com/tc39/proposal-resizablearraybuffer) |
+| &#x26a0; | ES2024 | [`RegExp v flag with set notation + properties of strings`](https://github.com/tc39/proposal-regexp-v-flag) |
+| &#x2705; | ES2024 | [`Atomics.waitAsync`](https://github.com/tc39/proposal-atomics-wait-async) |
+| &#x26a0; | ES2024 | [`Well-Formed Unicode Strings`](https://github.com/tc39/proposal-is-usv-string) |
+| &#x26a0; | ES2023 | [`Change Array by Copy`](https://github.com/tc39/proposal-change-array-by-copy) |
+| &#x2705; | ES2023 | [`Symbols as WeakMap keys`](https://github.com/tc39/proposal-symbols-as-weakmap-keys) |
+| &#x2705; | ES2023 | [`Hashbang Grammar`](https://github.com/tc39/proposal-hashbang) |
+| &#x2705; | ES2023 | [`Array find from last`](https://github.com/tc39/proposal-array-find-from-last) |
+| &#x2705; | ES2022 | [`Error Cause`](https://github.com/tc39/proposal-error-cause) |
+| &#x274c; | ES2022 | [`Class Static Block`](https://github.com/tc39/proposal-class-static-block) |
+| &#x274c; | ES2022 | [`Accessible Object.prototype.hasOwnProperty`](https://github.com/tc39/proposal-accessible-object-hasownproperty) |
+| &#x26a0; | ES2022 | [`.at()`](https://github.com/tc39/proposal-relative-indexing-method) |
+| &#x274c; | ES2022 | [`Ergonomic brand checks for Private Fields`](https://github.com/tc39/proposal-private-fields-in-in) |
+| &#x2705; | ES2022 | [`Top-level await`](https://github.com/tc39/proposal-top-level-await) |
+| &#x26a0; | ES2022 | [`RegExp Match Indices`](https://github.com/tc39/proposal-regexp-match-indices) |
+| &#x274c; | ES2022 | [`Class Public Instance Fields & Private Instance Fields`](https://github.com/tc39/proposal-class-fields) |
+| &#x2705; | ES2021 | [`Numeric separators`](https://github.com/tc39/proposal-numeric-separator) |
+| &#x26a0; | ES2021 | [`Logical Assignment Operators`](https://github.com/tc39/proposal-logical-assignment) |
+| &#x2705; | ES2021 | [`WeakRefs`](https://github.com/tc39/proposal-weakrefs) |
+| &#x2705; | ES2021 | [`Promise.any`](https://github.com/tc39/proposal-promise-any) |
+| &#x2705; | ES2021 | [`String.prototype.replaceAll`](https://github.com/tc39/proposal-string-replaceall) |
+| &#x2705; | ES2020 | [`import.meta`](https://github.com/tc39/proposal-import-meta) |
+| &#x2705; | ES2020 | [`Nullish coalescing Operator`](https://github.com/tc39/proposal-nullish-coalescing) |
+| &#x2705; | ES2020 | [`Optional Chaining`](https://github.com/tc39/proposal-optional-chaining) |
+| &#x274c; | ES2020 | [`for-in mechanics`](https://github.com/tc39/proposal-for-in-order) |
+| &#x2705; | ES2020 | [`globalThis`](https://github.com/tc39/proposal-global) |
+| &#x2705; | ES2020 | [`Promise.allSettled`](https://github.com/tc39/proposal-promise-allSettled) |
+| &#x2705; | ES2020 | [`BigInt`](https://github.com/tc39/proposal-bigint) |
+| &#x2705; | ES2020 | [`import()`](https://github.com/tc39/proposal-dynamic-import) |
+| &#x2705; | ES2020 | [`String.prototype.matchAll`](https://github.com/tc39/proposal-string-matchall) |
+| &#x2705; | ES2019 | [`Array.prototype.{flat,flatMap}`](https://github.com/tc39/proposal-flatMap) |
+| &#x2705; | ES2019 | [`String.prototype.{trimStart,trimEnd}`](https://github.com/tc39/proposal-string-left-right-trim) |
+| &#x2705; | ES2019 | [`Well-formed JSON.stringify`](https://github.com/tc39/proposal-well-formed-stringify) |
+| &#x2705; | ES2019 | [`Object.fromEntries`](https://github.com/tc39/proposal-object-from-entries) |
+| &#x2705; | ES2019 | [`Function.prototype.toString revision`](https://github.com/tc39/Function-prototype-toString-revision) |
+| &#x2705; | ES2019 | [`Symbol.prototype.description`](https://github.com/tc39/proposal-Symbol-description) |
+| &#x2705; | ES2019 | [`JSON superset`](https://github.com/tc39/proposal-json-superset) |
+| &#x2705; | ES2019 | [`Optional catch binding`](https://github.com/tc39/proposal-optional-catch-binding) |
+| &#x26a0; | ES2018 | [`Asynchronous Iteration`](https://github.com/tc39/proposal-async-iteration) |
+| &#x2705; | ES2018 | [`Promise.prototype.finally`](https://github.com/tc39/proposal-promise-finally) |
+| &#x2705; | ES2018 | [`RegExp Unicode Property Escapes`](https://github.com/tc39/proposal-regexp-unicode-property-escapes) |
+| &#x26a0; | ES2018 | [`RegExp Lookbehind Assertions`](https://github.com/tc39/proposal-regexp-lookbehind) |
+| &#x26a0; | ES2018 | [`Rest/Spread Properties`](https://github.com/tc39/proposal-object-rest-spread) |
+| &#x2705; | ES2018 | [`RegExp named capture groups`](https://github.com/tc39/proposal-regexp-named-groups) |
+| &#x26a0; | ES2018 | [`s (dotAll) flag for regular expressions`](https://github.com/tc39/proposal-regexp-dotall-flag) |
+| &#x2705; | ES2018 | [`Lifting template literal restriction`](https://github.com/tc39/proposal-template-literal-revision) |
+| &#x2705; | ES2017 | [`Shared memory and atomics`](https://github.com/tc39/proposal-ecmascript-sharedmem) |
+| &#x2705; | ES2017 | [`Async functions`](https://github.com/tc39/proposal-async-await) |
+| &#x26a0; | ES2017 | [`Trailing commas in function parameter lists and calls`](https://github.com/tc39/proposal-trailing-function-commas) |
+| &#x2705; | ES2017 | [`Object.getOwnPropertyDescriptors`](https://github.com/tc39/proposal-object-getownpropertydescriptors) |
+| &#x2705; | ES2017 | [`String padding`](https://github.com/tc39/proposal-string-pad-start-end) |
+| &#x2705; | ES2017 | [`Object.values/Object.entries`](https://github.com/tc39/proposal-object-values-entries) |
+| &#x2705; | ES2016 | [`Exponentiation operator`](https://github.com/tc39/proposal-exponentiation-operator) |
+| &#x2705; | ES2016 | [`Array.prototype.includes`](https://github.com/tc39/proposal-Array.prototype.includes) |
+| &#x2705; | ES2015 | [`arrows`](https://github.com/lukehoban/es6features#arrows) |
+| &#x274c; | ES2015 | [`classes`](https://github.com/lukehoban/es6features#classes) |
+| &#x274c; | ES2015 | [`enhanced object literals`](https://github.com/lukehoban/es6features#enhanced-object-literals) |
+| &#x2705; | ES2015 | [`template strings`](https://github.com/lukehoban/es6features#template-strings) |
+| &#x26a0; | ES2015 | [`destructuring`](https://github.com/lukehoban/es6features#destructuring) |
+| &#x2705; | ES2015 | [`default + rest + spread`](https://github.com/lukehoban/es6features#default--rest--spread) |
+| &#x2705; | ES2015 | [`let + const`](https://github.com/lukehoban/es6features#let--const) |
+| &#x274c; | ES2015 | [`iterators + for..of`](https://github.com/lukehoban/es6features#iterators--forof) |
+| &#x274c; | ES2015 | [`generators`](https://github.com/lukehoban/es6features#generators) |
+| &#x274c; | ES2015 | [`unicode`](https://github.com/lukehoban/es6features#unicode) |
+| &#x26a0; | ES2015 | [`modules`](https://github.com/lukehoban/es6features#modules) |
+| &#x2705; | ES2015 | [`module loaders`](https://github.com/lukehoban/es6features#module-loaders) |
+| &#x2705; | ES2015 | [`map + set + weakmap + weakset`](https://github.com/lukehoban/es6features#map--set--weakmap--weakset) |
+| &#x2705; | ES2015 | [`proxies`](https://github.com/lukehoban/es6features#proxies) |
+| &#x2705; | ES2015 | [`symbols`](https://github.com/lukehoban/es6features#symbols) |
+| &#x274c; | ES2015 | [`subclassable built-ins`](https://github.com/lukehoban/es6features#subclassable-built-ins) |
+| &#x2705; | ES2015 | [`promises`](https://github.com/lukehoban/es6features#promises) |
+| &#x2705; | ES2015 | [`math + number + string + array + object APIs`](https://github.com/lukehoban/es6features#math--number--string--array--object-apis) |
+| &#x2705; | ES2015 | [`binary and octal literals`](https://github.com/lukehoban/es6features#binary-and-octal-literals) |
+| &#x2705; | ES2015 | [`reflect api`](https://github.com/lukehoban/es6features#reflect-api) |
+| &#x2705; | ES2015 | [`tail calls`](https://github.com/lukehoban/es6features#tail-calls) |
+
+
+<br><br>
 # Package Listing
 ![screenshot_package_listing.svg](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_package_listing.svg)
 
@@ -954,7 +1063,7 @@ if (false) {
 - `git push upstream alpha -f`
     - verify ci-success for upstream-branch-alpha
     - https://github.com/jslint-org/jslint/actions
-- goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.6.23
+- goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.6.24
 - click `Create pull request`
 - input `Add your description here...` with:
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Douglas Crockford <douglas@crockford.com>
 
 9. [Documentation](#documentation)
     - [API Doc](#api-doc)
-    - [Directive `/*jslint*/`](#directive-jslint)
+    - [Directive](#directive)
         - [`/*jslint beta*/`](#jslint-beta)
         - [`/*jslint bitwise*/`](#jslint-bitwise)
         - [`/*jslint browser*/`](#jslint-browser)
@@ -62,12 +62,12 @@ Douglas Crockford <douglas@crockford.com>
         - [`/*jslint trace*/`](#jslint-trace)
         - [`/*jslint unordered*/`](#jslint-unordered)
         - [`/*jslint white*/`](#jslint-white)
-    - [Directive `/*global*/`](#directive-global)
-    - [Directive `/*property*/`](#directive-property)
-    - [Directive `/*jslint-disable*/.../*jslint-enable*/`](#directive-jslint-disablejslint-enable)
-    - [Directive `//jslint-ignore-line`](#directive-jslint-ignore-line)
-    - [Directive `/*coverage-disable*/.../*coverage-enable*/`](#directive-coverage-disablecoverage-enable)
-    - [Directive `//coverage-ignore-line`](#directive-coverage-ignore-line)
+        - [`/*global*/`](#global)
+        - [`/*property*/`](#property)
+        - [`/*jslint-disable*/.../*jslint-enable*/`](#jslint-disablejslint-enable)
+        - [`//jslint-ignore-line`](#jslint-ignore-line)
+        - [`/*coverage-disable*/.../*coverage-enable*/`](#coverage-disablecoverage-enable)
+        - [`//coverage-ignore-line`](#coverage-ignore-line)
     - [ECMAScript Feature Support](#ecmascript-feature-support)
 
 10. [Package Listing](#package-listing)
@@ -534,27 +534,8 @@ window.addEventListener("load", function () {
 
 <br><br>
 # Documentation
-
-
 - [jslint.mjs](jslint.mjs) contains the jslint function. It parses and analyzes a source file, returning an object with information about the file. It can also take an object that sets options.
-
 - [index.html](index.html) runs the jslint.mjs function in a web page.
-
-JSLint can be run anywhere that JavaScript (or Java) can run.
-
-The place to express yourself in programming is in the quality of your ideas and
-the efficiency of their execution. The role of style in programming is the same
-as in literature: It makes for better reading. A great writer doesn't express
-herself by putting the spaces before her commas instead of after, or by putting
-extra spaces inside her parentheses. A great writer will slavishly conform to
-some rules of style, and that in no way constrains her power to express herself
-creatively. See for example William Strunk's The Elements of Style
-[https://www.crockford.com/style.html].
-
-This applies to programming as well. Conforming to a consistent style improves
-readability, and frees you to express yourself in ways that matter. JSLint here
-plays the part of a stern but benevolent editor, helping you to get the style
-right so that you can focus your creative energy where it is most needed.
 
 
 <br><br>
@@ -565,12 +546,11 @@ right so that you can focus your creative energy where it is most needed.
 
 
 <br><br>
-### Directive `/*jslint*/`
+### Directive
 
 <br>
 
 ##### `/*jslint beta*/`
-
 ```js
 /*jslint beta*/
 // Enable experimental warnings.
@@ -585,7 +565,6 @@ right so that you can focus your creative energy where it is most needed.
 <br>
 
 ##### `/*jslint bitwise*/`
-
 ```js
 /*jslint bitwise*/
 // Allow bitwise operator.
@@ -596,7 +575,6 @@ let foo = 0 | 1;
 <br>
 
 ##### `/*jslint browser*/`
-
 ```js
 /*jslint browser*/
 // Assume browser environment.
@@ -607,7 +585,6 @@ localStorage.getItem("foo");
 <br>
 
 ##### `/*jslint convert*/`
-
 ```js
 /*jslint convert*/
 // Allow conversion operator.
@@ -619,7 +596,6 @@ let bar = !!0;
 <br>
 
 ##### `/*jslint couch*/`
-
 ```js
 /*jslint couch*/
 // Assume CouchDb environment.
@@ -630,7 +606,6 @@ registerType("text-json", "text/json");
 <br>
 
 ##### `/*jslint devel*/`
-
 ```js
 /*jslint devel*/
 // Allow console.log() and friends.
@@ -641,7 +616,6 @@ console.log("hello");
 <br>
 
 ##### `/*jslint eval*/`
-
 ```js
 /*jslint eval*/
 // Allow eval().
@@ -652,7 +626,6 @@ eval("1");
 <br>
 
 ##### `/*jslint fart*/`
-
 ```js
 /*jslint fart*/
 // Allow complex fat-arrow.
@@ -665,7 +638,6 @@ let foo = async ({bar, baz}) => {
 <br>
 
 ##### `/*jslint for*/`
-
 ```js
 /*jslint for*/
 // Allow for-loop.
@@ -681,7 +653,6 @@ function foo() {
 <br>
 
 ##### `/*jslint getset*/`
-
 ```js
 /*jslint getset, this, devel*/
 // Allow get() and set().
@@ -703,7 +674,6 @@ console.log(foo.getBar); // 1
 <br>
 
 ##### `/*jslint indent2*/`
-
 ```js
 /*jslint indent2*/
 // Use 2-space indent.
@@ -716,7 +686,6 @@ function foo() {
 <br>
 
 ##### `/*jslint long*/`
-
 ```js
 /*jslint long*/
 // Allow long lines.
@@ -727,7 +696,6 @@ let foo = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 <br>
 
 ##### `/*jslint node*/`
-
 ```js
 /*jslint node*/
 // Assume Node.js environment.
@@ -738,7 +706,6 @@ require("fs");
 <br>
 
 ##### `/*jslint nomen*/`
-
 ```js
 /*jslint nomen*/
 // Allow weird property name.
@@ -750,7 +717,6 @@ foo._bar = 1;
 <br>
 
 ##### `/*jslint single*/`
-
 ```js
 /*jslint single*/
 // Allow single-quote strings.
@@ -761,7 +727,6 @@ let foo = '';
 <br>
 
 ##### `/*jslint subscript*/`
-
 ```js
 /*jslint subscript*/
 // Allow identifiers in subscript-notation.
@@ -773,7 +738,6 @@ foo["bar"] = 1;
 <br>
 
 ##### `/*jslint this*/`
-
 ```js
 /*jslint this*/
 // Allow 'this'.
@@ -786,7 +750,6 @@ function foo() {
 <br>
 
 ##### `/*jslint trace*/`
-
 ```js
 /*jslint trace*/
 // Include jslint stack-trace in warnings.
@@ -816,7 +779,6 @@ Error
 <br>
 
 ##### `/*jslint unordered*/`
-
 ```js
 /*jslint unordered*/
 // Allow unordered cases, params, properties, variables, and exports.
@@ -839,7 +801,6 @@ export {
 <br>
 
 ##### `/*jslint white*/`
-
 ```js
 /*jslint white*/
 // Allow messy whitespace.
@@ -847,10 +808,9 @@ export {
 let foo = 1; let bar = 2;
 ```
 
+<br>
 
-<br><br>
-### Directive `/*global*/`
-
+##### `/*global*/`
 ```js
 /*global foo, bar*/
 // Declare global variables foo, bar.
@@ -859,10 +819,9 @@ foo();
 bar();
 ```
 
+<br>
 
-<br><br>
-### Directive `/*property*/`
-
+##### `/*property*/`
 ```js
 /*property foo, bar*/
 // Restrict property-access to only .foo, .bar.
@@ -870,10 +829,9 @@ bar();
 let aa = {bar: 1, foo: 2};
 ```
 
+<br>
 
-<br><br>
-### Directive `/*jslint-disable*/.../*jslint-enable*/`
-
+##### `/*jslint-disable*/.../*jslint-enable*/`
 ```js
 /*jslint-disable*/
 
@@ -883,20 +841,18 @@ Syntax error.
 /*jslint-enable*/
 ```
 
+<br>
 
-<br><br>
-### Directive `//jslint-ignore-line`
-
+##### `//jslint-ignore-line`
 ```js
 // JSLint will ignore non-fatal warnings at given line.
 
 eval("1"); //jslint-ignore-line
 ```
 
+<br>
 
-<br><br>
-### Directive `/*coverage-disable*/.../*coverage-enable*/`
-
+##### `/*coverage-disable*/.../*coverage-enable*/`
 ```js
 /*coverage-disable*/
 
@@ -909,10 +865,9 @@ if (false) {
 /*coverage-enable*/
 ```
 
+<br>
 
-<br><br>
-### Directive `//coverage-ignore-line`
-
+##### `//coverage-ignore-line`
 ```js
 // JSLint will ignore code-coverage at given line.
 

--- a/README.md
+++ b/README.md
@@ -950,9 +950,9 @@ if (false) {
 |  36. | &#x2705; | ES2018 | [`Promise.prototype.finally`](https://github.com/tc39/proposal-promise-finally) |
 |  35. | &#x2705; | ES2018 | [`RegExp Unicode Property Escapes`](https://github.com/tc39/proposal-regexp-unicode-property-escapes) |
 |  34. | &#x26a0; | ES2018 | [`RegExp Lookbehind Assertions`](https://github.com/tc39/proposal-regexp-lookbehind) |
-|  33. | &#x26a0; | ES2018 | [`Rest/Spread Properties`](https://github.com/tc39/proposal-object-rest-spread) |
+|  33. | &#x2705; | ES2018 | [`Rest/Spread Properties`](https://github.com/tc39/proposal-object-rest-spread) |
 |  32. | &#x2705; | ES2018 | [`RegExp named capture groups`](https://github.com/tc39/proposal-regexp-named-groups) |
-|  31. | &#x26a0; | ES2018 | [`s (dotAll) flag for regular expressions`](https://github.com/tc39/proposal-regexp-dotall-flag) |
+|  31. | &#x2705; | ES2018 | [`s (dotAll) flag for regular expressions`](https://github.com/tc39/proposal-regexp-dotall-flag) |
 |  30. | &#x2705; | ES2018 | [`Lifting template literal restriction`](https://github.com/tc39/proposal-template-literal-revision) |
 |  29. | &#x2705; | ES2017 | [`Shared memory and atomics`](https://github.com/tc39/proposal-ecmascript-sharedmem) |
 |  28. | &#x2705; | ES2017 | [`Async functions`](https://github.com/tc39/proposal-async-await) |

--- a/README.md
+++ b/README.md
@@ -887,7 +887,7 @@ if (false) {
 |  99. | &#x274c; | ES2027 | [`Explicit Resource Management`](https://github.com/tc39/proposal-explicit-resource-management) |
 |  98. | &#x2705; | ES2027 | [`Atomics.pause`](https://github.com/tc39/proposal-atomics-microwait) |
 |  97. | &#x274c; | ES2027 | [`Joint Iteration`](https://github.com/tc39/proposal-joint-iteration) |
-|  96. | &#x26a0; | ES2027 | [`Temporal`](https://github.com/tc39/proposal-temporal) |
+|  96. | &#x2705; | ES2027 | [`Temporal`](https://github.com/tc39/proposal-temporal) |
 |  95. | &#x2705; | ES2026 | [`Upsert`](https://github.com/tc39/proposal-upsert) |
 |  94. | &#x2705; | ES2026 | [`JSON.parse source text access`](https://github.com/tc39/proposal-json-parse-with-source) |
 |  93. | &#x274c; | ES2026 | [`Iterator Sequencing`](https://github.com/tc39/proposal-iterator-sequencing) |
@@ -902,9 +902,9 @@ if (false) {
 |  84. | &#x274c; | ES2025 | [`Sync Iterator helpers`](https://github.com/tc39/proposal-iterator-helpers) |
 |  83. | &#x2705; | ES2025 | [`JSON Modules`](https://github.com/tc39/proposal-json-modules) |
 |  82. | &#x2705; | ES2025 | [`Import Attributes`](https://github.com/tc39/proposal-import-attributes) |
-|  81. | &#x26a0; | ES2025 | [`RegExp Modifiers`](https://github.com/tc39/proposal-regexp-modifiers) |
+|  81. | &#x2705; | ES2025 | [`RegExp Modifiers`](https://github.com/tc39/proposal-regexp-modifiers) |
 |  80. | &#x2705; | ES2025 | [`New Set methods`](https://github.com/tc39/proposal-set-methods) |
-|  79. | &#x274c; | ES2025 | [`Duplicate named capture groups`](https://github.com/tc39/proposal-duplicate-named-capturing-groups) |
+|  79. | &#x2705; | ES2025 | [`Duplicate named capture groups`](https://github.com/tc39/proposal-duplicate-named-capturing-groups) |
 |  78. | &#x2705; | ES2024 | [`ArrayBuffer transfer`](https://github.com/tc39/proposal-arraybuffer-transfer) |
 |  77. | &#x2705; | ES2024 | [`Promise.withResolvers`](https://github.com/tc39/proposal-promise-with-resolvers) |
 |  76. | &#x2705; | ES2024 | [`Array Grouping`](https://github.com/tc39/proposal-array-grouping) |
@@ -918,21 +918,21 @@ if (false) {
 |  68. | &#x2705; | ES2023 | [`Array find from last`](https://github.com/tc39/proposal-array-find-from-last) |
 |  67. | &#x2705; | ES2022 | [`Error Cause`](https://github.com/tc39/proposal-error-cause) |
 |  66. | &#x274c; | ES2022 | [`Class Static Block`](https://github.com/tc39/proposal-class-static-block) |
-|  65. | &#x26a0; | ES2022 | [`Accessible Object.prototype.hasOwnProperty`](https://github.com/tc39/proposal-accessible-object-hasownproperty) |
+|  65. | &#x2705; | ES2022 | [`Accessible Object.prototype.hasOwnProperty`](https://github.com/tc39/proposal-accessible-object-hasownproperty) |
 |  64. | &#x2705; | ES2022 | [`.at()`](https://github.com/tc39/proposal-relative-indexing-method) |
 |  63. | &#x274c; | ES2022 | [`Ergonomic brand checks for Private Fields`](https://github.com/tc39/proposal-private-fields-in-in) |
 |  62. | &#x2705; | ES2022 | [`Top-level await`](https://github.com/tc39/proposal-top-level-await) |
-|  61. | &#x26a0; | ES2022 | [`RegExp Match Indices`](https://github.com/tc39/proposal-regexp-match-indices) |
+|  61. | &#x2705; | ES2022 | [`RegExp Match Indices`](https://github.com/tc39/proposal-regexp-match-indices) |
 |  60. | &#x274c; | ES2022 | [`Class Public Instance Fields & Private Instance Fields`](https://github.com/tc39/proposal-class-fields) |
 |  59. | &#x2705; | ES2021 | [`Numeric separators`](https://github.com/tc39/proposal-numeric-separator) |
-|  58. | &#x26a0; | ES2021 | [`Logical Assignment Operators`](https://github.com/tc39/proposal-logical-assignment) |
+|  58. | &#x2705; | ES2021 | [`Logical Assignment Operators`](https://github.com/tc39/proposal-logical-assignment) |
 |  57. | &#x2705; | ES2021 | [`WeakRefs`](https://github.com/tc39/proposal-weakrefs) |
 |  56. | &#x2705; | ES2021 | [`Promise.any`](https://github.com/tc39/proposal-promise-any) |
 |  55. | &#x2705; | ES2021 | [`String.prototype.replaceAll`](https://github.com/tc39/proposal-string-replaceall) |
 |  54. | &#x2705; | ES2020 | [`import.meta`](https://github.com/tc39/proposal-import-meta) |
 |  53. | &#x2705; | ES2020 | [`Nullish coalescing Operator`](https://github.com/tc39/proposal-nullish-coalescing) |
 |  52. | &#x2705; | ES2020 | [`Optional Chaining`](https://github.com/tc39/proposal-optional-chaining) |
-|  51. | &#x274c; | ES2020 | [`for-in mechanics`](https://github.com/tc39/proposal-for-in-order) |
+|  51. | &#x2705; | ES2020 | [`for-in mechanics`](https://github.com/tc39/proposal-for-in-order) |
 |  50. | &#x2705; | ES2020 | [`globalThis`](https://github.com/tc39/proposal-global) |
 |  49. | &#x2705; | ES2020 | [`Promise.allSettled`](https://github.com/tc39/proposal-promise-allSettled) |
 |  48. | &#x2705; | ES2020 | [`BigInt`](https://github.com/tc39/proposal-bigint) |
@@ -949,7 +949,7 @@ if (false) {
 |  37. | &#x274c; | ES2018 | [`Asynchronous Iteration`](https://github.com/tc39/proposal-async-iteration) |
 |  36. | &#x2705; | ES2018 | [`Promise.prototype.finally`](https://github.com/tc39/proposal-promise-finally) |
 |  35. | &#x2705; | ES2018 | [`RegExp Unicode Property Escapes`](https://github.com/tc39/proposal-regexp-unicode-property-escapes) |
-|  34. | &#x26a0; | ES2018 | [`RegExp Lookbehind Assertions`](https://github.com/tc39/proposal-regexp-lookbehind) |
+|  34. | &#x2705; | ES2018 | [`RegExp Lookbehind Assertions`](https://github.com/tc39/proposal-regexp-lookbehind) |
 |  33. | &#x2705; | ES2018 | [`Rest/Spread Properties`](https://github.com/tc39/proposal-object-rest-spread) |
 |  32. | &#x2705; | ES2018 | [`RegExp named capture groups`](https://github.com/tc39/proposal-regexp-named-groups) |
 |  31. | &#x2705; | ES2018 | [`s (dotAll) flag for regular expressions`](https://github.com/tc39/proposal-regexp-dotall-flag) |

--- a/README.md
+++ b/README.md
@@ -927,107 +927,107 @@ if (false) {
 - https://github.com/tc39/proposals/blob/main/finished-proposals.md
 - https://github.com/lukehoban/es6features
 
-| JSLint Support | ES Version | ES Feature |
-|:--|:--|:--|
-| &#x274c; | ES2027 | [`Explicit Resource Management`](https://github.com/tc39/proposal-explicit-resource-management) |
-| &#x2705; | ES2027 | [`Atomics.pause`](https://github.com/tc39/proposal-atomics-microwait) |
-| &#x274c; | ES2027 | [`Joint Iteration`](https://github.com/tc39/proposal-joint-iteration) |
-| &#x274c; | ES2027 | [`Temporal`](https://github.com/tc39/proposal-temporal) |
-| &#x274c; | ES2026 | [`Upsert`](https://github.com/tc39/proposal-upsert) |
-| &#x2705; | ES2026 | [`JSON.parse source text access`](https://github.com/tc39/proposal-json-parse-with-source) |
-| &#x274c; | ES2026 | [`Iterator Sequencing`](https://github.com/tc39/proposal-iterator-sequencing) |
-| &#x2705; | ES2026 | [`Uint8Array to/from Base64`](https://github.com/tc39/proposal-arraybuffer-base64) |
-| &#x2705; | ES2026 | [`Math.sumPrecise`](https://github.com/tc39/proposal-math-sum) |
-| &#x2705; | ES2026 | [`Error.isError`](https://github.com/tc39/proposal-is-error) |
-| &#x2705; | ES2026 | [`Array.fromAsync`](https://github.com/tc39/proposal-array-from-async) |
-| &#x26a0; | ES2025 | [`RegExp.escape`](https://github.com/tc39/proposal-regex-escaping) |
-| &#x2705; | ES2025 | [`Redeclarable global eval-introduced vars`](https://github.com/tc39/proposal-redeclarable-global-eval-vars) |
-| &#x26a0; | ES2025 | [`Float16 on TypedArrays, DataView, Math.f16round`](https://github.com/tc39/proposal-float16array) |
-| &#x2705; | ES2025 | [`Promise.try`](https://github.com/tc39/proposal-promise-try) |
-| &#x274c; | ES2025 | [`Sync Iterator helpers`](https://github.com/tc39/proposal-iterator-helpers) |
-| &#x2705; | ES2025 | [`JSON Modules`](https://github.com/tc39/proposal-json-modules) |
-| &#x2705; | ES2025 | [`Import Attributes`](https://github.com/tc39/proposal-import-attributes) |
-| &#x274c; | ES2025 | [`RegExp Modifiers`](https://github.com/tc39/proposal-regexp-modifiers) |
-| &#x2705; | ES2025 | [`New Set methods`](https://github.com/tc39/proposal-set-methods) |
-| &#x274c; | ES2025 | [`Duplicate named capture groups`](https://github.com/tc39/proposal-duplicate-named-capturing-groups) |
-| &#x2705; | ES2024 | [`ArrayBuffer transfer`](https://github.com/tc39/proposal-arraybuffer-transfer) |
-| &#x2705; | ES2024 | [`Promise.withResolvers`](https://github.com/tc39/proposal-promise-with-resolvers) |
-| &#x2705; | ES2024 | [`Array Grouping`](https://github.com/tc39/proposal-array-grouping) |
-| &#x2705; | ES2024 | [`Resizable and growable ArrayBuffers`](https://github.com/tc39/proposal-resizablearraybuffer) |
-| &#x26a0; | ES2024 | [`RegExp v flag with set notation + properties of strings`](https://github.com/tc39/proposal-regexp-v-flag) |
-| &#x2705; | ES2024 | [`Atomics.waitAsync`](https://github.com/tc39/proposal-atomics-wait-async) |
-| &#x26a0; | ES2024 | [`Well-Formed Unicode Strings`](https://github.com/tc39/proposal-is-usv-string) |
-| &#x26a0; | ES2023 | [`Change Array by Copy`](https://github.com/tc39/proposal-change-array-by-copy) |
-| &#x2705; | ES2023 | [`Symbols as WeakMap keys`](https://github.com/tc39/proposal-symbols-as-weakmap-keys) |
-| &#x2705; | ES2023 | [`Hashbang Grammar`](https://github.com/tc39/proposal-hashbang) |
-| &#x2705; | ES2023 | [`Array find from last`](https://github.com/tc39/proposal-array-find-from-last) |
-| &#x2705; | ES2022 | [`Error Cause`](https://github.com/tc39/proposal-error-cause) |
-| &#x274c; | ES2022 | [`Class Static Block`](https://github.com/tc39/proposal-class-static-block) |
-| &#x274c; | ES2022 | [`Accessible Object.prototype.hasOwnProperty`](https://github.com/tc39/proposal-accessible-object-hasownproperty) |
-| &#x26a0; | ES2022 | [`.at()`](https://github.com/tc39/proposal-relative-indexing-method) |
-| &#x274c; | ES2022 | [`Ergonomic brand checks for Private Fields`](https://github.com/tc39/proposal-private-fields-in-in) |
-| &#x2705; | ES2022 | [`Top-level await`](https://github.com/tc39/proposal-top-level-await) |
-| &#x26a0; | ES2022 | [`RegExp Match Indices`](https://github.com/tc39/proposal-regexp-match-indices) |
-| &#x274c; | ES2022 | [`Class Public Instance Fields & Private Instance Fields`](https://github.com/tc39/proposal-class-fields) |
-| &#x2705; | ES2021 | [`Numeric separators`](https://github.com/tc39/proposal-numeric-separator) |
-| &#x26a0; | ES2021 | [`Logical Assignment Operators`](https://github.com/tc39/proposal-logical-assignment) |
-| &#x2705; | ES2021 | [`WeakRefs`](https://github.com/tc39/proposal-weakrefs) |
-| &#x2705; | ES2021 | [`Promise.any`](https://github.com/tc39/proposal-promise-any) |
-| &#x2705; | ES2021 | [`String.prototype.replaceAll`](https://github.com/tc39/proposal-string-replaceall) |
-| &#x2705; | ES2020 | [`import.meta`](https://github.com/tc39/proposal-import-meta) |
-| &#x2705; | ES2020 | [`Nullish coalescing Operator`](https://github.com/tc39/proposal-nullish-coalescing) |
-| &#x2705; | ES2020 | [`Optional Chaining`](https://github.com/tc39/proposal-optional-chaining) |
-| &#x274c; | ES2020 | [`for-in mechanics`](https://github.com/tc39/proposal-for-in-order) |
-| &#x2705; | ES2020 | [`globalThis`](https://github.com/tc39/proposal-global) |
-| &#x2705; | ES2020 | [`Promise.allSettled`](https://github.com/tc39/proposal-promise-allSettled) |
-| &#x2705; | ES2020 | [`BigInt`](https://github.com/tc39/proposal-bigint) |
-| &#x2705; | ES2020 | [`import()`](https://github.com/tc39/proposal-dynamic-import) |
-| &#x2705; | ES2020 | [`String.prototype.matchAll`](https://github.com/tc39/proposal-string-matchall) |
-| &#x2705; | ES2019 | [`Array.prototype.{flat,flatMap}`](https://github.com/tc39/proposal-flatMap) |
-| &#x2705; | ES2019 | [`String.prototype.{trimStart,trimEnd}`](https://github.com/tc39/proposal-string-left-right-trim) |
-| &#x2705; | ES2019 | [`Well-formed JSON.stringify`](https://github.com/tc39/proposal-well-formed-stringify) |
-| &#x2705; | ES2019 | [`Object.fromEntries`](https://github.com/tc39/proposal-object-from-entries) |
-| &#x2705; | ES2019 | [`Function.prototype.toString revision`](https://github.com/tc39/Function-prototype-toString-revision) |
-| &#x2705; | ES2019 | [`Symbol.prototype.description`](https://github.com/tc39/proposal-Symbol-description) |
-| &#x2705; | ES2019 | [`JSON superset`](https://github.com/tc39/proposal-json-superset) |
-| &#x2705; | ES2019 | [`Optional catch binding`](https://github.com/tc39/proposal-optional-catch-binding) |
-| &#x26a0; | ES2018 | [`Asynchronous Iteration`](https://github.com/tc39/proposal-async-iteration) |
-| &#x2705; | ES2018 | [`Promise.prototype.finally`](https://github.com/tc39/proposal-promise-finally) |
-| &#x2705; | ES2018 | [`RegExp Unicode Property Escapes`](https://github.com/tc39/proposal-regexp-unicode-property-escapes) |
-| &#x26a0; | ES2018 | [`RegExp Lookbehind Assertions`](https://github.com/tc39/proposal-regexp-lookbehind) |
-| &#x26a0; | ES2018 | [`Rest/Spread Properties`](https://github.com/tc39/proposal-object-rest-spread) |
-| &#x2705; | ES2018 | [`RegExp named capture groups`](https://github.com/tc39/proposal-regexp-named-groups) |
-| &#x26a0; | ES2018 | [`s (dotAll) flag for regular expressions`](https://github.com/tc39/proposal-regexp-dotall-flag) |
-| &#x2705; | ES2018 | [`Lifting template literal restriction`](https://github.com/tc39/proposal-template-literal-revision) |
-| &#x2705; | ES2017 | [`Shared memory and atomics`](https://github.com/tc39/proposal-ecmascript-sharedmem) |
-| &#x2705; | ES2017 | [`Async functions`](https://github.com/tc39/proposal-async-await) |
-| &#x26a0; | ES2017 | [`Trailing commas in function parameter lists and calls`](https://github.com/tc39/proposal-trailing-function-commas) |
-| &#x2705; | ES2017 | [`Object.getOwnPropertyDescriptors`](https://github.com/tc39/proposal-object-getownpropertydescriptors) |
-| &#x2705; | ES2017 | [`String padding`](https://github.com/tc39/proposal-string-pad-start-end) |
-| &#x2705; | ES2017 | [`Object.values/Object.entries`](https://github.com/tc39/proposal-object-values-entries) |
-| &#x2705; | ES2016 | [`Exponentiation operator`](https://github.com/tc39/proposal-exponentiation-operator) |
-| &#x2705; | ES2016 | [`Array.prototype.includes`](https://github.com/tc39/proposal-Array.prototype.includes) |
-| &#x2705; | ES2015 | [`arrows`](https://github.com/lukehoban/es6features#arrows) |
-| &#x274c; | ES2015 | [`classes`](https://github.com/lukehoban/es6features#classes) |
-| &#x274c; | ES2015 | [`enhanced object literals`](https://github.com/lukehoban/es6features#enhanced-object-literals) |
-| &#x2705; | ES2015 | [`template strings`](https://github.com/lukehoban/es6features#template-strings) |
-| &#x26a0; | ES2015 | [`destructuring`](https://github.com/lukehoban/es6features#destructuring) |
-| &#x2705; | ES2015 | [`default + rest + spread`](https://github.com/lukehoban/es6features#default--rest--spread) |
-| &#x2705; | ES2015 | [`let + const`](https://github.com/lukehoban/es6features#let--const) |
-| &#x274c; | ES2015 | [`iterators + for..of`](https://github.com/lukehoban/es6features#iterators--forof) |
-| &#x274c; | ES2015 | [`generators`](https://github.com/lukehoban/es6features#generators) |
-| &#x274c; | ES2015 | [`unicode`](https://github.com/lukehoban/es6features#unicode) |
-| &#x26a0; | ES2015 | [`modules`](https://github.com/lukehoban/es6features#modules) |
-| &#x2705; | ES2015 | [`module loaders`](https://github.com/lukehoban/es6features#module-loaders) |
-| &#x2705; | ES2015 | [`map + set + weakmap + weakset`](https://github.com/lukehoban/es6features#map--set--weakmap--weakset) |
-| &#x2705; | ES2015 | [`proxies`](https://github.com/lukehoban/es6features#proxies) |
-| &#x2705; | ES2015 | [`symbols`](https://github.com/lukehoban/es6features#symbols) |
-| &#x274c; | ES2015 | [`subclassable built-ins`](https://github.com/lukehoban/es6features#subclassable-built-ins) |
-| &#x2705; | ES2015 | [`promises`](https://github.com/lukehoban/es6features#promises) |
-| &#x2705; | ES2015 | [`math + number + string + array + object APIs`](https://github.com/lukehoban/es6features#math--number--string--array--object-apis) |
-| &#x2705; | ES2015 | [`binary and octal literals`](https://github.com/lukehoban/es6features#binary-and-octal-literals) |
-| &#x2705; | ES2015 | [`reflect api`](https://github.com/lukehoban/es6features#reflect-api) |
-| &#x2705; | ES2015 | [`tail calls`](https://github.com/lukehoban/es6features#tail-calls) |
+| #. | JSLint Support | ES Version | ES Feature |
+|--:|:--|:--|:--|
+|  99. | &#x274c; | ES2027 | [`Explicit Resource Management`](https://github.com/tc39/proposal-explicit-resource-management) |
+|  98. | &#x2705; | ES2027 | [`Atomics.pause`](https://github.com/tc39/proposal-atomics-microwait) |
+|  97. | &#x274c; | ES2027 | [`Joint Iteration`](https://github.com/tc39/proposal-joint-iteration) |
+|  96. | &#x26a0; | ES2027 | [`Temporal`](https://github.com/tc39/proposal-temporal) |
+|  95. | &#x2705; | ES2026 | [`Upsert`](https://github.com/tc39/proposal-upsert) |
+|  94. | &#x2705; | ES2026 | [`JSON.parse source text access`](https://github.com/tc39/proposal-json-parse-with-source) |
+|  93. | &#x274c; | ES2026 | [`Iterator Sequencing`](https://github.com/tc39/proposal-iterator-sequencing) |
+|  92. | &#x2705; | ES2026 | [`Uint8Array to/from Base64`](https://github.com/tc39/proposal-arraybuffer-base64) |
+|  91. | &#x2705; | ES2026 | [`Math.sumPrecise`](https://github.com/tc39/proposal-math-sum) |
+|  90. | &#x2705; | ES2026 | [`Error.isError`](https://github.com/tc39/proposal-is-error) |
+|  89. | &#x2705; | ES2026 | [`Array.fromAsync`](https://github.com/tc39/proposal-array-from-async) |
+|  88. | &#x2705; | ES2025 | [`RegExp.escape`](https://github.com/tc39/proposal-regex-escaping) |
+|  87. | &#x2705; | ES2025 | [`Redeclarable global eval-introduced vars`](https://github.com/tc39/proposal-redeclarable-global-eval-vars) |
+|  86. | &#x2705; | ES2025 | [`Float16 on TypedArrays, DataView, Math.f16round`](https://github.com/tc39/proposal-float16array) |
+|  85. | &#x2705; | ES2025 | [`Promise.try`](https://github.com/tc39/proposal-promise-try) |
+|  84. | &#x274c; | ES2025 | [`Sync Iterator helpers`](https://github.com/tc39/proposal-iterator-helpers) |
+|  83. | &#x2705; | ES2025 | [`JSON Modules`](https://github.com/tc39/proposal-json-modules) |
+|  82. | &#x2705; | ES2025 | [`Import Attributes`](https://github.com/tc39/proposal-import-attributes) |
+|  81. | &#x26a0; | ES2025 | [`RegExp Modifiers`](https://github.com/tc39/proposal-regexp-modifiers) |
+|  80. | &#x2705; | ES2025 | [`New Set methods`](https://github.com/tc39/proposal-set-methods) |
+|  79. | &#x274c; | ES2025 | [`Duplicate named capture groups`](https://github.com/tc39/proposal-duplicate-named-capturing-groups) |
+|  78. | &#x2705; | ES2024 | [`ArrayBuffer transfer`](https://github.com/tc39/proposal-arraybuffer-transfer) |
+|  77. | &#x2705; | ES2024 | [`Promise.withResolvers`](https://github.com/tc39/proposal-promise-with-resolvers) |
+|  76. | &#x2705; | ES2024 | [`Array Grouping`](https://github.com/tc39/proposal-array-grouping) |
+|  75. | &#x2705; | ES2024 | [`Resizable and growable ArrayBuffers`](https://github.com/tc39/proposal-resizablearraybuffer) |
+|  74. | &#x26a0; | ES2024 | [`RegExp v flag with set notation + properties of strings`](https://github.com/tc39/proposal-regexp-v-flag) |
+|  73. | &#x2705; | ES2024 | [`Atomics.waitAsync`](https://github.com/tc39/proposal-atomics-wait-async) |
+|  72. | &#x2705; | ES2024 | [`Well-Formed Unicode Strings`](https://github.com/tc39/proposal-is-usv-string) |
+|  71. | &#x2705; | ES2023 | [`Change Array by Copy`](https://github.com/tc39/proposal-change-array-by-copy) |
+|  70. | &#x2705; | ES2023 | [`Symbols as WeakMap keys`](https://github.com/tc39/proposal-symbols-as-weakmap-keys) |
+|  69. | &#x2705; | ES2023 | [`Hashbang Grammar`](https://github.com/tc39/proposal-hashbang) |
+|  68. | &#x2705; | ES2023 | [`Array find from last`](https://github.com/tc39/proposal-array-find-from-last) |
+|  67. | &#x2705; | ES2022 | [`Error Cause`](https://github.com/tc39/proposal-error-cause) |
+|  66. | &#x274c; | ES2022 | [`Class Static Block`](https://github.com/tc39/proposal-class-static-block) |
+|  65. | &#x26a0; | ES2022 | [`Accessible Object.prototype.hasOwnProperty`](https://github.com/tc39/proposal-accessible-object-hasownproperty) |
+|  64. | &#x2705; | ES2022 | [`.at()`](https://github.com/tc39/proposal-relative-indexing-method) |
+|  63. | &#x274c; | ES2022 | [`Ergonomic brand checks for Private Fields`](https://github.com/tc39/proposal-private-fields-in-in) |
+|  62. | &#x2705; | ES2022 | [`Top-level await`](https://github.com/tc39/proposal-top-level-await) |
+|  61. | &#x26a0; | ES2022 | [`RegExp Match Indices`](https://github.com/tc39/proposal-regexp-match-indices) |
+|  60. | &#x274c; | ES2022 | [`Class Public Instance Fields & Private Instance Fields`](https://github.com/tc39/proposal-class-fields) |
+|  59. | &#x2705; | ES2021 | [`Numeric separators`](https://github.com/tc39/proposal-numeric-separator) |
+|  58. | &#x26a0; | ES2021 | [`Logical Assignment Operators`](https://github.com/tc39/proposal-logical-assignment) |
+|  57. | &#x2705; | ES2021 | [`WeakRefs`](https://github.com/tc39/proposal-weakrefs) |
+|  56. | &#x2705; | ES2021 | [`Promise.any`](https://github.com/tc39/proposal-promise-any) |
+|  55. | &#x2705; | ES2021 | [`String.prototype.replaceAll`](https://github.com/tc39/proposal-string-replaceall) |
+|  54. | &#x2705; | ES2020 | [`import.meta`](https://github.com/tc39/proposal-import-meta) |
+|  53. | &#x2705; | ES2020 | [`Nullish coalescing Operator`](https://github.com/tc39/proposal-nullish-coalescing) |
+|  52. | &#x2705; | ES2020 | [`Optional Chaining`](https://github.com/tc39/proposal-optional-chaining) |
+|  51. | &#x274c; | ES2020 | [`for-in mechanics`](https://github.com/tc39/proposal-for-in-order) |
+|  50. | &#x2705; | ES2020 | [`globalThis`](https://github.com/tc39/proposal-global) |
+|  49. | &#x2705; | ES2020 | [`Promise.allSettled`](https://github.com/tc39/proposal-promise-allSettled) |
+|  48. | &#x2705; | ES2020 | [`BigInt`](https://github.com/tc39/proposal-bigint) |
+|  47. | &#x2705; | ES2020 | [`import()`](https://github.com/tc39/proposal-dynamic-import) |
+|  46. | &#x2705; | ES2020 | [`String.prototype.matchAll`](https://github.com/tc39/proposal-string-matchall) |
+|  45. | &#x2705; | ES2019 | [`Array.prototype.{flat,flatMap}`](https://github.com/tc39/proposal-flatMap) |
+|  44. | &#x2705; | ES2019 | [`String.prototype.{trimStart,trimEnd}`](https://github.com/tc39/proposal-string-left-right-trim) |
+|  43. | &#x2705; | ES2019 | [`Well-formed JSON.stringify`](https://github.com/tc39/proposal-well-formed-stringify) |
+|  42. | &#x2705; | ES2019 | [`Object.fromEntries`](https://github.com/tc39/proposal-object-from-entries) |
+|  41. | &#x2705; | ES2019 | [`Function.prototype.toString revision`](https://github.com/tc39/Function-prototype-toString-revision) |
+|  40. | &#x2705; | ES2019 | [`Symbol.prototype.description`](https://github.com/tc39/proposal-Symbol-description) |
+|  39. | &#x2705; | ES2019 | [`JSON superset`](https://github.com/tc39/proposal-json-superset) |
+|  38. | &#x2705; | ES2019 | [`Optional catch binding`](https://github.com/tc39/proposal-optional-catch-binding) |
+|  37. | &#x274c; | ES2018 | [`Asynchronous Iteration`](https://github.com/tc39/proposal-async-iteration) |
+|  36. | &#x2705; | ES2018 | [`Promise.prototype.finally`](https://github.com/tc39/proposal-promise-finally) |
+|  35. | &#x2705; | ES2018 | [`RegExp Unicode Property Escapes`](https://github.com/tc39/proposal-regexp-unicode-property-escapes) |
+|  34. | &#x26a0; | ES2018 | [`RegExp Lookbehind Assertions`](https://github.com/tc39/proposal-regexp-lookbehind) |
+|  33. | &#x26a0; | ES2018 | [`Rest/Spread Properties`](https://github.com/tc39/proposal-object-rest-spread) |
+|  32. | &#x2705; | ES2018 | [`RegExp named capture groups`](https://github.com/tc39/proposal-regexp-named-groups) |
+|  31. | &#x26a0; | ES2018 | [`s (dotAll) flag for regular expressions`](https://github.com/tc39/proposal-regexp-dotall-flag) |
+|  30. | &#x2705; | ES2018 | [`Lifting template literal restriction`](https://github.com/tc39/proposal-template-literal-revision) |
+|  29. | &#x2705; | ES2017 | [`Shared memory and atomics`](https://github.com/tc39/proposal-ecmascript-sharedmem) |
+|  28. | &#x2705; | ES2017 | [`Async functions`](https://github.com/tc39/proposal-async-await) |
+|  27. | &#x26a0; | ES2017 | [`Trailing commas in function parameter lists and calls`](https://github.com/tc39/proposal-trailing-function-commas) |
+|  26. | &#x2705; | ES2017 | [`Object.getOwnPropertyDescriptors`](https://github.com/tc39/proposal-object-getownpropertydescriptors) |
+|  25. | &#x2705; | ES2017 | [`String padding`](https://github.com/tc39/proposal-string-pad-start-end) |
+|  24. | &#x2705; | ES2017 | [`Object.values/Object.entries`](https://github.com/tc39/proposal-object-values-entries) |
+|  23. | &#x2705; | ES2016 | [`Exponentiation operator`](https://github.com/tc39/proposal-exponentiation-operator) |
+|  22. | &#x2705; | ES2016 | [`Array.prototype.includes`](https://github.com/tc39/proposal-Array.prototype.includes) |
+|  21. | &#x2705; | ES2015 | [`arrows`](https://github.com/lukehoban/es6features#arrows) |
+|  20. | &#x274c; | ES2015 | [`classes`](https://github.com/lukehoban/es6features#classes) |
+|  19. | &#x274c; | ES2015 | [`enhanced object literals`](https://github.com/lukehoban/es6features#enhanced-object-literals) |
+|  18. | &#x2705; | ES2015 | [`template strings`](https://github.com/lukehoban/es6features#template-strings) |
+|  17. | &#x26a0; | ES2015 | [`destructuring`](https://github.com/lukehoban/es6features#destructuring) |
+|  16. | &#x2705; | ES2015 | [`default + rest + spread`](https://github.com/lukehoban/es6features#default--rest--spread) |
+|  15. | &#x2705; | ES2015 | [`let + const`](https://github.com/lukehoban/es6features#let--const) |
+|  14. | &#x274c; | ES2015 | [`iterators + for..of`](https://github.com/lukehoban/es6features#iterators--forof) |
+|  13. | &#x274c; | ES2015 | [`generators`](https://github.com/lukehoban/es6features#generators) |
+|  12. | &#x2705; | ES2015 | [`unicode`](https://github.com/lukehoban/es6features#unicode) |
+|  11. | &#x26a0; | ES2015 | [`modules`](https://github.com/lukehoban/es6features#modules) |
+|  10. | &#x2705; | ES2015 | [`module loaders`](https://github.com/lukehoban/es6features#module-loaders) |
+|   9. | &#x2705; | ES2015 | [`map + set + weakmap + weakset`](https://github.com/lukehoban/es6features#map--set--weakmap--weakset) |
+|   8. | &#x2705; | ES2015 | [`proxies`](https://github.com/lukehoban/es6features#proxies) |
+|   7. | &#x2705; | ES2015 | [`symbols`](https://github.com/lukehoban/es6features#symbols) |
+|   6. | &#x274c; | ES2015 | [`subclassable built-ins`](https://github.com/lukehoban/es6features#subclassable-built-ins) |
+|   5. | &#x2705; | ES2015 | [`promises`](https://github.com/lukehoban/es6features#promises) |
+|   4. | &#x2705; | ES2015 | [`math + number + string + array + object APIs`](https://github.com/lukehoban/es6features#math--number--string--array--object-apis) |
+|   3. | &#x2705; | ES2015 | [`binary and octal literals`](https://github.com/lukehoban/es6features#binary-and-octal-literals) |
+|   2. | &#x2705; | ES2015 | [`reflect api`](https://github.com/lukehoban/es6features#reflect-api) |
+|   1. | &#x2705; | ES2015 | [`tail calls`](https://github.com/lukehoban/es6features#tail-calls) |
 
 
 <br><br>

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -489,6 +489,7 @@ let jslint_rgx_token = new RegExp(
     + "(\\s+)"
     + "|([a-zA-Z_$][a-zA-Z0-9_$]*)"
     + "|[(){}\\[\\],:;'\"~\\`]"
+    + "|\\?\\?="
     + "|\\?[?.]?"
     + "|=(?:==?|>)?"
     + "|\\.+"
@@ -497,9 +498,10 @@ let jslint_rgx_token = new RegExp(
     + "|\\+[=+]?"
     + "|-[=\\-]?"
     + "|[\\^%]=?"
+    + "|&&="
     + "|&[&=]?"
-    + "|\\"
-    + "|[|=]?"
+    + "|\\|\\|="
+    + "|\\|[|=]?"
     + "|>{1,3}=?"
     + "|<<?=?"
     + "|!(?:!|==?)?"
@@ -1266,7 +1268,7 @@ function jslint(
         case "infix_in":
             mm = (
                 `Unexpected 'in'. Compare with undefined,`
-                + ` or use the hasOwnProperty method instead.`
+                + ` or use Object.hasOwn() instead.`
             );
             break;
         case "label_a":
@@ -3088,13 +3090,54 @@ function jslint_phase2_lex(state) {
                     case "?":
                         char_after("?");
                         switch (char) {
+
+// ES1999-feature Negative lookahead assertion.
+
                         case "!":
 
 // PR-437 - Add grammar for regexp-named-capture-group.
 
                         case "<":
+
+// ES1999-feature Positive lookahead assertion.
+
                         case "=":
                             char_after();
+                            break;
+
+// PR-xxx - Add ES2025-feature RegExp Modifiers.
+
+                        case "-":
+                        case "i":
+                        case "m":
+                        case "s":
+                            char_after();
+                            while (true) {
+                                if (char === ":" && snippet.slice(-1) !== "-") {
+                                    char_after();
+                                    break;
+                                }
+                                switch (char) {
+                                case "-":
+                                case "i":
+                                case "m":
+                                case "s":
+                                    char_after();
+                                    break;
+                                default:
+
+// test_cause:
+// ["aa=/(?-.", "lex_regexp_group", "unexpected_a_after_b", "(?-", 8]
+
+                                    return stop_at(
+                                        "unexpected_a_after_b",
+                                        line,
+                                        column,
+                                        snippet.slice(-1),
+                                        snippet.slice(0, -1)
+                                    );
+                                }
+                            }
                             break;
                         default:
                             char_after(":");
@@ -3256,15 +3299,28 @@ function jslint_phase2_lex(state) {
 // Process dangling flag letters.
 
             switch (!flag[char] && char) {
+
+// PR-xxx - Add ES2022-feature RegExp Match Indices.
+
+            case "d":
+                break;
             case "g":
                 break;
             case "i":
                 break;
             case "m":
                 break;
+
+// PR-xxx - Add ES2018-feature s (dotall) flag for regular expressions.
+
             case "s":
                 break;
             case "u":
+                break;
+
+// PR-xxx - Add ES2024-feature RegExp v flag with set-notation + str-properties.
+
+            case "v":
                 break;
             case "y":
 
@@ -3752,9 +3808,9 @@ import https from "https";
         });
     });
     result.replace((
-        /\n- \{\{JSxRef\("(?:Global_Objects\/)?([^"\/]+?)"/g
+        /\n- \{\{jsxref\("(?:global_objects\/)?([^"]+?)"/ig
     ), function (ignore, key) {
-        if (globalThis.hasOwnProperty(key)) {
+        if (Object.hasOwn(globalThis, key)) {
             dict[key] = true;
         }
         return "";
@@ -3805,6 +3861,7 @@ import https from "https";
                 "String",
                 "Symbol",
                 "SyntaxError",
+                "Temporal",
                 "TypeError",
                 "URIError",
                 "Uint16Array",
@@ -5190,6 +5247,9 @@ function jslint_phase3_parse(state) {
 
                 return stop("wrap_fart_parameter", token_now);
             }
+
+// PR-xxx - Update ES2015-feature arrow, to continue parsing unwrapped-form
+// with warning, instead of stopping.
 
 // test_cause:
 // ["aa=>0", "parse_fart", "wrap_fart_parameter", "=>", 3]
@@ -7622,6 +7682,7 @@ function jslint_phase3_parse(state) {
 // Begin defining the language.
 
     assignment("%=");
+    assignment("&&=");
     assignment("&=");
     assignment("*=");
     assignment("+=");
@@ -7631,8 +7692,10 @@ function jslint_phase3_parse(state) {
     assignment("=");
     assignment(">>=");
     assignment(">>>=");
+    assignment("??=");
     assignment("^=");
     assignment("|=");
+    assignment("||=");
     constant("(number)", "number");
     constant("(regexp)", "regexp");
     constant("(string)", "string");
@@ -9090,9 +9153,19 @@ function jslint_phase5_whitage(state) {
 // This is the set of infix operators that require a space on each side.
 
     let spaceop = object_assign_from_list(empty(), [
-        "!=", "!==", "%", "%=", "&", "&&", "&=", "*", "*=", "+=", "-=", "/",
-        "/=", "<", "<<", "<<=", "<=", "=", "==", "===", "=>", ">", ">=", ">>",
-        ">>=", ">>>", ">>>=", "^", "^=", "|", "|=", "||"
+        "!=", "!==",
+        "%", "%=",
+        "&", "&&", "&&=", "&=",
+        "*", "*=",
+        "+=",
+        "-=",
+        "/", "/=",
+        "<", "<<", "<<=", "<=",
+        "=", "==", "===", "=>",
+        ">", ">=", ">>", ">>=", ">>>", ">>>=",
+        "??", "??=",
+        "^", "^=",
+        "|", "|=", "||", "||="
     ], true);
 
     function at_margin(fit) {

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -6084,9 +6084,9 @@ function jslint_phase3_parse(state) {
             if (!name.identifier && token_nxt.id === "...") {
 
 // test_cause:
-// ["aa={...aa}", "property_parse", "aa={...aa}", "", 0]
+// ["aa={...aa}", "property_parse", "ellipsis", "", 0]
 
-                test_cause("aa={...aa}");
+                test_cause("ellipsis");
                 value = prefix_ellipsis();
                 value.ellipsis = true;
                 return value;
@@ -6252,16 +6252,25 @@ function jslint_phase3_parse(state) {
 // Parse/loop through each element in [...].
 
             while (true) {
-                if (token_nxt.id === "...") {
+                if (!state.mode_json && token_nxt.id === ",") {
 
 // test_cause:
-// ["aa=[...aa]", "prefix_lbracket", "aa=[...aa]", "", 0]
+// [";[,aa]=0", "prefix_lbracket", "ignore", "", 0]
 
-                    test_cause("aa=[...aa]");
-                    element = prefix_ellipsis();
-                } else {
-                    element = parse_expression(10);
+                    test_cause("ignore");
+                    advance(",");
                 }
+                if (!state.mode_json && token_nxt.id === "...") {
+
+// test_cause:
+// ["aa=[...aa]", "prefix_lbracket", "ellipsis", "", 0]
+
+                    test_cause("ellipsis");
+                    element = prefix_ellipsis();
+                    the_token.expression.push(element);
+                    break;
+                }
+                element = parse_expression(10);
                 the_token.expression.push(element);
                 if (token_nxt.id !== ",") {
                     break;
@@ -7201,12 +7210,128 @@ function jslint_phase3_parse(state) {
 
     function stmt_var() {
         let ellipsis;
-        let is_brace;
         let mode_const;
         let name;
-        let the_brace_or_bracket;
+        let the_destructure;
         let the_variable = token_now;
         let variable_prv;
+        function destructure_parse() {
+            const is_brace = token_nxt.id === "{";
+            the_destructure = token_nxt;
+            advance();
+            while (true) {
+                if (!is_brace && token_nxt.id === ",") {
+
+// test_cause:
+// ["let[,aa]=0", "destructure_parse", "ignore", "", 0]
+
+                    test_cause("ignore");
+                    advance(",");
+                }
+                ellipsis = token_nxt.id === "...";
+                if (ellipsis) {
+
+// test_cause:
+// ["let[...aa]=0", "destructure_parse", "ellipsis", "", 0]
+// ["let{...aa}=0", "destructure_parse", "ellipsis", "", 0]
+
+                    test_cause("ellipsis");
+                    advance("...");
+                }
+                name = token_nxt;
+                if (!name.identifier) {
+
+// test_cause:
+// ["let[0]", "destructure_parse", "expected_identifier_a", "0", 5]
+// ["let{0}", "destructure_parse", "expected_identifier_a", "0", 5]
+
+                    return stop("expected_identifier_a");
+                }
+                if (is_brace) {
+                    survey(name);
+                }
+                advance();
+                if (is_brace && token_nxt.id === ":") {
+                    advance(":");
+
+// Recurse destructure_parse().
+
+                    if (token_nxt.id === "{" || token_nxt.id === "[") {
+
+// test_cause:
+// ["let{aa:{aa}}", "destructure_parse", "recurse", "", 0]
+
+                        test_cause("recurse");
+                        destructure_parse();
+                    } else {
+                        if (!token_nxt.identifier) {
+
+// test_cause:
+// ["let{aa:0}", "destructure_parse", "expected_identifier_a", "0", 8]
+
+                            return stop("expected_identifier_a");
+                        }
+
+// PR-363 - Bugfix
+// Add test against false-warning <uninitialized 'bb'> in code
+// '/*jslint node*/\nlet {aa:bb} = {}; bb();'.
+//
+//                         token_nxt.label = name;
+//                         the_variable.names.push(token_nxt);
+//                         enroll(token_nxt, "variable", mode_const);
+
+                        name = token_nxt;
+                        the_variable.names.push(name);
+                        survey(name);
+                        enroll(name, "variable", mode_const);
+                        advance();
+                        the_destructure.open = true;
+                    }
+                } else {
+                    the_variable.names.push(name);
+                    enroll(name, "variable", mode_const);
+                }
+
+// Issue #458 - Regression - Warn about variable usage before initialization.
+
+//                    name.dead = false;
+
+                name.init = true;
+                if (ellipsis) {
+                    break;
+                }
+
+// test_cause:
+// ["const[aa]=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
+// ["const{aa}=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
+
+                if (token_nxt.id === "=") {
+
+// test_cause:
+// ["let[aa=0]", "destructure_parse", "assign", "", 0]
+// ["let{aa=0}", "destructure_parse", "assign", "", 0]
+
+                    test_cause("assign");
+                    advance("=");
+                    name.expression = parse_expression();
+                    the_destructure.open = true;
+                }
+                if (token_nxt.id !== ",") {
+                    break;
+                }
+                advance(",");
+            }
+            if (is_brace) {
+
+// test_cause:
+// ["let{bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
+
+                check_ordered(the_variable.id, the_variable.names);
+                advance("}");
+            } else {
+                advance("]");
+            }
+        }
         mode_const = the_variable.id === "const";
         the_variable.names = [];
 
@@ -7274,7 +7399,6 @@ function jslint_phase3_parse(state) {
             }
         }
         while (true) {
-            is_brace = token_nxt.id === "{";
             if (token_nxt.id === "{" || token_nxt.id === "[") {
                 if (the_variable.id === "var") {
 
@@ -7284,102 +7408,7 @@ function jslint_phase3_parse(state) {
 
                     warn("unexpected_a", the_variable);
                 }
-                the_brace_or_bracket = token_nxt;
-                advance();
-                while (true) {
-                    ellipsis = false;
-                    if (token_nxt.id === "...") {
-
-// test_cause:
-// ["let [...aa]=0", "stmt_var", "ellipsis", "", 0]
-// ["let {...aa}=0", "stmt_var", "ellipsis", "", 0]
-
-                        test_cause("ellipsis");
-                        ellipsis = true;
-                        advance("...");
-                    }
-                    name = token_nxt;
-                    if (!name.identifier) {
-
-// test_cause:
-// ["let [0]", "stmt_var", "expected_identifier_a", "0", 6]
-// ["let {0}", "stmt_var", "expected_identifier_a", "0", 6]
-
-                        return stop("expected_identifier_a");
-                    }
-                    if (is_brace) {
-                        survey(name);
-                    }
-                    advance();
-                    if (is_brace && token_nxt.id === ":") {
-                        advance(":");
-                        if (!token_nxt.identifier) {
-
-// test_cause:
-// ["let {aa:0}", "stmt_var", "expected_identifier_a", "0", 9]
-// ["let {aa:{aa}}", "stmt_var", "expected_identifier_a", "{", 9]
-
-                            return stop("expected_identifier_a");
-                        }
-
-// PR-363 - Bugfix
-// Add test against false-warning <uninitialized 'bb'> in code
-// '/*jslint node*/\nlet {aa:bb} = {}; bb();'.
-//
-//                         token_nxt.label = name;
-//                         the_variable.names.push(token_nxt);
-//                         enroll(token_nxt, "variable", mode_const);
-
-                        name = token_nxt;
-                        the_variable.names.push(name);
-                        survey(name);
-                        enroll(name, "variable", mode_const);
-                        advance();
-                        the_brace_or_bracket.open = true;
-                    } else {
-                        the_variable.names.push(name);
-                        enroll(name, "variable", mode_const);
-                    }
-
-// Issue #458 - Regression - Warn about variable usage before initialization.
-
-//                    name.dead = false;
-
-                    name.init = true;
-                    if (ellipsis) {
-                        break;
-                    }
-
-// test_cause:
-// ["const [aa]=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 12]
-// ["const {aa}=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 12]
-
-                    if (token_nxt.id === "=") {
-
-// test_cause:
-// ["let [aa=0]", "stmt_var", "assign", "", 0]
-// ["let {aa=0}", "stmt_var", "assign", "", 0]
-
-                        test_cause("assign");
-                        advance("=");
-                        name.expression = parse_expression();
-                        the_brace_or_bracket.open = true;
-                    }
-                    if (token_nxt.id !== ",") {
-                        break;
-                    }
-                    advance(",");
-                }
-                if (is_brace) {
-
-// test_cause:
-// ["let{bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
-
-                    check_ordered(the_variable.id, the_variable.names);
-                    advance("}");
-                } else {
-                    advance("]");
-                }
+                destructure_parse();
                 advance("=");
                 the_variable.expression = parse_expression(0);
             } else if (token_nxt.identifier) {
@@ -7414,7 +7443,6 @@ function jslint_phase3_parse(state) {
 
 // test_cause:
 // ["let 0", "stmt_var", "expected_identifier_a", "0", 5]
-// ["var{aa:{aa}}", "stmt_var", "expected_identifier_a", "{", 8]
 
                 return stop("expected_identifier_a");
             }
@@ -9482,7 +9510,7 @@ function jslint_phase5_whitage(state) {
             )) {
 
 // test_cause:
-// ["let {aa,bb} = 0;", "one_space", "expected_space_a_b", "bb", 9]
+// ["let{aa,bb} = 0;", "one_space", "expected_space_a_b", "bb", 8]
 
                 one_space();
             } else {

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -3262,6 +3262,8 @@ function jslint_phase2_lex(state) {
                 break;
             case "m":
                 break;
+            case "s":
+                break;
             case "u":
                 break;
             case "y":
@@ -7199,10 +7201,10 @@ function jslint_phase3_parse(state) {
 
     function stmt_var() {
         let ellipsis;
+        let is_brace;
         let mode_const;
         let name;
-        let the_brace;
-        let the_bracket;
+        let the_brace_or_bracket;
         let the_variable = token_now;
         let variable_prv;
         mode_const = the_variable.id === "const";
@@ -7272,28 +7274,44 @@ function jslint_phase3_parse(state) {
             }
         }
         while (true) {
-            if (token_nxt.id === "{") {
+            is_brace = token_nxt.id === "{";
+            if (token_nxt.id === "{" || token_nxt.id === "[") {
                 if (the_variable.id === "var") {
 
 // test_cause:
+// ["var[aa]=0", "stmt_var", "unexpected_a", "var", 1]
 // ["var{aa}=0", "stmt_var", "unexpected_a", "var", 1]
 
                     warn("unexpected_a", the_variable);
                 }
-                the_brace = token_nxt;
-                advance("{");
+                the_brace_or_bracket = token_nxt;
+                advance();
                 while (true) {
+                    ellipsis = false;
+                    if (token_nxt.id === "...") {
+
+// test_cause:
+// ["let [...aa]=0", "stmt_var", "ellipsis", "", 0]
+// ["let {...aa}=0", "stmt_var", "ellipsis", "", 0]
+
+                        test_cause("ellipsis");
+                        ellipsis = true;
+                        advance("...");
+                    }
                     name = token_nxt;
                     if (!name.identifier) {
 
 // test_cause:
+// ["let [0]", "stmt_var", "expected_identifier_a", "0", 6]
 // ["let {0}", "stmt_var", "expected_identifier_a", "0", 6]
 
                         return stop("expected_identifier_a");
                     }
-                    survey(name);
+                    if (is_brace) {
+                        survey(name);
+                    }
                     advance();
-                    if (token_nxt.id === ":") {
+                    if (is_brace && token_nxt.id === ":") {
                         advance(":");
                         if (!token_nxt.identifier) {
 
@@ -7316,9 +7334,8 @@ function jslint_phase3_parse(state) {
                         the_variable.names.push(name);
                         survey(name);
                         enroll(name, "variable", mode_const);
-
                         advance();
-                        the_brace.open = true;
+                        the_brace_or_bracket.open = true;
                     } else {
                         the_variable.names.push(name);
                         enroll(name, "variable", mode_const);
@@ -7329,89 +7346,40 @@ function jslint_phase3_parse(state) {
 //                    name.dead = false;
 
                     name.init = true;
+                    if (ellipsis) {
+                        break;
+                    }
 
 // test_cause:
+// ["const [aa]=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 12]
 // ["const {aa}=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 12]
 
                     if (token_nxt.id === "=") {
 
 // test_cause:
+// ["let [aa=0]", "stmt_var", "assign", "", 0]
 // ["let {aa=0}", "stmt_var", "assign", "", 0]
 
                         test_cause("assign");
                         advance("=");
                         name.expression = parse_expression();
-                        the_brace.open = true;
+                        the_brace_or_bracket.open = true;
                     }
                     if (token_nxt.id !== ",") {
                         break;
                     }
                     advance(",");
                 }
+                if (is_brace) {
 
 // test_cause:
 // ["let{bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
 
-                check_ordered(the_variable.id, the_variable.names);
-                advance("}");
-                advance("=");
-                the_variable.expression = parse_expression(0);
-            } else if (token_nxt.id === "[") {
-                if (the_variable.id === "var") {
-
-// test_cause:
-// ["var[aa]=0", "stmt_var", "unexpected_a", "var", 1]
-
-                    warn("unexpected_a", the_variable);
+                    check_ordered(the_variable.id, the_variable.names);
+                    advance("}");
+                } else {
+                    advance("]");
                 }
-                the_bracket = token_nxt;
-                advance("[");
-                while (true) {
-                    ellipsis = false;
-                    if (token_nxt.id === "...") {
-
-// test_cause:
-// ["let [...aa]=aa", "stmt_var", "let [...aa]=aa", "", 0]
-
-                        test_cause("let [...aa]=aa");
-                        ellipsis = true;
-                        advance("...");
-                    }
-                    if (!token_nxt.identifier) {
-
-// test_cause:
-// ["let[]", "stmt_var", "expected_identifier_a", "]", 5]
-
-                        return stop("expected_identifier_a");
-                    }
-                    name = token_nxt;
-                    advance();
-                    the_variable.names.push(name);
-                    enroll(name, "variable", mode_const);
-
-// Issue #458 - Regression - Warn about variable usage before initialization.
-
-//                    name.dead = false;
-
-                    name.init = true;
-
-// test_cause:
-// ["const [aa]=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 12]
-
-                    if (ellipsis) {
-                        break;
-                    }
-                    if (token_nxt.id === "=") {
-                        advance("=");
-                        name.expression = parse_expression();
-                        the_bracket.open = true;
-                    }
-                    if (token_nxt.id !== ",") {
-                        break;
-                    }
-                    advance(",");
-                }
-                advance("]");
                 advance("=");
                 the_variable.expression = parse_expression(0);
             } else if (token_nxt.identifier) {

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -3105,7 +3105,7 @@ function jslint_phase2_lex(state) {
                             char_after();
                             break;
 
-// PR-xxx - Add ES2025-feature RegExp Modifiers.
+// PR-499 - Add ES2025-feature RegExp Modifiers.
 
                         case "-":
                         case "i":
@@ -3300,7 +3300,7 @@ function jslint_phase2_lex(state) {
 
             switch (!flag[char] && char) {
 
-// PR-xxx - Add ES2022-feature RegExp Match Indices.
+// PR-499 - Add ES2022-feature RegExp Match Indices.
 
             case "d":
                 break;
@@ -3311,14 +3311,14 @@ function jslint_phase2_lex(state) {
             case "m":
                 break;
 
-// PR-xxx - Add ES2018-feature s (dotall) flag for regular expressions.
+// PR-499 - Add ES2018-feature s (dotall) flag for regular expressions.
 
             case "s":
                 break;
             case "u":
                 break;
 
-// PR-xxx - Add ES2024-feature RegExp v flag with set-notation + str-properties.
+// PR-499 - Add ES2024-feature RegExp v flag with set-notation + str-properties.
 
             case "v":
                 break;
@@ -5248,7 +5248,7 @@ function jslint_phase3_parse(state) {
                 return stop("wrap_fart_parameter", token_now);
             }
 
-// PR-xxx - Update ES2015-feature arrow, to continue parsing unwrapped-form
+// PR-499 - Update ES2015-feature arrow, to continue parsing unwrapped-form
 // with warning, instead of stopping.
 
 // test_cause:
@@ -8212,7 +8212,7 @@ function jslint_phase4_walk(state) {
         } else if (thing.id === "." || thing.id === "?.") {
             if (thing.expression.id === "RegExp") {
 
-// PR-xxx - Relax warning for ES2025-feature RegExp.escape().
+// PR-499 - Relax warning for ES2025-feature RegExp.escape().
 
                 if (!thing.name || thing.name.id !== "escape") {
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -3776,6 +3776,7 @@ import https from "https";
                 "Date",
                 "Error",
                 "EvalError",
+                "Float16Array",
                 "Float32Array",
                 "Float64Array",
                 "Function",
@@ -3797,6 +3798,7 @@ import https from "https";
                 "Reflect",
                 "RegExp",
                 "Set",
+                "ShadowRealm",
                 "SharedArrayBuffer",
                 "String",
                 "Symbol",
@@ -4809,20 +4811,24 @@ function jslint_phase3_parse(state) {
             (
                 left.id !== "(string)"
                 || (
-                    name.id !== "charCodeAt"
+                    name.id !== "at"
+                    && name.id !== "charCodeAt"
                     && name.id !== "includes"
                     && name.id !== "indexOf"
+                    && name.id !== "isWellFormed"
                     && name.id !== "match"
                     && name.id !== "repeat"
                     && name.id !== "replace"
                     && name.id !== "toLowerCase"
                     && name.id !== "toUpperCase"
+                    && name.id !== "toWellFormed"
                 )
             )
             && (
                 left.id !== "["
                 || (
-                    name.id !== "concat"
+                    name.id !== "at"
+                    && name.id !== "concat"
                     && name.id !== "every"
                     && name.id !== "filter"
                     && name.id !== "find"
@@ -4847,14 +4853,34 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
+// ["(/./)?.0", "check_left", "unexpected_a", "?.", 6]
 // ["\"\".aa", "check_left", "unexpected_a", ".", 3]
+// ["\"aa\"?.0", "check_left", "unexpected_a", "?.", 5]
+// ["aa=[]?.aa", "check_left", "unexpected_a", "?.", 6]
 
             check_left(left, the_token);
+        }
+
+// Issue #468 - Fix optional dynamic-property/function-call not recognized.
+
+        if (
+            the_token.id === "?."
+            && (name.id === "[" || name.id === "(")
+        ) {
+
+// test_cause:
+// ["aa?.(bb)", "infix_dot", "dyn_prop_or_call", "", 0]
+// ["aa?.[bb]", "infix_dot", "dyn_prop_or_call", "", 0]
+
+            test_cause("dyn_prop_or_call");
+            return left;
         }
         if (!name.identifier) {
 
 // test_cause:
+// ["(0+0)?.0", "infix_dot", "expected_identifier_a", "0", 8]
 // ["aa.0", "infix_dot", "expected_identifier_a", "0", 4]
+// ["aa?.0", "infix_dot", "expected_identifier_a", "0", 5]
 
             return stop("expected_identifier_a");
         }
@@ -4982,91 +5008,6 @@ function jslint_phase3_parse(state) {
             the_paren.free = false;
         }
         return the_paren;
-    }
-
-    function infix_option_chain(left) {
-        const the_token = token_now;
-        let name = token_nxt;
-        if (
-            (
-                left.id !== "(string)"
-                || (
-                    name.id !== "charCodeAt"
-                    && name.id !== "includes"
-                    && name.id !== "indexOf"
-                    && name.id !== "match"
-                    && name.id !== "repeat"
-                    && name.id !== "replace"
-                    && name.id !== "toLowerCase"
-                    && name.id !== "toUpperCase"
-                )
-            )
-            && (
-                left.id !== "["
-                || (
-                    name.id !== "concat"
-                    && name.id !== "every"
-                    && name.id !== "filter"
-                    && name.id !== "find"
-                    && name.id !== "findIndex"
-                    && name.id !== "flat"
-                    && name.id !== "flatMap"
-                    && name.id !== "forEach"
-                    && name.id !== "includes"
-                    && name.id !== "join"
-                    && name.id !== "map"
-                    && name.id !== "reduce"
-                    && name.id !== "some"
-                    && name.id !== "toReversed"
-                    && name.id !== "toSorted"
-                )
-            )
-
-// test_cause:
-// ["(0+0)?.0", "infix_option_chain", "check_left", "", 0]
-
-            && (left.id !== "+" || name.id !== "slice")
-            && (
-                left.id !== "(regexp)"
-                || (name.id !== "exec" && name.id !== "test")
-            )
-        ) {
-            test_cause("check_left");
-
-// test_cause:
-// ["(/./)?.0", "check_left", "unexpected_a", "?.", 6]
-// ["\"aa\"?.0", "check_left", "unexpected_a", "?.", 5]
-// ["aa=[]?.aa", "check_left", "unexpected_a", "?.", 6]
-
-            check_left(left, the_token);
-        }
-
-// Issue #468 - Fix optional dynamic-property/function-call not recognized.
-
-        if (name.id === "[" || name.id === "(") {
-            test_cause("dyn_prop_or_call");
-
-// test_cause:
-// ["aa?.(bb)", "infix_option_chain", "dyn_prop_or_call", "", 0]
-// ["aa?.[bb]", "infix_option_chain", "dyn_prop_or_call", "", 0]
-
-            return left;
-        }
-        if (!name.identifier) {
-
-// test_cause:
-// ["aa?.0", "infix_option_chain", "expected_identifier_a", "0", 5]
-
-            return stop("expected_identifier_a");
-        }
-        advance();
-        survey(name);
-
-// The property name is not an expression.
-
-        the_token.name = name;
-        the_token.expression = left;
-        return the_token;
     }
 
     function infixr(bp, id) {
@@ -7714,7 +7655,7 @@ function jslint_phase3_parse(state) {
     infix(160, "`", infix_grave);
     infix(170, ".", infix_dot);
     infix(170, "=>", infix_fart_unwrapped);
-    infix(170, "?.", infix_option_chain);
+    infix(170, "?.", infix_dot);
     infix(170, "[", infix_lbracket);
     infix(35, "??");
     infix(40, "||");
@@ -8192,10 +8133,15 @@ function jslint_phase4_walk(state) {
         } else if (thing.id === "." || thing.id === "?.") {
             if (thing.expression.id === "RegExp") {
 
+// PR-xxx - Relax warning for ES2025-feature RegExp.escape().
+
+                if (!thing.name || thing.name.id !== "escape") {
+
 // test_cause:
 // ["aa=RegExp.aa", "post_b", "weird_expression_a", ".", 10]
 
-                warn("weird_expression_a", thing);
+                    warn("weird_expression_a", thing);
+                }
             }
         } else if (thing.id !== "=>" && thing.id !== "(") {
             right = thing.expression[1];

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -3808,6 +3808,7 @@ import https from "https";
                 "Uint8Array",
                 "Uint8ClampedArray",
                 "WeakMap",
+                "WeakRef",
                 "WeakSet",
                 "WebAssembly",
                 "decodeURI",
@@ -4201,6 +4202,7 @@ function jslint_phase3_parse(state) {
                                         // ... the parse.
     let token_nxt = token_global;       // The next token to be examined in
                                         // ... <token_list>.
+    let token_prv = token_global;       // The previous token examined.
 
     function advance(id, match) {
 
@@ -4248,6 +4250,7 @@ function jslint_phase3_parse(state) {
 
 // Promote the tokens, skipping comments.
 
+        token_prv = token_now;
         token_now = token_nxt;
         while (true) {
             token_nxt = token_list[token_ii];
@@ -4866,11 +4869,7 @@ function jslint_phase3_parse(state) {
     }
 
     function infix_fart_unwrapped() {
-
-// test_cause:
-// ["aa=>0", "infix_fart_unwrapped", "wrap_fart_parameter", "=>", 3]
-
-        return stop("wrap_fart_parameter", token_now);
+        return parse_fart(token_now, true);
     }
 
     function infix_grave(left) {
@@ -5209,7 +5208,7 @@ function jslint_phase3_parse(state) {
         return left;
     }
 
-    function parse_fart(the_fart) {
+    function parse_fart(the_fart, mode_infix) {
 
 // Give the function properties storing its names and for observing the depth
 // of loops and switches.
@@ -5240,11 +5239,29 @@ function jslint_phase3_parse(state) {
         function_list.push(the_fart);
         function_stack.push(functionage);
         functionage = the_fart;
+        if (mode_infix) {
+            if (!token_prv.identifier) {
+
+// test_cause:
+// ["0=>0", "parse_fart", "wrap_fart_parameter", "=>", 2]
+
+                return stop("wrap_fart_parameter", token_now);
+            }
+
+// test_cause:
+// ["aa=>0", "parse_fart", "wrap_fart_parameter", "=>", 3]
+
+            warn("wrap_fart_parameter", token_now);
+            the_fart.parameters = [token_prv];
+            the_fart.signature = token_prv.id;
+            enroll(token_prv, "parameter", false);
+        } else {
 
 // Parse the parameter list.
 
-        prefix_function_parameter(the_fart);
-        advance("=>");
+            prefix_function_parameter(the_fart);
+            advance("=>");
+        }
 
 // The function's body is a block.
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -6771,7 +6771,81 @@ function jslint_phase3_parse(state) {
     function stmt_import() {
         const the_import = token_now;
         let name;
-        let names;
+        the_import.name = [];
+        state.mode_module = true;
+        while (true) {
+
+// PR-436 - Add grammar for side-effect import-statement.
+
+            if (token_nxt.id === "(string)") {
+
+// test_cause:
+// ["import \"aa\"", "stmt_import", "import_side_effect", "", 0]
+
+                test_cause("import_side_effect");
+                warn("expected_a_b", token_nxt, "{", artifact());
+                advance();
+                semicolon();
+                return the_import;
+            }
+            if (token_nxt.id === "*") {
+                advance("*");
+                advance("as");
+                if (!token_nxt.identifier) {
+
+// test_cause:
+// ["import * as", "stmt_import", "expected_identifier_a", "(end)", 1]
+
+                    return stop("expected_identifier_a");
+                }
+            }
+            if (token_nxt.identifier) {
+                name = token_nxt;
+                advance();
+                if (name.id === "ignore") {
+
+// test_cause:
+// ["import ignore from \"aa\"", "stmt_import", "unexpected_a", "ignore", 8]
+
+                    warn("unexpected_a", name);
+                }
+                enroll(name, "variable", true);
+                the_import.name.push(name);
+            } else {
+                advance("{");
+                if (token_nxt.id !== "}") {
+                    while (true) {
+                        if (!token_nxt.identifier) {
+
+// test_cause:
+// ["import {", "stmt_import", "expected_identifier_a", "(end)", 1]
+
+                            return stop("expected_identifier_a");
+                        }
+                        name = token_nxt;
+                        advance();
+                        if (token_nxt.id === "as") {
+                            advance("as");
+                            name = token_nxt;
+                            advance();
+                        }
+                        if (name.id === "ignore") {
+
+// test_cause:
+// ["import {ignore} from \"aa\"", "stmt_import", "unexpected_a", "ignore", 9]
+
+                            warn("unexpected_a", name);
+                        }
+                        enroll(name, "variable", true);
+                        the_import.name.push(name);
+                        if (token_nxt.id !== ",") {
+                            break;
+                        }
+                        advance(",");
+                    }
+                }
+                advance("}");
+            }
 
 // PR-347 - Disable warning "unexpected_directive_a".
 //
@@ -6790,64 +6864,10 @@ function jslint_phase3_parse(state) {
 //             );
 //         }
 
-        state.mode_module = true;
-
-// PR-436 - Add grammar for side-effect import-statement.
-
-        if (token_nxt.id === "(string)") {
-
-// test_cause:
-// ["import \"./aa.mjs\";", "stmt_import", "import_side_effect", "", 0]
-
-            test_cause("import_side_effect");
-            warn("expected_a_b", token_nxt, "{", artifact());
-            advance();
-            semicolon();
-            return the_import;
-        }
-        if (token_nxt.identifier) {
-            name = token_nxt;
-            advance();
-            if (name.id === "ignore") {
-
-// test_cause:
-// ["import ignore from \"aa\"", "stmt_import", "unexpected_a", "ignore", 8]
-
-                warn("unexpected_a", name);
+            if (token_nxt.id !== ",") {
+                break;
             }
-            enroll(name, "variable", true);
-            the_import.name = name;
-        } else {
-            names = [];
-            advance("{");
-            if (token_nxt.id !== "}") {
-                while (true) {
-                    if (!token_nxt.identifier) {
-
-// test_cause:
-// ["import {", "stmt_import", "expected_identifier_a", "(end)", 1]
-
-                        return stop("expected_identifier_a");
-                    }
-                    name = token_nxt;
-                    advance();
-                    if (name.id === "ignore") {
-
-// test_cause:
-// ["import {ignore} from \"aa\"", "stmt_import", "unexpected_a", "ignore", 9]
-
-                        warn("unexpected_a", name);
-                    }
-                    enroll(name, "variable", true);
-                    names.push(name);
-                    if (token_nxt.id !== ",") {
-                        break;
-                    }
-                    advance(",");
-                }
-            }
-            advance("}");
-            the_import.name = names;
+            advance(",");
         }
         advance("from");
         advance("(string)");
@@ -8407,21 +8427,12 @@ function jslint_phase4_walk(state) {
     }
 
     function post_s_import(the_thing) {
-        const name = the_thing.name;
-        if (name) {
-            if (Array.isArray(name)) {
-                name.forEach(function (name) {
-                    name.dead = false;
-                    name.init = true;
-                    blockage.live.push(name);
-                });
-            } else {
-                name.dead = false;
-                name.init = true;
-                blockage.live.push(name);
-            }
-            return post_s_export(the_thing);
-        }
+        the_thing.name.forEach(function (name) {
+            name.dead = false;
+            name.init = true;
+            blockage.live.push(name);
+        });
+        return post_s_export(the_thing);
     }
 
     function post_s_lbrace() {

--- a/test.mjs
+++ b/test.mjs
@@ -723,14 +723,10 @@ jstestDescribe((
                 )
             ],
             import: [
-                `const aa = await import("aa");\naa();`,
-                `const aa = await import("aa", {with: {type: "json"}});\naa();`,
-                `const {aa} = await import("aa");\naa();`,
-                "import(\"aa\").then(function () {\n    return;\n});",
-                (
-                    "let aa = 0;\n"
-                    + "import(aa).then(aa).then(aa).catch(aa).finally(aa);\n"
-                )
+                `let aa = 0;\nimport(aa).then(aa).catch(aa).finally(aa);`,
+                `let aa = await import("aa");`,
+                `let aa = await import("aa", {with: {type: "json"}});`,
+                `let {aa, bb} = await import("aa");`
             ],
             indent_method: [
                 "let aa = 0;\naa\n    .bb\n    .cc(\n        0\n    );"
@@ -795,12 +791,7 @@ jstestDescribe((
                 `import * as aa from "aa";\naa();`,
                 `import aa from "aa" with {type: "json"};\naa();`,
                 `import aa from "aa";\naa();`,
-                `import aa, * as bb from "aa";\naa(bb);`,
-                `import aa, {aa as bb} from "aa";\naa(bb);`,
-                `import aa, {bb, cc} from "aa";\naa(bb, cc);`,
-                `import {aa as aa, bb as bb} from "aa";\naa(bb);`,
-                `import {aa as aa} from "aa";\naa();`,
-                `import {aa, bb} from "aa";\naa(bb);`,
+                `import aa, {aa as bb, cc} from "aa";\naa(bb, cc);`,
                 `import {} from "aa";`
             ],
             number: [
@@ -837,7 +828,7 @@ jstestDescribe((
                 "RegExp.escape(\"\");",
                 "function aa() {\n    return /./;\n}",
                 "let aa = /(?!.)(?:.)(?=.)/;",
-                "let aa = /./gimuy;",
+                "let aa = /./gimsuy;",
                 "let aa = /[\\--\\-]/;"
             ],
             ternary: [
@@ -918,8 +909,9 @@ jstestDescribe((
                 ""
             ].map(function (directive) {
                 return [
-                    "let [\n    aa, bb = 0\n] = 0;\naa();\nbb();",
-                    "let aa = 0;\nlet [...bb] = [...aa];\nbb();",
+                    "const aa = 0;\naa();\n",
+                    "let [\n    aa, bb = 0, ...cc\n] = 0;\naa(bb, cc);",
+                    "let aa = 0;\naa();\n",
 
 // PR-459 - Allow destructuring-assignment after function-definition.
 
@@ -931,11 +923,16 @@ jstestDescribe((
                         + "}\n"
                         + "[aa, bb] = cc();\n"
                     ),
-                    "let constructor = 0;\nconstructor();",
-                    "let {\n    aa: bb\n} = 0;\nbb();",
-                    "let {\n    aa: bb,\n    bb: cc\n} = 0;\nbb();\ncc();",
-                    "let {aa, bb} = 0;\naa();\nbb();",
-                    "let {constructor} = 0;\nconstructor();"
+                    (
+                        "let {\n"
+                        + "    aa,\n"
+                        + "    bb = 0,\n"
+                        + "    cc: dd,\n"
+                        + "    ...ee\n"
+                        + "} = 0;\n"
+                        + "aa(bb, dd, ee);\n"
+                    ),
+                    "var aa = 0;\naa();\n"
                 ].map(function (code) {
                     return directive + code;
                 });

--- a/test.mjs
+++ b/test.mjs
@@ -689,6 +689,28 @@ jstestDescribe((
                 "let aa = aa().getTime();",
                 "let aa = aa.aa().getTime();"
             ],
+            destructure: [
+                "let [\n    , aa, bb = 0, ...cc\n] = 0;\naa(bb, cc);",
+
+// PR-459 - Allow destructuring-assignment after function-definition.
+
+                (
+                    "let aa;\n"
+                    + "let bb;\n"
+                    + "function cc() {\n"
+                    + "    return;\n"
+                    + "}\n"
+                    + "[aa, bb] = cc();\n"
+                ),
+                (
+                    "let {\n"
+                    + "    aa,\n"
+                    + "    bb = 0,\n"
+                    + "    cc: dd,\n"
+                    + "    ...ee\n"
+                    + "} = 0;\n"
+                )
+            ],
             directive: [
                 "#!\n/*jslint browser:false, node*/\n\"use strict\";",
                 "/*property aa bb*/"
@@ -910,28 +932,7 @@ jstestDescribe((
             ].map(function (directive) {
                 return [
                     "const aa = 0;\naa();\n",
-                    "let [\n    aa, bb = 0, ...cc\n] = 0;\naa(bb, cc);",
                     "let aa = 0;\naa();\n",
-
-// PR-459 - Allow destructuring-assignment after function-definition.
-
-                    (
-                        "let aa;\n"
-                        + "let bb;\n"
-                        + "function cc() {\n"
-                        + "    return;\n"
-                        + "}\n"
-                        + "[aa, bb] = cc();\n"
-                    ),
-                    (
-                        "let {\n"
-                        + "    aa,\n"
-                        + "    bb = 0,\n"
-                        + "    cc: dd,\n"
-                        + "    ...ee\n"
-                        + "} = 0;\n"
-                        + "aa(bb, dd, ee);\n"
-                    ),
                     "var aa = 0;\naa();\n"
                 ].map(function (code) {
                     return directive + code;

--- a/test.mjs
+++ b/test.mjs
@@ -723,7 +723,14 @@ jstestDescribe((
                 )
             ],
             import: [
-                `import aa from "aa" with {"type": "json"};\naa();`
+                `const aa = await import("aa");\naa();`,
+                `const aa = await import("aa", {with: {type: "json"}});\naa();`,
+                `const {aa} = await import("aa");\naa();`,
+                "import(\"aa\").then(function () {\n    return;\n});",
+                (
+                    "let aa = 0;\n"
+                    + "import(aa).then(aa).then(aa).catch(aa).finally(aa);\n"
+                )
             ],
             indent_method: [
                 "let aa = 0;\naa\n    .bb\n    .cc(\n        0\n    );"
@@ -784,14 +791,17 @@ jstestDescribe((
                     + "    return await 0;\n"
                     + "});\n"
                 ),
-                "import {aa, bb} from \"aa\";\naa(bb);",
-                "import {} from \"aa\";",
-                "import(\"aa\").then(function () {\n    return;\n});",
-                (
-                    "let aa = 0;\n"
-                    + "import(aa).then(aa).then(aa)"
-                    + ".catch(aa).finally(aa);\n"
-                )
+                // `import "aa";`,
+                `import * as aa from "aa";\naa();`,
+                `import aa from "aa" with {type: "json"};\naa();`,
+                `import aa from "aa";\naa();`,
+                `import aa, * as bb from "aa";\naa(bb);`,
+                `import aa, {aa as bb} from "aa";\naa(bb);`,
+                `import aa, {bb, cc} from "aa";\naa(bb, cc);`,
+                `import {aa as aa, bb as bb} from "aa";\naa(bb);`,
+                `import {aa as aa} from "aa";\naa();`,
+                `import {aa, bb} from "aa";\naa(bb);`,
+                `import {} from "aa";`
             ],
             number: [
                 "let aa = 0.0e0;",

--- a/test.mjs
+++ b/test.mjs
@@ -778,6 +778,11 @@ jstestDescribe((
                 "String(\"\".at());",
                 "String([].at());"
             ],
+            logical_assignment: [
+                "let aa = 0;\naa &&= 0;",
+                "let aa = 0;\naa ??= 0;",
+                "let aa = 0;\naa ||= 0;"
+            ],
             loop: [
                 (
                     "function aa() {\n"
@@ -847,11 +852,12 @@ jstestDescribe((
                 "let aa = aa[`!`];"
             ],
             regexp: [
-                "RegExp.escape(\"\");",
-                "function aa() {\n    return /./;\n}",
-                "let aa = /(?!.)(?:.)(?=.)/;",
-                "let aa = /./gimsuy;",
-                "let aa = /[\\--\\-]/;"
+                `RegExp.escape("");`,
+                `function aa() {\n    return /./;\n}`,
+                `let aa = /(?!.)(?:.)(?=.)/;`,
+                `let aa = /(?ims-ims:.)/;`,
+                `let aa = /./dgimsuvy;`,
+                `let aa = /[\\--\\-]/;`
             ],
             ternary: [
                 (

--- a/test.mjs
+++ b/test.mjs
@@ -749,6 +749,10 @@ jstestDescribe((
                     + "}\n"
                 )
             ],
+            literal: [
+                "String(\"\".at());",
+                "String([].at());"
+            ],
             loop: [
                 (
                     "function aa() {\n"
@@ -820,6 +824,7 @@ jstestDescribe((
                 "let aa = aa[`!`];"
             ],
             regexp: [
+                "RegExp.escape(\"\");",
                 "function aa() {\n    return /./;\n}",
                 "let aa = /(?!.)(?:.)(?=.)/;",
                 "let aa = /./gimuy;",


### PR DESCRIPTION
- Finally got this todo done -- yay!
- also added new syntax / grammar for previously unsupported ECMA features:

- jslint - Update warning infix_in to recommend Object.hasOwn() over hasOwnProperty().
- jslint-ecma - Add ES2025-feature RegExp Modifiers.
- jslint-ecma - Add ES2022-feature RegExp Match Indices.
- jslint-ecma - Add ES2021-feature Logical Assignment Operators.
- jslint-ecma - Add ES2027-feature Temporal.
- jslint-ecma - Expand ES2015-feature-support for destructuring.
- jslint-ecma - Add ES2018-feature Rest/Spread Properties.
- jslint-ecma - Add ES2018-feature s (dotall) flag for regular expressions.
- jslint-ecma - Expand ES2015-feature-support for es-module-import-statement.
- jslint-ecma - Add ES2023-feature ShadowRealm to global-scope.
- jslint-ecma - Add ES2024-feature .isWellFormed(), .toWellFormed() for literal string.
- jslint-ecma - Add ES2022-feature .at() for literal string/array.
- jslint-ecma - Add ES2025-feature Float16Array to global-scope.
- jslint-ecma - Relax warning for ES2025-feature RegExp.escape().
- jslint-ecma - Add ES2021-feature WeakRef to global-scope.
- jslint-ecma - Update ES2015-feature arrow, to continue parsing unwrapped-form with warning, instead of stopping.


<img width="1200" height="1440" alt="image" src="https://github.com/user-attachments/assets/9072569e-8e06-4278-9571-c4bd5194bd73" />
