### PR TITLE
- jslint-ecma - Unify ES2015-destructure-logic into function prefix_destructure().

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -156,7 +156,7 @@ import moduleChildProcess from "child_process";
     GITHUB_REPO_BASENAME="$(printf "$GITHUB_GITHUB_IO" | cut -d'/' -f2)"
     if [ "$GITHUB_REPO_BASENAME" != jslint ]
     then
-        for FILE in $(ls .artifact/*_2f${GITHUB_REPO_BASENAME}_2f*)
+        for FILE in $(ls .artifact/*_2f"${GITHUB_REPO_BASENAME}"_2f*)
         do
             mv "$FILE" "$(printf "$FILE" | \
                 sed -e "s|_2f${GITHUB_REPO_BASENAME}_2f|_2fjslint_2f|")"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.6.1-beta
+- jslint-ci - Rename ci-functions shGitPullrequestXxx to shGithubPrXxx.
 - jslint-ecma - Unify ES2015-destructure-logic into function prefix_destructure().
 - jslint-ecma - Update README.md, documenting supported ES2015+ features.
 - jslint - Update warning infix_in to recommend Object.hasOwn() over hasOwnProperty().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 # Todo
-- jslint-ecma - Unify ES2015-destructure-logic into function prefix_destructure().
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
 - jslint - Relax warning expected_line_break_a_b for ternary-operator inside template-literal.
 - jslint - Add ability to auto-fix whitespace.
@@ -11,6 +10,7 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.6.1-beta
+- jslint-ecma - Unify ES2015-destructure-logic into function prefix_destructure().
 - jslint-ecma - Update README.md, documenting supported ES2015+ features.
 - jslint - Update warning infix_in to recommend Object.hasOwn() over hasOwnProperty().
 - jslint-ecma - Add ES2025-feature RegExp Modifiers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 # Todo
+- jslint-ci - Automate linting of shell-scripts with shellcheck.
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
 - jslint - Relax warning expected_line_break_a_b for ternary-operator inside template-literal.
 - jslint - Add ability to auto-fix whitespace.
@@ -10,8 +11,9 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.6.1-beta
-- jslint-ci - Rename ci-functions shGitPullrequestXxx to shGithubPrXxx.
 - jslint-ecma - Unify ES2015-destructure-logic into function prefix_destructure().
+- jslint-ci - Add shell-function shGithubPrUpdatePrxxx() to auto-update 'PR-xxx' placeholder to next sequential github issue/pull number.
+- jslint-ci - Rename shell-functions shGitPullrequestXxx() to shGithubPrXxx().
 - jslint-ecma - Update README.md, documenting supported ES2015+ features.
 - jslint - Update warning infix_in to recommend Object.hasOwn() over hasOwnProperty().
 - jslint-ecma - Add ES2025-feature RegExp Modifiers.

--- a/README.md
+++ b/README.md
@@ -1018,7 +1018,7 @@ if (false) {
 - `git push upstream alpha -f`
     - verify ci-success for upstream-branch-alpha
     - https://github.com/jslint-org/jslint/actions
-- goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.6.24
+- goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.6.28
 - click `Create pull request`
 - input `Add your description here...` with:
 ```

--- a/README.md
+++ b/README.md
@@ -884,105 +884,105 @@ if (false) {
 
 | #. | JSLint Support | ES Version | ES Feature |
 |--:|:--|:--|:--|
-|  99. | &#x274c; | ES2027 | [`Explicit Resource Management`](https://github.com/tc39/proposal-explicit-resource-management) |
-|  98. | &#x2705; | ES2027 | [`Atomics.pause`](https://github.com/tc39/proposal-atomics-microwait) |
-|  97. | &#x274c; | ES2027 | [`Joint Iteration`](https://github.com/tc39/proposal-joint-iteration) |
-|  96. | &#x2705; | ES2027 | [`Temporal`](https://github.com/tc39/proposal-temporal) |
-|  95. | &#x2705; | ES2026 | [`Upsert`](https://github.com/tc39/proposal-upsert) |
-|  94. | &#x2705; | ES2026 | [`JSON.parse source text access`](https://github.com/tc39/proposal-json-parse-with-source) |
-|  93. | &#x274c; | ES2026 | [`Iterator Sequencing`](https://github.com/tc39/proposal-iterator-sequencing) |
-|  92. | &#x2705; | ES2026 | [`Uint8Array to/from Base64`](https://github.com/tc39/proposal-arraybuffer-base64) |
-|  91. | &#x2705; | ES2026 | [`Math.sumPrecise`](https://github.com/tc39/proposal-math-sum) |
-|  90. | &#x2705; | ES2026 | [`Error.isError`](https://github.com/tc39/proposal-is-error) |
-|  89. | &#x2705; | ES2026 | [`Array.fromAsync`](https://github.com/tc39/proposal-array-from-async) |
-|  88. | &#x2705; | ES2025 | [`RegExp.escape`](https://github.com/tc39/proposal-regex-escaping) |
-|  87. | &#x2705; | ES2025 | [`Redeclarable global eval-introduced vars`](https://github.com/tc39/proposal-redeclarable-global-eval-vars) |
-|  86. | &#x2705; | ES2025 | [`Float16 on TypedArrays, DataView, Math.f16round`](https://github.com/tc39/proposal-float16array) |
-|  85. | &#x2705; | ES2025 | [`Promise.try`](https://github.com/tc39/proposal-promise-try) |
-|  84. | &#x274c; | ES2025 | [`Sync Iterator helpers`](https://github.com/tc39/proposal-iterator-helpers) |
-|  83. | &#x2705; | ES2025 | [`JSON Modules`](https://github.com/tc39/proposal-json-modules) |
-|  82. | &#x2705; | ES2025 | [`Import Attributes`](https://github.com/tc39/proposal-import-attributes) |
-|  81. | &#x2705; | ES2025 | [`RegExp Modifiers`](https://github.com/tc39/proposal-regexp-modifiers) |
-|  80. | &#x2705; | ES2025 | [`New Set methods`](https://github.com/tc39/proposal-set-methods) |
-|  79. | &#x2705; | ES2025 | [`Duplicate named capture groups`](https://github.com/tc39/proposal-duplicate-named-capturing-groups) |
-|  78. | &#x2705; | ES2024 | [`ArrayBuffer transfer`](https://github.com/tc39/proposal-arraybuffer-transfer) |
-|  77. | &#x2705; | ES2024 | [`Promise.withResolvers`](https://github.com/tc39/proposal-promise-with-resolvers) |
-|  76. | &#x2705; | ES2024 | [`Array Grouping`](https://github.com/tc39/proposal-array-grouping) |
-|  75. | &#x2705; | ES2024 | [`Resizable and growable ArrayBuffers`](https://github.com/tc39/proposal-resizablearraybuffer) |
-|  74. | &#x26a0; | ES2024 | [`RegExp v flag with set notation + properties of strings`](https://github.com/tc39/proposal-regexp-v-flag) |
-|  73. | &#x2705; | ES2024 | [`Atomics.waitAsync`](https://github.com/tc39/proposal-atomics-wait-async) |
-|  72. | &#x2705; | ES2024 | [`Well-Formed Unicode Strings`](https://github.com/tc39/proposal-is-usv-string) |
-|  71. | &#x2705; | ES2023 | [`Change Array by Copy`](https://github.com/tc39/proposal-change-array-by-copy) |
-|  70. | &#x2705; | ES2023 | [`Symbols as WeakMap keys`](https://github.com/tc39/proposal-symbols-as-weakmap-keys) |
-|  69. | &#x2705; | ES2023 | [`Hashbang Grammar`](https://github.com/tc39/proposal-hashbang) |
-|  68. | &#x2705; | ES2023 | [`Array find from last`](https://github.com/tc39/proposal-array-find-from-last) |
-|  67. | &#x2705; | ES2022 | [`Error Cause`](https://github.com/tc39/proposal-error-cause) |
-|  66. | &#x274c; | ES2022 | [`Class Static Block`](https://github.com/tc39/proposal-class-static-block) |
-|  65. | &#x2705; | ES2022 | [`Accessible Object.prototype.hasOwnProperty`](https://github.com/tc39/proposal-accessible-object-hasownproperty) |
-|  64. | &#x2705; | ES2022 | [`.at()`](https://github.com/tc39/proposal-relative-indexing-method) |
-|  63. | &#x274c; | ES2022 | [`Ergonomic brand checks for Private Fields`](https://github.com/tc39/proposal-private-fields-in-in) |
-|  62. | &#x2705; | ES2022 | [`Top-level await`](https://github.com/tc39/proposal-top-level-await) |
-|  61. | &#x2705; | ES2022 | [`RegExp Match Indices`](https://github.com/tc39/proposal-regexp-match-indices) |
-|  60. | &#x274c; | ES2022 | [`Class Public Instance Fields & Private Instance Fields`](https://github.com/tc39/proposal-class-fields) |
-|  59. | &#x2705; | ES2021 | [`Numeric separators`](https://github.com/tc39/proposal-numeric-separator) |
-|  58. | &#x2705; | ES2021 | [`Logical Assignment Operators`](https://github.com/tc39/proposal-logical-assignment) |
-|  57. | &#x2705; | ES2021 | [`WeakRefs`](https://github.com/tc39/proposal-weakrefs) |
-|  56. | &#x2705; | ES2021 | [`Promise.any`](https://github.com/tc39/proposal-promise-any) |
-|  55. | &#x2705; | ES2021 | [`String.prototype.replaceAll`](https://github.com/tc39/proposal-string-replaceall) |
-|  54. | &#x2705; | ES2020 | [`import.meta`](https://github.com/tc39/proposal-import-meta) |
-|  53. | &#x2705; | ES2020 | [`Nullish coalescing Operator`](https://github.com/tc39/proposal-nullish-coalescing) |
-|  52. | &#x2705; | ES2020 | [`Optional Chaining`](https://github.com/tc39/proposal-optional-chaining) |
-|  51. | &#x2705; | ES2020 | [`for-in mechanics`](https://github.com/tc39/proposal-for-in-order) |
-|  50. | &#x2705; | ES2020 | [`globalThis`](https://github.com/tc39/proposal-global) |
-|  49. | &#x2705; | ES2020 | [`Promise.allSettled`](https://github.com/tc39/proposal-promise-allSettled) |
-|  48. | &#x2705; | ES2020 | [`BigInt`](https://github.com/tc39/proposal-bigint) |
-|  47. | &#x2705; | ES2020 | [`import()`](https://github.com/tc39/proposal-dynamic-import) |
-|  46. | &#x2705; | ES2020 | [`String.prototype.matchAll`](https://github.com/tc39/proposal-string-matchall) |
-|  45. | &#x2705; | ES2019 | [`Array.prototype.{flat,flatMap}`](https://github.com/tc39/proposal-flatMap) |
-|  44. | &#x2705; | ES2019 | [`String.prototype.{trimStart,trimEnd}`](https://github.com/tc39/proposal-string-left-right-trim) |
-|  43. | &#x2705; | ES2019 | [`Well-formed JSON.stringify`](https://github.com/tc39/proposal-well-formed-stringify) |
-|  42. | &#x2705; | ES2019 | [`Object.fromEntries`](https://github.com/tc39/proposal-object-from-entries) |
-|  41. | &#x2705; | ES2019 | [`Function.prototype.toString revision`](https://github.com/tc39/Function-prototype-toString-revision) |
-|  40. | &#x2705; | ES2019 | [`Symbol.prototype.description`](https://github.com/tc39/proposal-Symbol-description) |
-|  39. | &#x2705; | ES2019 | [`JSON superset`](https://github.com/tc39/proposal-json-superset) |
-|  38. | &#x2705; | ES2019 | [`Optional catch binding`](https://github.com/tc39/proposal-optional-catch-binding) |
-|  37. | &#x274c; | ES2018 | [`Asynchronous Iteration`](https://github.com/tc39/proposal-async-iteration) |
-|  36. | &#x2705; | ES2018 | [`Promise.prototype.finally`](https://github.com/tc39/proposal-promise-finally) |
-|  35. | &#x2705; | ES2018 | [`RegExp Unicode Property Escapes`](https://github.com/tc39/proposal-regexp-unicode-property-escapes) |
-|  34. | &#x2705; | ES2018 | [`RegExp Lookbehind Assertions`](https://github.com/tc39/proposal-regexp-lookbehind) |
-|  33. | &#x2705; | ES2018 | [`Rest/Spread Properties`](https://github.com/tc39/proposal-object-rest-spread) |
-|  32. | &#x2705; | ES2018 | [`RegExp named capture groups`](https://github.com/tc39/proposal-regexp-named-groups) |
-|  31. | &#x2705; | ES2018 | [`s (dotAll) flag for regular expressions`](https://github.com/tc39/proposal-regexp-dotall-flag) |
-|  30. | &#x2705; | ES2018 | [`Lifting template literal restriction`](https://github.com/tc39/proposal-template-literal-revision) |
-|  29. | &#x2705; | ES2017 | [`Shared memory and atomics`](https://github.com/tc39/proposal-ecmascript-sharedmem) |
-|  28. | &#x2705; | ES2017 | [`Async functions`](https://github.com/tc39/proposal-async-await) |
-|  27. | &#x26a0; | ES2017 | [`Trailing commas in function parameter lists and calls`](https://github.com/tc39/proposal-trailing-function-commas) |
-|  26. | &#x2705; | ES2017 | [`Object.getOwnPropertyDescriptors`](https://github.com/tc39/proposal-object-getownpropertydescriptors) |
-|  25. | &#x2705; | ES2017 | [`String padding`](https://github.com/tc39/proposal-string-pad-start-end) |
-|  24. | &#x2705; | ES2017 | [`Object.values/Object.entries`](https://github.com/tc39/proposal-object-values-entries) |
-|  23. | &#x2705; | ES2016 | [`Exponentiation operator`](https://github.com/tc39/proposal-exponentiation-operator) |
-|  22. | &#x2705; | ES2016 | [`Array.prototype.includes`](https://github.com/tc39/proposal-Array.prototype.includes) |
-|  21. | &#x2705; | ES2015 | [`arrows`](https://github.com/lukehoban/es6features#arrows) |
-|  20. | &#x274c; | ES2015 | [`classes`](https://github.com/lukehoban/es6features#classes) |
-|  19. | &#x274c; | ES2015 | [`enhanced object literals`](https://github.com/lukehoban/es6features#enhanced-object-literals) |
-|  18. | &#x2705; | ES2015 | [`template strings`](https://github.com/lukehoban/es6features#template-strings) |
-|  17. | &#x2705; | ES2015 | [`destructuring`](https://github.com/lukehoban/es6features#destructuring) |
-|  16. | &#x2705; | ES2015 | [`default + rest + spread`](https://github.com/lukehoban/es6features#default--rest--spread) |
-|  15. | &#x2705; | ES2015 | [`let + const`](https://github.com/lukehoban/es6features#let--const) |
-|  14. | &#x274c; | ES2015 | [`iterators + for..of`](https://github.com/lukehoban/es6features#iterators--forof) |
-|  13. | &#x274c; | ES2015 | [`generators`](https://github.com/lukehoban/es6features#generators) |
-|  12. | &#x2705; | ES2015 | [`unicode`](https://github.com/lukehoban/es6features#unicode) |
-|  11. | &#x26a0; | ES2015 | [`modules`](https://github.com/lukehoban/es6features#modules) |
-|  10. | &#x2705; | ES2015 | [`module loaders`](https://github.com/lukehoban/es6features#module-loaders) |
-|   9. | &#x2705; | ES2015 | [`map + set + weakmap + weakset`](https://github.com/lukehoban/es6features#map--set--weakmap--weakset) |
-|   8. | &#x2705; | ES2015 | [`proxies`](https://github.com/lukehoban/es6features#proxies) |
-|   7. | &#x2705; | ES2015 | [`symbols`](https://github.com/lukehoban/es6features#symbols) |
-|   6. | &#x274c; | ES2015 | [`subclassable built-ins`](https://github.com/lukehoban/es6features#subclassable-built-ins) |
-|   5. | &#x2705; | ES2015 | [`promises`](https://github.com/lukehoban/es6features#promises) |
-|   4. | &#x2705; | ES2015 | [`math + number + string + array + object APIs`](https://github.com/lukehoban/es6features#math--number--string--array--object-apis) |
-|   3. | &#x2705; | ES2015 | [`binary and octal literals`](https://github.com/lukehoban/es6features#binary-and-octal-literals) |
-|   2. | &#x2705; | ES2015 | [`reflect api`](https://github.com/lukehoban/es6features#reflect-api) |
-|   1. | &#x2705; | ES2015 | [`tail calls`](https://github.com/lukehoban/es6features#tail-calls) |
+|  99. | ❌ | ES2027 | [`Explicit Resource Management`](https://github.com/tc39/proposal-explicit-resource-management) |
+|  98. | ✅ | ES2027 | [`Atomics.pause`](https://github.com/tc39/proposal-atomics-microwait) |
+|  97. | ❌ | ES2027 | [`Joint Iteration`](https://github.com/tc39/proposal-joint-iteration) |
+|  96. | ✅ | ES2027 | [`Temporal`](https://github.com/tc39/proposal-temporal) |
+|  95. | ✅ | ES2026 | [`Upsert`](https://github.com/tc39/proposal-upsert) |
+|  94. | ✅ | ES2026 | [`JSON.parse source text access`](https://github.com/tc39/proposal-json-parse-with-source) |
+|  93. | ❌ | ES2026 | [`Iterator Sequencing`](https://github.com/tc39/proposal-iterator-sequencing) |
+|  92. | ✅ | ES2026 | [`Uint8Array to/from Base64`](https://github.com/tc39/proposal-arraybuffer-base64) |
+|  91. | ✅ | ES2026 | [`Math.sumPrecise`](https://github.com/tc39/proposal-math-sum) |
+|  90. | ✅ | ES2026 | [`Error.isError`](https://github.com/tc39/proposal-is-error) |
+|  89. | ✅ | ES2026 | [`Array.fromAsync`](https://github.com/tc39/proposal-array-from-async) |
+|  88. | ✅ | ES2025 | [`RegExp.escape`](https://github.com/tc39/proposal-regex-escaping) |
+|  87. | ✅ | ES2025 | [`Redeclarable global eval-introduced vars`](https://github.com/tc39/proposal-redeclarable-global-eval-vars) |
+|  86. | ✅ | ES2025 | [`Float16 on TypedArrays, DataView, Math.f16round`](https://github.com/tc39/proposal-float16array) |
+|  85. | ✅ | ES2025 | [`Promise.try`](https://github.com/tc39/proposal-promise-try) |
+|  84. | ❌ | ES2025 | [`Sync Iterator helpers`](https://github.com/tc39/proposal-iterator-helpers) |
+|  83. | ✅ | ES2025 | [`JSON Modules`](https://github.com/tc39/proposal-json-modules) |
+|  82. | ✅ | ES2025 | [`Import Attributes`](https://github.com/tc39/proposal-import-attributes) |
+|  81. | ✅ | ES2025 | [`RegExp Modifiers`](https://github.com/tc39/proposal-regexp-modifiers) |
+|  80. | ✅ | ES2025 | [`New Set methods`](https://github.com/tc39/proposal-set-methods) |
+|  79. | ✅ | ES2025 | [`Duplicate named capture groups`](https://github.com/tc39/proposal-duplicate-named-capturing-groups) |
+|  78. | ✅ | ES2024 | [`ArrayBuffer transfer`](https://github.com/tc39/proposal-arraybuffer-transfer) |
+|  77. | ✅ | ES2024 | [`Promise.withResolvers`](https://github.com/tc39/proposal-promise-with-resolvers) |
+|  76. | ✅ | ES2024 | [`Array Grouping`](https://github.com/tc39/proposal-array-grouping) |
+|  75. | ✅ | ES2024 | [`Resizable and growable ArrayBuffers`](https://github.com/tc39/proposal-resizablearraybuffer) |
+|  74. | ⚠️ | ES2024 | [`RegExp v flag with set notation + properties of strings`](https://github.com/tc39/proposal-regexp-v-flag) |
+|  73. | ✅ | ES2024 | [`Atomics.waitAsync`](https://github.com/tc39/proposal-atomics-wait-async) |
+|  72. | ✅ | ES2024 | [`Well-Formed Unicode Strings`](https://github.com/tc39/proposal-is-usv-string) |
+|  71. | ✅ | ES2023 | [`Change Array by Copy`](https://github.com/tc39/proposal-change-array-by-copy) |
+|  70. | ✅ | ES2023 | [`Symbols as WeakMap keys`](https://github.com/tc39/proposal-symbols-as-weakmap-keys) |
+|  69. | ✅ | ES2023 | [`Hashbang Grammar`](https://github.com/tc39/proposal-hashbang) |
+|  68. | ✅ | ES2023 | [`Array find from last`](https://github.com/tc39/proposal-array-find-from-last) |
+|  67. | ✅ | ES2022 | [`Error Cause`](https://github.com/tc39/proposal-error-cause) |
+|  66. | ❌ | ES2022 | [`Class Static Block`](https://github.com/tc39/proposal-class-static-block) |
+|  65. | ✅ | ES2022 | [`Accessible Object.prototype.hasOwnProperty`](https://github.com/tc39/proposal-accessible-object-hasownproperty) |
+|  64. | ✅ | ES2022 | [`.at()`](https://github.com/tc39/proposal-relative-indexing-method) |
+|  63. | ❌ | ES2022 | [`Ergonomic brand checks for Private Fields`](https://github.com/tc39/proposal-private-fields-in-in) |
+|  62. | ✅ | ES2022 | [`Top-level await`](https://github.com/tc39/proposal-top-level-await) |
+|  61. | ✅ | ES2022 | [`RegExp Match Indices`](https://github.com/tc39/proposal-regexp-match-indices) |
+|  60. | ❌ | ES2022 | [`Class Public Instance Fields & Private Instance Fields`](https://github.com/tc39/proposal-class-fields) |
+|  59. | ✅ | ES2021 | [`Numeric separators`](https://github.com/tc39/proposal-numeric-separator) |
+|  58. | ✅ | ES2021 | [`Logical Assignment Operators`](https://github.com/tc39/proposal-logical-assignment) |
+|  57. | ✅ | ES2021 | [`WeakRefs`](https://github.com/tc39/proposal-weakrefs) |
+|  56. | ✅ | ES2021 | [`Promise.any`](https://github.com/tc39/proposal-promise-any) |
+|  55. | ✅ | ES2021 | [`String.prototype.replaceAll`](https://github.com/tc39/proposal-string-replaceall) |
+|  54. | ✅ | ES2020 | [`import.meta`](https://github.com/tc39/proposal-import-meta) |
+|  53. | ✅ | ES2020 | [`Nullish coalescing Operator`](https://github.com/tc39/proposal-nullish-coalescing) |
+|  52. | ✅ | ES2020 | [`Optional Chaining`](https://github.com/tc39/proposal-optional-chaining) |
+|  51. | ✅ | ES2020 | [`for-in mechanics`](https://github.com/tc39/proposal-for-in-order) |
+|  50. | ✅ | ES2020 | [`globalThis`](https://github.com/tc39/proposal-global) |
+|  49. | ✅ | ES2020 | [`Promise.allSettled`](https://github.com/tc39/proposal-promise-allSettled) |
+|  48. | ✅ | ES2020 | [`BigInt`](https://github.com/tc39/proposal-bigint) |
+|  47. | ✅ | ES2020 | [`import()`](https://github.com/tc39/proposal-dynamic-import) |
+|  46. | ✅ | ES2020 | [`String.prototype.matchAll`](https://github.com/tc39/proposal-string-matchall) |
+|  45. | ✅ | ES2019 | [`Array.prototype.{flat,flatMap}`](https://github.com/tc39/proposal-flatMap) |
+|  44. | ✅ | ES2019 | [`String.prototype.{trimStart,trimEnd}`](https://github.com/tc39/proposal-string-left-right-trim) |
+|  43. | ✅ | ES2019 | [`Well-formed JSON.stringify`](https://github.com/tc39/proposal-well-formed-stringify) |
+|  42. | ✅ | ES2019 | [`Object.fromEntries`](https://github.com/tc39/proposal-object-from-entries) |
+|  41. | ✅ | ES2019 | [`Function.prototype.toString revision`](https://github.com/tc39/Function-prototype-toString-revision) |
+|  40. | ✅ | ES2019 | [`Symbol.prototype.description`](https://github.com/tc39/proposal-Symbol-description) |
+|  39. | ✅ | ES2019 | [`JSON superset`](https://github.com/tc39/proposal-json-superset) |
+|  38. | ✅ | ES2019 | [`Optional catch binding`](https://github.com/tc39/proposal-optional-catch-binding) |
+|  37. | ❌ | ES2018 | [`Asynchronous Iteration`](https://github.com/tc39/proposal-async-iteration) |
+|  36. | ✅ | ES2018 | [`Promise.prototype.finally`](https://github.com/tc39/proposal-promise-finally) |
+|  35. | ✅ | ES2018 | [`RegExp Unicode Property Escapes`](https://github.com/tc39/proposal-regexp-unicode-property-escapes) |
+|  34. | ✅ | ES2018 | [`RegExp Lookbehind Assertions`](https://github.com/tc39/proposal-regexp-lookbehind) |
+|  33. | ✅ | ES2018 | [`Rest/Spread Properties`](https://github.com/tc39/proposal-object-rest-spread) |
+|  32. | ✅ | ES2018 | [`RegExp named capture groups`](https://github.com/tc39/proposal-regexp-named-groups) |
+|  31. | ✅ | ES2018 | [`s (dotAll) flag for regular expressions`](https://github.com/tc39/proposal-regexp-dotall-flag) |
+|  30. | ✅ | ES2018 | [`Lifting template literal restriction`](https://github.com/tc39/proposal-template-literal-revision) |
+|  29. | ✅ | ES2017 | [`Shared memory and atomics`](https://github.com/tc39/proposal-ecmascript-sharedmem) |
+|  28. | ✅ | ES2017 | [`Async functions`](https://github.com/tc39/proposal-async-await) |
+|  27. | ⚠️ | ES2017 | [`Trailing commas in function parameter lists and calls`](https://github.com/tc39/proposal-trailing-function-commas) |
+|  26. | ✅ | ES2017 | [`Object.getOwnPropertyDescriptors`](https://github.com/tc39/proposal-object-getownpropertydescriptors) |
+|  25. | ✅ | ES2017 | [`String padding`](https://github.com/tc39/proposal-string-pad-start-end) |
+|  24. | ✅ | ES2017 | [`Object.values/Object.entries`](https://github.com/tc39/proposal-object-values-entries) |
+|  23. | ✅ | ES2016 | [`Exponentiation operator`](https://github.com/tc39/proposal-exponentiation-operator) |
+|  22. | ✅ | ES2016 | [`Array.prototype.includes`](https://github.com/tc39/proposal-Array.prototype.includes) |
+|  21. | ✅ | ES2015 | [`arrows`](https://github.com/lukehoban/es6features#arrows) |
+|  20. | ❌ | ES2015 | [`classes`](https://github.com/lukehoban/es6features#classes) |
+|  19. | ❌ | ES2015 | [`enhanced object literals`](https://github.com/lukehoban/es6features#enhanced-object-literals) |
+|  18. | ✅ | ES2015 | [`template strings`](https://github.com/lukehoban/es6features#template-strings) |
+|  17. | ✅ | ES2015 | [`destructuring`](https://github.com/lukehoban/es6features#destructuring) |
+|  16. | ✅ | ES2015 | [`default + rest + spread`](https://github.com/lukehoban/es6features#default--rest--spread) |
+|  15. | ✅ | ES2015 | [`let + const`](https://github.com/lukehoban/es6features#let--const) |
+|  14. | ❌ | ES2015 | [`iterators + for..of`](https://github.com/lukehoban/es6features#iterators--forof) |
+|  13. | ❌ | ES2015 | [`generators`](https://github.com/lukehoban/es6features#generators) |
+|  12. | ✅ | ES2015 | [`unicode`](https://github.com/lukehoban/es6features#unicode) |
+|  11. | ⚠️ | ES2015 | [`modules`](https://github.com/lukehoban/es6features#modules) |
+|  10. | ✅ | ES2015 | [`module loaders`](https://github.com/lukehoban/es6features#module-loaders) |
+|   9. | ✅ | ES2015 | [`map + set + weakmap + weakset`](https://github.com/lukehoban/es6features#map--set--weakmap--weakset) |
+|   8. | ✅ | ES2015 | [`proxies`](https://github.com/lukehoban/es6features#proxies) |
+|   7. | ✅ | ES2015 | [`symbols`](https://github.com/lukehoban/es6features#symbols) |
+|   6. | ❌ | ES2015 | [`subclassable built-ins`](https://github.com/lukehoban/es6features#subclassable-built-ins) |
+|   5. | ✅ | ES2015 | [`promises`](https://github.com/lukehoban/es6features#promises) |
+|   4. | ✅ | ES2015 | [`math + number + string + array + object APIs`](https://github.com/lukehoban/es6features#math--number--string--array--object-apis) |
+|   3. | ✅ | ES2015 | [`binary and octal literals`](https://github.com/lukehoban/es6features#binary-and-octal-literals) |
+|   2. | ✅ | ES2015 | [`reflect api`](https://github.com/lukehoban/es6features#reflect-api) |
+|   1. | ✅ | ES2015 | [`tail calls`](https://github.com/lukehoban/es6features#tail-calls) |
 
 
 <br><br>

--- a/README.md
+++ b/README.md
@@ -1010,129 +1010,171 @@ if (false) {
 
 <br><br>
 ### pull-request merge
-1. find highest issue-number at https://github.com/jslint-org/jslint/issues/, https://github.com/jslint-org/jslint/pulls/, and add +1 to it for PR-xxx
-1. checkpoint local-branch-beta
-1. `sh jslint_ci.sh shGithubPrCreate beta beta # 20xx-xx-xx`
-    - verify ci-success for origin-branch-alpha
-    - https://github.com/kaizhu256/jslint/actions
-1. `git push upstream alpha -f`
-    - verify ci-success for upstream-branch-alpha
-    - https://github.com/jslint-org/jslint/actions
+1. update `.github/workflows/ci.yml` `.github/workflows/publish.yml` to:
+    - latest nodejs-lts version @ https://nodejs.org/en/about/previous-releases
+1. update `CHANGELOG.md`
+    - verify `<CHANGELOG.md entry #1>` is most-relevant to pull-request.
+    - run
+        ```shell
+        npm run test2 # re-run until version propagates
+
+        git commit -am "<CHANGELOG.md entries>"
+        ```
+    - run
+        ```shell
+        sh jslint_ci.sh shGithubPrUpdatePrxxx
+
+        git push . HEAD:beta -f
+
+        sh jslint_ci.sh shGithubPrCreate beta beta # 20xx-xx-xx
+
+        git push upstream alpha -f
+        ```
+        - verify ci-success @ https://github.com/kaizhu256/jslint/actions
+        - verify ci-success @ https://github.com/jslint-org/jslint/actions
+
 1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.6.28
-1. click `Create pull request`
-1. input `Add your description here...` with:
-```
-Fixes #xxx.
-- <primary-commit-message>
+    - click `Create pull request`
+    - input `Add a title *` with: `<CHANGELOG.md entry #1>`
+    - input `Add a description` with:
+        ```
+        Fixes #xxx.
 
-This PR will ...
+        This PR will:
+        <CHANGELOG.md entry #1>
 
-This PR will additionally:
-- <secondary-commit-message>
-...
+        This PR will additionally:
+        <CHANGELOG.md entry extra>
 
-<screenshot>
-```
-1. verify `commit into jslint-org:beta`
-1. click `Create pull request`
-    - verify ci-success for pull-request
-    - https://github.com/jslint-org/jslint/actions/workflows/on_pull_request.yml
+        <screenshot>
+        ```
+    - verify:
+        - base respository: `jslint-org/jslint`
+        - base: `beta`
+    - click `Create pull request`
+        - verify ci-success @ https://github.com/jslint-org/jslint/actions/workflows/on_pull_request.yml
+
 1. wait awhile before continuing ...
-1. click `Squash and merge`
-    - verify ci-success for upstream-branch-beta
-    - https://github.com/jslint-org/jslint/actions
-1. `sh jslint_ci.sh shGithubPrCleanup`
-    - verify ci-success for origin-branch-alpha
-    - https://github.com/kaizhu256/jslint/actions
-1. `git push upstream alpha -f`
-    - verify ci-success for upstream-branch-alpha
-    - https://github.com/jslint-org/jslint/actions
-1. click `Delete branch`
+    - click `Squash and merge`
+        - verify ci-success @ https://github.com/jslint-org/jslint/actions
+    - run
+        ```shell
+        sh jslint_ci.sh shGithubPrCleanup
+
+        git push upstream alpha -f
+        ```
+        - verify ci-success @ https://github.com/kaizhu256/jslint/actions
+        - verify ci-success @ https://github.com/jslint-org/jslint/actions
+    - click `Delete branch`
 
 
 <br><br>
 ### branch-master commit
-1. update ci.yml to latest nodejs-lts
-1. checkpoint local-branch-beta
-1. `sh jslint_ci.sh shGithubPrCreate master beta # re-run until version propagates`
-    - verify ci-success for origin-branch-alpha
-    - https://github.com/kaizhu256/jslint/actions
-1. `git push upstream alpha -f`
-    - verify ci-success for upstream-branch-alpha
-    - https://github.com/jslint-org/jslint/actions
+1. update `.github/workflows/ci.yml` `.github/workflows/publish.yml` to:
+    - latest nodejs-lts version @ https://nodejs.org/en/about/previous-releases
+1. update `CHANGELOG.md`
+    - verify `<CHANGELOG.md entry #1>` is most-relevant to pull-request.
+    - run
+        ```shell
+        npm run test2 # re-run until version propagates
+
+        git commit -am "<CHANGELOG.md entries>"
+        ```
+    - run
+        ```shell
+        sh jslint_ci.sh shGithubPrUpdatePrxxx
+
+        git push . HEAD:beta -f
+
+        sh jslint_ci.sh shGithubPrCreate master beta
+
+        git push upstream alpha -f
+        ```
+        - verify ci-success @ https://github.com/kaizhu256/jslint/actions
+        - verify ci-success @ https://github.com/jslint-org/jslint/actions
+
 1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-v2026.4.30
-1. click `Create pull request`
-1. input `Add a title` with: `# v20yy.mm.dd`
-1. input `Add a description` with:
-```
-- <primary-commit-message>
-- <secondary-commit-message>
-```
-1. verify `commit into jslint-org:beta`
-1. click `Create pull request`
-    - verify ci-success for pull-request
-    - https://github.com/jslint-org/jslint/actions/workflows/on_pull_request.yml
+    - click `Create pull request`
+    - input `Add a title *` with: `# v20yy.mm.dd`
+    - input `Add a description` with:
+        ```
+        <CHANGELOG.md entry #1>
+        <CHANGELOG.md entry extra>
+        ```
+    - verify:
+        - base respository: `jslint-org/jslint`
+        - base: `beta`
+    - click `Create pull request`
+        - verify ci-success @ https://github.com/jslint-org/jslint/actions/workflows/on_pull_request.yml
+
 1. wait awhile before continuing ...
-1. click `Squash and merge`
-    - verify ci-success for upstream-branch-beta
-    - https://github.com/jslint-org/jslint/actions
-1. `sh jslint_ci.sh shGithubPrCleanup`
-    - verify ci-success for origin-branch-alpha
-    - https://github.com/kaizhu256/jslint/actions
-1. `git push upstream alpha -f`
-    - verify ci-success for upstream-branch-alpha
-    - https://github.com/jslint-org/jslint/actions
-1. click `Delete branch`
-1. `git push origin beta:master`
-    - verify ci-success for origin-branch-master
-    - https://github.com/kaizhu256/jslint/actions
-1. `git push upstream beta:master`
-    - verify ci-success for upstream-branch-master
-    - https://github.com/jslint-org/jslint/actions
+    - click `Squash and merge`
+        - verify ci-success @ https://github.com/jslint-org/jslint/actions
+    - run
+        ```shell
+        sh jslint_ci.sh shGithubPrCleanup
+
+        git push upstream alpha -f
+        ```
+        - verify ci-success @ https://github.com/kaizhu256/jslint/actions
+        - verify ci-success @ https://github.com/jslint-org/jslint/actions
+    - click `Delete branch`
+    - run
+        ```shell
+        git push origin beta:master
+
+        git push upstream beta:master
+        ```
+        - verify ci-success @ https://github.com/kaizhu256/jslint/actions
+        - verify ci-success @ https://github.com/jslint-org/jslint/actions
 
 
 <br><br>
 ### branch-master publish
 1. goto https://www.npmjs.com/package/@jslint-org/jslint/access <!--no-validate-->
-1. click `Github Actions`
-1. input `Organization or user*` with: `jslint-org`
-1. input `Repository*` with: `jslint`
-1. input `Workflow filename*` with: `publish.yml`
-1. click `Set up connection` or `Update Package Settings`
-1. `git push upstream beta:master`
-    - verify ci-success for upstream-branch-master
-    - https://github.com/jslint-org/jslint/actions
+    - click `Github Actions`
+    - input `Organization or user*` with: `jslint-org`
+    - input `Repository*` with: `jslint`
+    - input `Workflow filename*` with: `publish.yml`
+    - click `Set up connection` or `Update Package Settings`
+1.
+    - run
+        ```shell
+        git push upstream beta:master
+        ```
+        - verify ci-success @ https://github.com/jslint-org/jslint/actions
 1. goto https://github.com/jslint-org/jslint/releases/new
-1. input `Choose a tag` with: `v20yy.mm.dd`
-1. click `Create new tag: v20yy.mm.dd on publish`
-    - verify correct-year `20yy`
-1. select `Target: master`
-1. select `Previous tag:auto`
-1. input `Release title` with: `v20yy.mm.dd - <primary-commit-message>`
-1. input `Describe this release` with:
-```
-- <primary-commit-message>
-- <secondary-commit-message>
-```
-1. click `Generate release notes`
-1. click `Set as the latest release`
-1. click `Preview` and review
-1. click `Publish release`
-    - verify ci-success for upstream-branch-publish
-    - https://github.com/jslint-org/jslint/actions
-    - verify email-notification `Successfully published @jslint-org/jslint@20yy.mm.dd`
+    - input `Tag: Select tag` with: `v20yy.mm.dd`
+        - click `Create new tag` and click `Create`
+        - verify correct-year `v20yy.mm.dd`
+        - select `Target: master`
+    - input `Release title` with: `v20yy.mm.dd - <CHANGELOG.md entry #1>`
+        - select `Previous tag: Auto`
+        - click `Generate release notes`
+    - input `Write` with:
+        ```
+        <CHANGELOG.md entry #1>
+        <CHANGELOG.md entry extra>
+
+        **Full Changelog**: ...
+        ```
+        - click `Preview` and review
+    - click `Latest`
+    - click `Publish release`
+        - verify ci-success @ https://github.com/jslint-org/jslint/actions
+        - verify email-notification `Successfully published @jslint-org/jslint@20yy.mm.dd`
 
 
 <br><br>
 ### vscode-jslint publish
 1. goto https://github.com/jslint-org/jslint/tree/gh-pages/branch-beta/.artifact/jslint_wrapper_vscode
-1. click `vscode-jslint-20yy.mm.dd.vsix`
-1. click `Raw` to download
+    - click `vscode-jslint-20yy.mm.dd.vsix`
+    - click `Raw` to download
 1. goto https://marketplace.visualstudio.com/manage/publishers/jslint
-1. right-click `Update`
-1. upload downloaded file `vscode-jslint-20yy.mm.dd.vsix`
-1. click 'Upload'
-1. verify email-notification `[Succeeded] Extension publish on Visual Studio Marketplace - vscode-jslint`
+    - move mouse to version-number, right-click, and select `Update`
+    - upload downloaded file `vscode-jslint-20yy.mm.dd.vsix`
+    - click 'Upload'
+        - verify email-notification `[Succeeded] Extension publish on Visual Studio Marketplace - vscode-jslint`
 
 
 <!--

--- a/README.md
+++ b/README.md
@@ -1010,17 +1010,17 @@ if (false) {
 
 <br><br>
 ### pull-request merge
-- find highest issue-number at https://github.com/jslint-org/jslint/issues/, https://github.com/jslint-org/jslint/pulls/, and add +1 to it for PR-xxx
-- checkpoint local-branch-beta
-- `shGitPullrequest beta beta`
+1. find highest issue-number at https://github.com/jslint-org/jslint/issues/, https://github.com/jslint-org/jslint/pulls/, and add +1 to it for PR-xxx
+1. checkpoint local-branch-beta
+1. `sh jslint_ci.sh shGithubPrCreate beta beta # 20xx-xx-xx`
     - verify ci-success for origin-branch-alpha
     - https://github.com/kaizhu256/jslint/actions
-- `git push upstream alpha -f`
+1. `git push upstream alpha -f`
     - verify ci-success for upstream-branch-alpha
     - https://github.com/jslint-org/jslint/actions
-- goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.6.28
-- click `Create pull request`
-- input `Add your description here...` with:
+1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.6.28
+1. click `Create pull request`
+1. input `Add your description here...` with:
 ```
 Fixes #xxx.
 - <primary-commit-message>
@@ -1033,91 +1033,91 @@ This PR will additionally:
 
 <screenshot>
 ```
-- verify `commit into jslint-org:beta`
-- click `Create pull request`
+1. verify `commit into jslint-org:beta`
+1. click `Create pull request`
     - verify ci-success for pull-request
     - https://github.com/jslint-org/jslint/actions/workflows/on_pull_request.yml
-- wait awhile before continuing ...
-- click `Squash and merge`
+1. wait awhile before continuing ...
+1. click `Squash and merge`
     - verify ci-success for upstream-branch-beta
     - https://github.com/jslint-org/jslint/actions
-- `shGitPullrequestCleanup`
+1. `sh jslint_ci.sh shGithubPrCleanup`
     - verify ci-success for origin-branch-alpha
     - https://github.com/kaizhu256/jslint/actions
-- `git push upstream alpha -f`
+1. `git push upstream alpha -f`
     - verify ci-success for upstream-branch-alpha
     - https://github.com/jslint-org/jslint/actions
-- click `Delete branch`
+1. click `Delete branch`
 
 
 <br><br>
 ### branch-master commit
-- update ci.yml to latest nodejs-lts
-- checkpoint local-branch-beta
-- `shGitPullrequest master beta # re-run until version propagates`
+1. update ci.yml to latest nodejs-lts
+1. checkpoint local-branch-beta
+1. `sh jslint_ci.sh shGithubPrCreate master beta # re-run until version propagates`
     - verify ci-success for origin-branch-alpha
     - https://github.com/kaizhu256/jslint/actions
-- `git push upstream alpha -f`
+1. `git push upstream alpha -f`
     - verify ci-success for upstream-branch-alpha
     - https://github.com/jslint-org/jslint/actions
-- goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-v2026.4.30
-- click `Create pull request`
-- input `Add a title` with: `# v20yy.mm.dd`
-- input `Add a description` with:
+1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-v2026.4.30
+1. click `Create pull request`
+1. input `Add a title` with: `# v20yy.mm.dd`
+1. input `Add a description` with:
 ```
 - <primary-commit-message>
 - <secondary-commit-message>
 ```
-- verify `commit into jslint-org:beta`
-- click `Create pull request`
+1. verify `commit into jslint-org:beta`
+1. click `Create pull request`
     - verify ci-success for pull-request
     - https://github.com/jslint-org/jslint/actions/workflows/on_pull_request.yml
-- wait awhile before continuing ...
-- click `Squash and merge`
+1. wait awhile before continuing ...
+1. click `Squash and merge`
     - verify ci-success for upstream-branch-beta
     - https://github.com/jslint-org/jslint/actions
-- `shGitPullrequestCleanup`
+1. `sh jslint_ci.sh shGithubPrCleanup`
     - verify ci-success for origin-branch-alpha
     - https://github.com/kaizhu256/jslint/actions
-- `git push upstream alpha -f`
+1. `git push upstream alpha -f`
     - verify ci-success for upstream-branch-alpha
     - https://github.com/jslint-org/jslint/actions
-- click `Delete branch`
-- `git push origin beta:master`
+1. click `Delete branch`
+1. `git push origin beta:master`
     - verify ci-success for origin-branch-master
     - https://github.com/kaizhu256/jslint/actions
-- `git push upstream beta:master`
+1. `git push upstream beta:master`
     - verify ci-success for upstream-branch-master
     - https://github.com/jslint-org/jslint/actions
 
 
 <br><br>
 ### branch-master publish
-- goto https://www.npmjs.com/package/@jslint-org/jslint/access <!--no-validate-->
-- click `Github Actions`
-- input `Organization or user*` with: `jslint-org`
-- input `Repository*` with: `jslint`
-- input `Workflow filename*` with: `publish.yml`
-- click `Set up connection` or `Update Package Settings`
-- `git push upstream beta:master`
+1. goto https://www.npmjs.com/package/@jslint-org/jslint/access <!--no-validate-->
+1. click `Github Actions`
+1. input `Organization or user*` with: `jslint-org`
+1. input `Repository*` with: `jslint`
+1. input `Workflow filename*` with: `publish.yml`
+1. click `Set up connection` or `Update Package Settings`
+1. `git push upstream beta:master`
     - verify ci-success for upstream-branch-master
     - https://github.com/jslint-org/jslint/actions
-- goto https://github.com/jslint-org/jslint/releases/new
-- input `Choose a tag` with: `v20yy.mm.dd`
-- click `Create new tag: v20yy.mm.dd on publish`
+1. goto https://github.com/jslint-org/jslint/releases/new
+1. input `Choose a tag` with: `v20yy.mm.dd`
+1. click `Create new tag: v20yy.mm.dd on publish`
     - verify correct-year `20yy`
-- select `Target: master`
-- select `Previous tag:auto`
-- input `Release title` with: `v20yy.mm.dd - <primary-commit-message>`
-- input `Describe this release` with:
+1. select `Target: master`
+1. select `Previous tag:auto`
+1. input `Release title` with: `v20yy.mm.dd - <primary-commit-message>`
+1. input `Describe this release` with:
 ```
 - <primary-commit-message>
 - <secondary-commit-message>
 ```
-- click `Generate release notes`
-- click `Set as the latest release`
-- click `Preview` and review
-- click `Publish release`
+1. click `Generate release notes`
+1. click `Set as the latest release`
+1. click `Preview` and review
+1. click `Publish release`
     - verify ci-success for upstream-branch-publish
     - https://github.com/jslint-org/jslint/actions
     - verify email-notification `Successfully published @jslint-org/jslint@20yy.mm.dd`
@@ -1125,14 +1125,14 @@ This PR will additionally:
 
 <br><br>
 ### vscode-jslint publish
-- goto https://github.com/jslint-org/jslint/tree/gh-pages/branch-beta/.artifact/jslint_wrapper_vscode
-- click `vscode-jslint-20yy.mm.dd.vsix`
-- click `Raw` to download
-- goto https://marketplace.visualstudio.com/manage/publishers/jslint
-- right-click `Update`
-- upload downloaded file `vscode-jslint-20yy.mm.dd.vsix`
-- click 'Upload'
-- verify email-notification `[Succeeded] Extension publish on Visual Studio Marketplace - vscode-jslint`
+1. goto https://github.com/jslint-org/jslint/tree/gh-pages/branch-beta/.artifact/jslint_wrapper_vscode
+1. click `vscode-jslint-20yy.mm.dd.vsix`
+1. click `Raw` to download
+1. goto https://marketplace.visualstudio.com/manage/publishers/jslint
+1. right-click `Update`
+1. upload downloaded file `vscode-jslint-20yy.mm.dd.vsix`
+1. click 'Upload'
+1. verify email-notification `[Succeeded] Extension publish on Visual Studio Marketplace - vscode-jslint`
 
 
 <!--

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -6035,6 +6035,7 @@ function jslint_phase3_parse(state) {
             }
         }
         function param_parse() {
+            const is_brace = token_nxt.id === "{";
             let param;
             switch (token_nxt.id) {
             case "...":
@@ -6069,6 +6070,7 @@ function jslint_phase3_parse(state) {
 
 // test_cause:
 // ["function aa(aa=0,[]){}", "param_parse", "required_a_optional_b", "aa", 18]
+// ["function aa(aa=0,{}){}", "param_parse", "required_a_optional_b", "aa", 18]
 
                     warn(
                         "required_a_optional_b",
@@ -6079,17 +6081,24 @@ function jslint_phase3_parse(state) {
                 }
                 param = token_nxt;
                 param.names = [];
-                advance("[");
-                signature.push("[]");
+                advance();
+                if (is_brace) {
+                    signature.push("{");
+                } else {
+                    signature.push("[]");
+                }
                 while (true) {
                     subparam = token_nxt;
                     if (!subparam.identifier) {
 
 // test_cause:
 // ["function aa(aa=0,[]){}", "param_parse", "expected_identifier_a", "]", 19]
+// ["function aa(aa=0,{}){}", "param_parse", "expected_identifier_a", "}", 19]
+// ["function aa({0}){}", "param_parse", "expected_identifier_a", "0", 14]
 
                         return stop("expected_identifier_a");
                     }
+                    //
                     advance();
                     param.names.push(subparam);
 
@@ -6107,6 +6116,7 @@ function jslint_phase3_parse(state) {
                     }
                     advance(",");
                 }
+                //
                 parameters.push(param);
                 advance("]");
                 break;
@@ -6114,6 +6124,7 @@ function jslint_phase3_parse(state) {
                 if (optional !== undefined) {
 
 // test_cause:
+// ["function aa(aa=0,[]){}", "param_parse", "required_a_optional_b", "aa", 18]
 // ["function aa(aa=0,{}){}", "param_parse", "required_a_optional_b", "aa", 18]
 
                     warn(
@@ -6125,18 +6136,24 @@ function jslint_phase3_parse(state) {
                 }
                 param = token_nxt;
                 param.names = [];
-                advance("{");
-                signature.push("{");
+                advance();
+                if (is_brace) {
+                    signature.push("{");
+                } else {
+                    signature.push("[]");
+                }
                 while (true) {
                     subparam = token_nxt;
                     if (!subparam.identifier) {
 
 // test_cause:
+// ["function aa(aa=0,[]){}", "param_parse", "expected_identifier_a", "]", 19]
 // ["function aa(aa=0,{}){}", "param_parse", "expected_identifier_a", "}", 19]
 // ["function aa({0}){}", "param_parse", "expected_identifier_a", "0", 14]
 
                         return stop("expected_identifier_a");
                     }
+                    //
                     survey(subparam);
                     advance();
                     signature.push(subparam.id);
@@ -6173,6 +6190,7 @@ function jslint_phase3_parse(state) {
                     advance(",");
                     signature.push(", ");
                 }
+                //
                 parameters.push(param);
 
 // test_cause:

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -5723,9 +5723,8 @@ function jslint_phase3_parse(state) {
         return the_await;
     }
 
-    function prefix_destructure(the_variable) {
+    function prefix_destructure(role, readonly, name_list) {
         const is_brace = token_nxt.id === "{";
-        const mode_const = the_variable.id === "const";
         const the_destructure = token_nxt;
         let ellipsis;
         let name;
@@ -5773,7 +5772,7 @@ function jslint_phase3_parse(state) {
 // ["let{aa:{aa}}", "prefix_destructure", "recurse", "", 0]
 
                     test_cause("recurse");
-                    prefix_destructure();
+                    prefix_destructure(role, readonly, []);
                 } else {
                     if (!token_nxt.identifier) {
 
@@ -5788,19 +5787,19 @@ function jslint_phase3_parse(state) {
 // '/*jslint node*/\nlet {aa:bb} = {}; bb();'.
 //
 //                         token_nxt.label = name;
-//                         the_variable.names.push(token_nxt);
-//                         enroll(token_nxt, "variable", mode_const);
+//                         name_list.push(token_nxt);
+//                         enroll(token_nxt, role, readonly);
 
                     name = token_nxt;
-                    the_variable.names.push(name);
+                    name_list.push(name);
                     survey(name);
-                    enroll(name, "variable", mode_const);
+                    enroll(name, role, readonly);
                     advance();
                     the_destructure.open = true;
                 }
             } else {
-                the_variable.names.push(name);
-                enroll(name, "variable", mode_const);
+                name_list.push(name);
+                enroll(name, role, readonly);
             }
 
 // Issue #458 - Regression - Warn about variable usage before initialization.
@@ -5837,7 +5836,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["let{bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
 
-            check_ordered(the_variable.id, the_variable.names);
+            check_ordered(role, name_list);
             advance("}");
         } else {
             advance("]");
@@ -7326,16 +7325,15 @@ function jslint_phase3_parse(state) {
     }
 
     function stmt_var() {
-        let mode_const;
+        const readonly = token_now.id === "const";
         let name;
         let the_variable = token_now;
         let variable_prv;
-        mode_const = the_variable.id === "const";
         the_variable.names = [];
 
 // A program may use var or let, but not both.
 
-        if (!mode_const) {
+        if (!readonly) {
             if (mode_var === undefined) {
                 mode_var = the_variable.id;
             } else if (the_variable.id !== mode_var) {
@@ -7406,7 +7404,11 @@ function jslint_phase3_parse(state) {
 
                     warn("unexpected_a", the_variable);
                 }
-                prefix_destructure(the_variable);
+                prefix_destructure(
+                    "variable",
+                    the_variable.id === "const",
+                    the_variable.names
+                );
                 advance("=");
                 the_variable.expression = parse_expression(0);
             } else if (token_nxt.identifier) {
@@ -7421,8 +7423,8 @@ function jslint_phase3_parse(state) {
 
                     warn("unexpected_a", name);
                 }
-                enroll(name, "variable", mode_const);
-                if (token_nxt.id === "=" || mode_const) {
+                enroll(name, "variable", readonly);
+                if (token_nxt.id === "=" || readonly) {
                     advance("=");
 
 // Issue #458 - Regression - Warn about variable usage before initialization.

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -4854,7 +4854,7 @@ function jslint_phase3_parse(state) {
         the_symbol.led_infix = function (left) {
             const the_token = token_now;
             the_token.arity = "binary";
-            if (f !== undefined) {
+            if (typeof f === "function") {
                 return f(left);
             }
             the_token.expression = [left, parse_expression(bp)];
@@ -5723,8 +5723,9 @@ function jslint_phase3_parse(state) {
         return the_await;
     }
 
-    function prefix_destructure(role, readonly, name_list, mode_enroll) {
+    function prefix_destructure(enroll, role, readonly, names) {
         const is_brace = token_now.id === "{";
+        const name_list = [];
         const the_destructure = token_now;
         function name_parse() {
             let name = token_nxt;
@@ -5756,7 +5757,7 @@ function jslint_phase3_parse(state) {
 
                 test_cause("recurse_element");
                 advance();
-                prefix_destructure(role, readonly, [], mode_enroll);
+                prefix_destructure(enroll, role, readonly, names);
                 return;
             }
             if (!name.identifier) {
@@ -5774,20 +5775,14 @@ function jslint_phase3_parse(state) {
             if (is_brace && token_nxt.id === ":") {
                 advance(":");
                 the_destructure.open = true;
-                switch (token_nxt.id) {
-                case "...":
+                if (token_nxt.id === "...") {
 
 // test_cause:
 // ["let{aa:...aa}=0", "name_parse", "unexpected_a", "...", 8]
 
                     return stop("unexpected_a", token_nxt);
                 }
-                if (token_nxt.identifier) {
-                    token_nxt.label = name;
-                    name = token_nxt;
-                    name_push(name);
-                    advance();
-                } else {
+                if (!token_nxt.identifier) {
 
 // test_cause:
 // ["let{aa:[aa]}=0", "name_parse", "recurse_property", "", 0]
@@ -5795,10 +5790,15 @@ function jslint_phase3_parse(state) {
 
                     test_cause("recurse_property");
                     name_parse();
+                    return;
                 }
-            } else {
+                token_nxt.label = name;
+                name = token_nxt;
                 name_push(name);
+                advance();
+                return;
             }
+            name_push(name);
 
 // test_cause:
 // ["const[aa]=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
@@ -5807,7 +5807,7 @@ function jslint_phase3_parse(state) {
             if (token_nxt.id === "=") {
                 advance("=");
                 the_destructure.open = true;
-                name.expression = parse_expression();
+                name.expression = parse_expression(0);
 
 // test_cause:
 // ["let[aa=0]=0", "name_parse", "default", "", 0]
@@ -5818,11 +5818,24 @@ function jslint_phase3_parse(state) {
         }
         function name_push(name) {
             name_list.push(name);
-            if (mode_enroll) {
+            if (typeof enroll === "function") {
                 enroll(name, role, readonly);
+                name.init = true;
             }
-            name.init = true;
+            if (role === "variable") {
+
+// PR-xxx - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
+
+                name.arity = "variable";
+            }
         }
+        //!! if (token_now.id !== "[" && token_now.id !== "{") {
+
+//!! // test_cause:
+//!! // ["(aa)=0", "prefix_destructure", "unexpected_a", "aa", 2]
+
+            //!! return stop("unexpected_a", token_now);
+        //!! }
         while (true) {
             if (!is_brace && token_nxt.id === ",") {
 
@@ -5853,6 +5866,7 @@ function jslint_phase3_parse(state) {
         } else {
             advance("]");
         }
+        names.push(...name_list);
         return the_destructure;
     }
 
@@ -6066,6 +6080,14 @@ function jslint_phase3_parse(state) {
                 break;
             case "[":
             case "{":
+
+// test_cause:
+// ["([aa])=>0", "param_parse", "use_function_not_fart", "=>", 7]
+// ["({aa})=>0", "param_parse", "use_function_not_fart", "=>", 7]
+
+                if (the_function.id === "=>" && !option_dict.fart) {
+                    warn("use_function_not_fart", the_function);
+                }
                 if (optional !== undefined) {
 
 // test_cause:
@@ -6114,7 +6136,7 @@ function jslint_phase3_parse(state) {
                     test_cause("equal");
                     if (token_nxt.id === "=") {
                         advance("=");
-                        subparam.expression = parse_expression();
+                        subparam.expression = parse_expression(0);
                         param.open = true;
                     }
                     if (token_nxt.id !== ",") {
@@ -6166,14 +6188,6 @@ function jslint_phase3_parse(state) {
                     }
                 }
             }
-        }
-
-// test_cause:
-// ["([aa])=>0", "prefix_function_parameter", "use_function_not_fart", "=>", 7]
-// ["({aa})=>0", "prefix_function_parameter", "use_function_not_fart", "=>", 7]
-
-        if (the_function.id === "=>" && !option_dict.fart) {
-            warn("use_function_not_fart", the_function);
         }
         token_now.free = false;
         if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
@@ -7418,10 +7432,10 @@ function jslint_phase3_parse(state) {
                 }
                 advance();
                 prefix_destructure(
+                    enroll,
                     "variable",
-                    the_variable.id === "const",
-                    the_variable.names,
-                    true
+                    readonly,
+                    the_variable.names
                 );
                 advance("=");
                 the_variable.expression = parse_expression(0);
@@ -8033,24 +8047,23 @@ function jslint_phase4_walk(state) {
         let right;
         if (thing.id === "=") {
             if (thing.names !== undefined) {
+                if (Array.isArray(thing.names)) {
+
+// PR-xxx - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
+
+//!! // test_cause:
+//!! // ["[aa]=0", "post_a", "[aa]=0", "", 0]
+
+                    test_cause("[aa]=0");
+                    thing.names.forEach(init_variable);
+                } else {
 
 // test_cause:
-// ["if(0){aa=0}", "post_a", "=", "", 0]
+// ["aa=0", "post_a", "aa=0", "", 0]
 
-                test_cause("=");
-
-// Probably deadcode.
-// if (Array.isArray(thing.names)) {
-//     thing.names.forEach(init_variable);
-// } else {
-//     init_variable(thing.names);
-// }
-
-                jslint_assert(
-                    !Array.isArray(thing.names),
-                    `Expected !Array.isArray(thing.names).`
-                );
-                init_variable(thing.names);
+                    test_cause("aa=0");
+                    init_variable(thing.names);
+                }
             } else {
                 if (lvalue.id === "[" || lvalue.id === "{") {
                     lvalue.expression.forEach(function (thing) {

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -403,14 +403,14 @@ let debugInline = (function () {
     let __consoleError = function () {
         return;
     };
-    function debug(...argv) {
+    function debug(...argList) {
 
-// This function will print <argv> to stderr and then return <argv>[0].
+// This function will print <argList> to stderr and then return <argList>[0].
 
         __consoleError("\n\ndebugInline");
-        __consoleError(...argv);
+        __consoleError(...argList);
         __consoleError("\n");
-        return argv[0];
+        return argList[0];
     }
     debug(); // Coverage-hack.
     __consoleError = console.error; //jslint-ignore-line
@@ -5763,7 +5763,7 @@ function jslint_phase3_parse(state) {
         function name_list_push(name) {
             name_list.push(name);
 
-// PR-xxx - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
+// PR-500 - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
 
             name.arity = role;
             if (enroll) {
@@ -6126,7 +6126,7 @@ function jslint_phase3_parse(state) {
         token_now.free = false;
         if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
 
-// PR-xxx - Unify ES2015-destructure-logic. - function([aa]) {...}
+// PR-500 - Unify ES2015-destructure-logic. - function([aa]) {...}
 
             prefix_destructure(
                 enroll,                 // enroll
@@ -6328,7 +6328,7 @@ function jslint_phase3_parse(state) {
             the_token = token_now.assignment;
             the_token.names = [];
 
-// PR-xxx - Unify ES2015-destructure-logic. - [aa] = ...;
+// PR-500 - Unify ES2015-destructure-logic. - [aa] = ...;
 
             element = prefix_destructure(
                 undefined,              // enroll
@@ -7376,7 +7376,7 @@ function jslint_phase3_parse(state) {
                 }
                 advance();
 
-// PR-xxx - Unify ES2015-destructure-logic. - let [aa] = ...;
+// PR-500 - Unify ES2015-destructure-logic. - let [aa] = ...;
 
                 prefix_destructure(
                     enroll,             // enroll
@@ -7998,7 +7998,7 @@ function jslint_phase4_walk(state) {
             if (thing.names !== undefined) {
                 if (Array.isArray(thing.names)) {
 
-// PR-xxx - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
+// PR-500 - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
 
 // test_cause:
 // [";[aa]=0", "post_a", ";[aa]=0", "", 0]
@@ -8823,7 +8823,7 @@ function jslint_phase4_walk(state) {
             }
         }
 
-// PR-xxx - Unify property the_function.parameters into the_function.names.
+// PR-500 - Unify property the_function.parameters into the_function.names.
 
         thing.names.forEach(function (name) {
             if (name.expression) {

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -5723,37 +5723,47 @@ function jslint_phase3_parse(state) {
         return the_await;
     }
 
-    function prefix_destructure(role, readonly, name_list) {
-        const is_brace = token_nxt.id === "{";
-        const the_destructure = token_nxt;
-        let ellipsis;
-        let name;
-        advance();
-        while (true) {
-            if (!is_brace && token_nxt.id === ",") {
-
-// test_cause:
-// ["let[,aa]=0", "prefix_destructure", "ignore", "", 0]
-
-                test_cause("ignore");
-                advance(",");
-            }
-            ellipsis = token_nxt.id === "...";
-            if (ellipsis) {
-
-// test_cause:
-// ["let[...aa]=0", "prefix_destructure", "ellipsis", "", 0]
-// ["let{...aa}=0", "prefix_destructure", "ellipsis", "", 0]
-
-                test_cause("ellipsis");
+    function prefix_destructure(role, readonly, name_list, mode_enroll) {
+        const is_brace = token_now.id === "{";
+        const the_destructure = token_now;
+        function name_parse() {
+            let name = token_nxt;
+            switch (name.id) {
+            case "...":
                 advance("...");
+                name = token_nxt;
+                if (!name.identifier) {
+
+// test_cause:
+// ["let[...0]=0", "name_parse", "recurse_ellipsis", "", 0]
+
+                    warn("expected_identifier_a", name);
+                }
+
+// test_cause:
+// ["let[...aa]=0", "name_parse", "recurse_ellipsis", "", 0]
+// ["let{...aa}=0", "name_parse", "recurse_ellipsis", "", 0]
+
+                test_cause("recurse_ellipsis");
+                name_parse();
+                return true;
+            case "[":
+            case "{":
+
+// test_cause:
+// ["let[[aa]]=0", "name_parse", "recurse_element", "", 0]
+// ["let[{aa}]=0", "name_parse", "recurse_element", "", 0]
+
+                test_cause("recurse_element");
+                advance();
+                prefix_destructure(role, readonly, [], mode_enroll);
+                return;
             }
-            name = token_nxt;
             if (!name.identifier) {
 
 // test_cause:
-// ["let[0]", "prefix_destructure", "expected_identifier_a", "0", 5]
-// ["let{0}", "prefix_destructure", "expected_identifier_a", "0", 5]
+// ["let[0]=0", "name_parse", "expected_identifier_a", "0", 5]
+// ["let{0}=0", "name_parse", "expected_identifier_a", "0", 5]
 
                 return stop("expected_identifier_a", name);
             }
@@ -5763,52 +5773,31 @@ function jslint_phase3_parse(state) {
             advance();
             if (is_brace && token_nxt.id === ":") {
                 advance(":");
-
-// Recurse prefix_destructure().
-
-                if (token_nxt.id === "{" || token_nxt.id === "[") {
-
-// test_cause:
-// ["let{aa:{aa}}", "prefix_destructure", "recurse", "", 0]
-
-                    test_cause("recurse");
-                    prefix_destructure(role, readonly, []);
-                } else {
-                    if (!token_nxt.identifier) {
+                the_destructure.open = true;
+                switch (token_nxt.id) {
+                case "...":
 
 // test_cause:
-// ["let{aa:0}", "prefix_destructure", "expected_identifier_a", "0", 8]
+// ["let{aa:...aa}=0", "name_parse", "unexpected_a", "...", 8]
 
-                        return stop("expected_identifier_a", token_nxt);
-                    }
-
-// PR-363 - Bugfix
-// Add test against false-warning <uninitialized 'bb'> in code
-// '/*jslint node*/\nlet {aa:bb} = {}; bb();'.
-//
-//                         token_nxt.label = name;
-//                         name_list.push(token_nxt);
-//                         enroll(token_nxt, role, readonly);
-
+                    return stop("unexpected_a", token_nxt);
+                }
+                if (token_nxt.identifier) {
+                    token_nxt.label = name;
                     name = token_nxt;
-                    name_list.push(name);
-                    survey(name);
-                    enroll(name, role, readonly);
+                    name_push(name);
                     advance();
-                    the_destructure.open = true;
+                } else {
+
+// test_cause:
+// ["let{aa:[aa]}=0", "name_parse", "recurse_property", "", 0]
+// ["let{aa:{aa}}=0", "name_parse", "recurse_property", "", 0]
+
+                    test_cause("recurse_property");
+                    name_parse();
                 }
             } else {
-                name_list.push(name);
-                enroll(name, role, readonly);
-            }
-
-// Issue #458 - Regression - Warn about variable usage before initialization.
-
-//                    name.dead = false;
-
-            name.init = true;
-            if (ellipsis) {
-                break;
+                name_push(name);
             }
 
 // test_cause:
@@ -5816,15 +5805,38 @@ function jslint_phase3_parse(state) {
 // ["const{aa}=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
 
             if (token_nxt.id === "=") {
+                advance("=");
+                the_destructure.open = true;
+                name.expression = parse_expression();
 
 // test_cause:
-// ["let[aa=0]", "prefix_destructure", "assign", "", 0]
-// ["let{aa=0}", "prefix_destructure", "assign", "", 0]
+// ["let[aa=0]=0", "name_parse", "default", "", 0]
+// ["let{aa=0}=0", "name_parse", "default", "", 0]
 
-                test_cause("assign");
-                advance("=");
-                name.expression = parse_expression();
-                the_destructure.open = true;
+                test_cause("default");
+            }
+        }
+        function name_push(name) {
+            name_list.push(name);
+            if (mode_enroll) {
+                enroll(name, role, readonly);
+            }
+            name.init = true;
+        }
+        while (true) {
+            if (!is_brace && token_nxt.id === ",") {
+
+// test_cause:
+// ["let[,aa]=0", "prefix_destructure", "ignore", "", 0]
+
+                test_cause("ignore");
+                advance(",");
+            }
+
+// Break from ellipsis.
+
+            if (name_parse()) {
+                break;
             }
             if (token_nxt.id !== ",") {
                 break;
@@ -5834,13 +5846,14 @@ function jslint_phase3_parse(state) {
         if (is_brace) {
 
 // test_cause:
-// ["let{bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
+// ["let{bb,aa}=0", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
 
             check_ordered(role, name_list);
             advance("}");
         } else {
             advance("]");
         }
+        return the_destructure;
     }
 
     function prefix_ellipsis() {
@@ -6013,17 +6026,16 @@ function jslint_phase3_parse(state) {
 // This function will parse input <parameters> at beginning of <the_function>
 
         const parameters = [];
-        const signature = ["("];
         let optional;
-        function advance_and_signature_push(id) {
+        let signature = "(";
+        function advance_and_signature_append(id) {
             advance(id);
+            signature += id;
             switch (id) {
             case ",":
             case ":":
-                signature.push(id + " ");
+                signature += " ";
                 break;
-            default:
-                signature.push(id);
             }
         }
         function param_parse() {
@@ -6032,7 +6044,7 @@ function jslint_phase3_parse(state) {
             let subparam;
             switch (param.id) {
             case "...":
-                advance_and_signature_push("...");
+                advance_and_signature_append("...");
                 param = token_nxt;
                 if (optional !== undefined) {
 
@@ -6050,7 +6062,7 @@ function jslint_phase3_parse(state) {
                 }
                 enroll(param, "parameter", false);
                 parameters.push(param);
-                advance_and_signature_push(param.id);
+                advance_and_signature_append(param.id);
                 break;
             case "[":
             case "{":
@@ -6063,7 +6075,7 @@ function jslint_phase3_parse(state) {
                     warn("required_a_optional_b", param, param.id, optional.id);
                 }
                 param.names = [];
-                advance_and_signature_push(param.id);
+                advance_and_signature_append(param.id);
                 while (true) {
                     subparam = token_nxt;
                     if (!subparam.identifier) {
@@ -6075,12 +6087,12 @@ function jslint_phase3_parse(state) {
 
                         return stop("expected_identifier_a", subparam);
                     }
-                    advance_and_signature_push(subparam.id);
+                    advance_and_signature_append(subparam.id);
                     if (is_brace) {
                         survey(subparam);
                         if (token_nxt.id === ":") {
-                            advance_and_signature_push(":");
-                            advance_and_signature_push(token_nxt.id);
+                            advance_and_signature_append(":");
+                            advance_and_signature_append(token_nxt.id);
                             token_now.label = subparam;
                             subparam = token_now;
                             if (!subparam.identifier) {
@@ -6108,11 +6120,11 @@ function jslint_phase3_parse(state) {
                     if (token_nxt.id !== ",") {
                         break;
                     }
-                    advance_and_signature_push(",");
+                    advance_and_signature_append(",");
                 }
                 parameters.push(param);
                 if (is_brace) {
-                    advance_and_signature_push("}");
+                    advance_and_signature_append("}");
 
 // test_cause:
 // ["
@@ -6121,7 +6133,7 @@ function jslint_phase3_parse(state) {
 
                     check_ordered("parameter", param.names);
                 } else {
-                    advance_and_signature_push("]");
+                    advance_and_signature_append("]");
                 }
                 break;
             default:
@@ -6134,7 +6146,7 @@ function jslint_phase3_parse(state) {
                 }
                 enroll(param, "parameter", false);
                 parameters.push(param);
-                advance_and_signature_push(param.id);
+                advance_and_signature_append(param.id);
                 if (token_nxt.id === "=") {
                     advance("=");
                     optional = param;
@@ -6170,12 +6182,12 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id !== ",") {
                     break;
                 }
-                advance_and_signature_push(",");
+                advance_and_signature_append(",");
             }
         }
-        advance_and_signature_push(")");
+        advance_and_signature_append(")");
         the_function.parameters = parameters;
-        the_function.signature = signature.join("");
+        the_function.signature = signature;
     }
 
     function prefix_lbrace() {
@@ -7404,10 +7416,12 @@ function jslint_phase3_parse(state) {
 
                     warn("unexpected_a", the_variable);
                 }
+                advance();
                 prefix_destructure(
                     "variable",
                     the_variable.id === "const",
-                    the_variable.names
+                    the_variable.names,
+                    true
                 );
                 advance("=");
                 the_variable.expression = parse_expression(0);

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -5274,6 +5274,7 @@ function jslint_phase3_parse(state) {
 
             warn("wrap_fart_parameter", token_now);
             the_fart.name = "anonymous";
+            the_fart.names = [token_prv];
             the_fart.parameters = [token_prv];
             the_fart.signature = token_prv.id;
             enroll(token_prv, "parameter", false);
@@ -5740,24 +5741,23 @@ function jslint_phase3_parse(state) {
         enroll,
         role,
         readonly,
-        names,
+        name_list,
         the_function,
         the_function_toplevel
     ) {
         const is_brace = token_now.id === "{";
-        const name_list = [];
-        const parameters = the_function?.parameters || [];
-        const signature = the_function?.signature || [];
         const the_destructure = token_now;
         let optional;
         function advance_and_signature_push(id) {
             advance(id);
-            signature.push(id);
-            switch (id) {
-            case ",":
-            case ":":
-                signature.push(" ");
-                break;
+            if (the_function?.signature) {
+                the_function.signature.push(id);
+                switch (id) {
+                case ",":
+                case ":":
+                    the_function.signature.push(" ");
+                    break;
+                }
             }
         }
         function name_list_push(name) {
@@ -5823,13 +5823,26 @@ function jslint_phase3_parse(state) {
 // ["let[{aa}]=0", "name_parse", "recurse_element", "", 0]
 
                 test_cause("recurse_element");
-                parameters_push(name);
                 advance_and_signature_push(token_nxt.id);
+                if (the_function_toplevel) {
+                    the_function.parameters.push(name);
+                    name.names = [];
+                    prefix_destructure(
+                        enroll,         // enroll
+                        role,           // role
+                        readonly,       // readonly
+                        name.names,     // name_list
+                        the_function,   // the_function
+                        false           // the_function_toplevel
+                    );
+                    name_list.push(...name.names);
+                    return;
+                }
                 prefix_destructure(
                     enroll,             // enroll
                     role,               // role
                     readonly,           // readonly
-                    names,              // names
+                    name_list,          // name_list
                     the_function,       // the_function
                     false               // the_function_toplevel
                 );
@@ -5852,7 +5865,6 @@ function jslint_phase3_parse(state) {
             if (is_brace) {
                 survey(name);
             }
-            parameters_push(name);
             advance_and_signature_push(token_nxt.id);
             if (is_brace && token_nxt.id === ":") {
                 advance_and_signature_push(":");
@@ -5876,9 +5888,15 @@ function jslint_phase3_parse(state) {
                 }
                 token_nxt.label = name;
                 name = token_nxt;
+                if (the_function_toplevel) {
+                    the_function.parameters.push(name);
+                }
                 name_list_push(name);
                 advance_and_signature_push(token_nxt.id);
                 return;
+            }
+            if (the_function_toplevel) {
+                the_function.parameters.push(name);
             }
             name_list_push(name);
 
@@ -5907,13 +5925,6 @@ function jslint_phase3_parse(state) {
 // ["function aa(aa=0,bb){}", "name_parse", "required_a_optional_b", "aa", 18]
 
                 warn("required_a_optional_b", name, name.id, optional.id);
-            }
-        }
-        function parameters_push(name) {
-            if (the_function_toplevel) {
-                names = [];
-                name.names = names;
-                parameters.push(name);
             }
         }
         while (true) {
@@ -5952,7 +5963,6 @@ function jslint_phase3_parse(state) {
         } else {
             advance_and_signature_push("]");
         }
-        names.push(...name_list);
         return the_destructure;
     }
 
@@ -6125,6 +6135,7 @@ function jslint_phase3_parse(state) {
 
 // This function will parse input <parameters> at beginning of <the_function>
 
+        the_function.names = [];
         the_function.parameters = [];
         the_function.signature = ["("];
         token_now.free = false;
@@ -6136,7 +6147,7 @@ function jslint_phase3_parse(state) {
                 enroll,                 // enroll
                 "parameter",            // role
                 false,                  // readonly
-                [],                     // names
+                the_function.names,     // name_list
                 the_function,           // the_function
                 true                    // the_function_toplevel
             );
@@ -6338,7 +6349,7 @@ function jslint_phase3_parse(state) {
                 undefined,              // enroll
                 "variable",             // role
                 false,                  // readonly
-                the_token.names,        // names
+                the_token.names,        // name_list
                 undefined,              // the_function
                 false                   // the_function_toplevel
             );
@@ -7386,7 +7397,7 @@ function jslint_phase3_parse(state) {
                     enroll,             // enroll
                     "variable",         // role
                     readonly,           // readonly
-                    the_variable.names, // names
+                    the_variable.names, // name_list
                     undefined,          // the_function
                     false               // the_function_toplevel
                 );
@@ -10273,14 +10284,10 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
             level,
             line,
             name,
-
-// Bugfix - fix html-report from crashing if parameters is undefined.
-
-            parameters = [],
+            names = [],
             signature
         } = the_function;
         let list = Object.keys(context);
-        let params;
         html += (
             "<div class=\"level level" + htmlEscape(level) + "\">"
             + address(line, from + 1)
@@ -10300,26 +10307,9 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
             )
             + "</dfn>"
         );
-        params = [];
-        parameters.forEach(function extract({
-            id,
-            names
-        }) {
-            switch (id) {
-            case "[":
-            case "{":
-
-// Recurse extract().
-
-                names.forEach(extract);
-                break;
-            case "ignore":
-                break;
-            default:
-                params.push(id);
-            }
-        });
-        html += detail("parameter", params.sort());
+        html += detail("parameter", names.map(function ({id}) {
+            return id;
+        }).sort());
         list.sort();
         html += detail("variable", list.filter(function (id) {
             return (

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -5736,22 +5736,42 @@ function jslint_phase3_parse(state) {
         return the_await;
     }
 
-    function prefix_destructure(enroll, role, readonly, names) {
+    function prefix_destructure(enroll, role, readonly, names, signature) {
         const is_brace = token_now.id === "{";
         const name_list = [];
         const the_destructure = token_now;
+        function advance_and_signature_push(id) {
+            advance(id);
+            signature.push(id);
+            switch (id) {
+            case ",":
+            case ":":
+                signature.push(" ");
+                break;
+            }
+        }
+        function name_list_push(name) {
+            name_list.push(name);
+            if (typeof enroll === "function") {
+                enroll(name, role, readonly);
+                name.init = true;
+            }
+
+// PR-xxx - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
+
+            name.arity = role;
+        }
         function name_parse() {
             let name = token_nxt;
             switch (name.id) {
             case "...":
-                advance("...");
-                name = token_nxt;
-                if (!name.identifier) {
+                advance_and_signature_push("...");
+                if (token_nxt.id === "...") {
 
 // test_cause:
-// ["let[...0]=0", "name_parse", "recurse_ellipsis", "", 0]
+// ["let[... ...]=0", "name_parse", "unexpected_a_after_b", "...", 5]
 
-                    warn("expected_identifier_a", name);
+                    return stop("unexpected_a_after_b", name, name.id, "...");
                 }
 
 // test_cause:
@@ -5769,13 +5789,18 @@ function jslint_phase3_parse(state) {
 // ["let[{aa}]=0", "name_parse", "recurse_element", "", 0]
 
                 test_cause("recurse_element");
-                advance();
-                prefix_destructure(enroll, role, readonly, names);
+                advance_and_signature_push(token_nxt.id);
+                prefix_destructure(enroll, role, readonly, names, signature);
                 return;
             }
             if (!name.identifier) {
 
 // test_cause:
+// ["function aa(aa=0,[]){}", "name_parse", "expected_identifier_a", "]", 19]
+// ["function aa(aa=0,{}){}", "name_parse", "expected_identifier_a", "}", 19]
+// ["function aa({0}){}", "name_parse", "expected_identifier_a", "0", 14]
+// ["function aa({aa:0}){}", "name_parse", "expected_identifier_a", "0", 17]
+// ["let[...0]=0", "name_parse", "expected_identifier_a", "0", 8]
 // ["let[0]=0", "name_parse", "expected_identifier_a", "0", 5]
 // ["let{0}=0", "name_parse", "expected_identifier_a", "0", 5]
 
@@ -5784,9 +5809,9 @@ function jslint_phase3_parse(state) {
             if (is_brace) {
                 survey(name);
             }
-            advance();
+            advance_and_signature_push(token_nxt.id);
             if (is_brace && token_nxt.id === ":") {
-                advance(":");
+                advance_and_signature_push(":");
                 the_destructure.open = true;
                 if (token_nxt.id === "...") {
 
@@ -5807,38 +5832,29 @@ function jslint_phase3_parse(state) {
                 }
                 token_nxt.label = name;
                 name = token_nxt;
-                name_push(name);
-                advance();
+                name_list_push(name);
+                advance_and_signature_push(token_nxt.id);
                 return;
             }
-            name_push(name);
+            name_list_push(name);
 
 // test_cause:
 // ["const[aa]=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
 // ["const{aa}=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
 
             if (token_nxt.id === "=") {
-                advance("=");
+                advance_and_signature_push("=");
                 the_destructure.open = true;
                 name.expression = parse_expression(0);
 
 // test_cause:
+// ["function aa([aa=aa],aa){}", "name_parse", "default", "", 0]
+// ["function aa({aa=aa},aa){}", "name_parse", "default", "", 0]
 // ["let[aa=0]=0", "name_parse", "default", "", 0]
 // ["let{aa=0}=0", "name_parse", "default", "", 0]
 
                 test_cause("default");
             }
-        }
-        function name_push(name) {
-            name_list.push(name);
-            if (typeof enroll === "function") {
-                enroll(name, role, readonly);
-                name.init = true;
-            }
-
-// PR-xxx - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
-
-            name.arity = role;
         }
         while (true) {
             if (!is_brace && token_nxt.id === ",") {
@@ -5848,7 +5864,7 @@ function jslint_phase3_parse(state) {
 // ["let[,aa]=0", "prefix_destructure", "ignore", "", 0]
 
                 test_cause("ignore");
-                advance(",");
+                advance_and_signature_push(",");
             }
 
 // Break from ellipsis.
@@ -5859,17 +5875,20 @@ function jslint_phase3_parse(state) {
             if (token_nxt.id !== ",") {
                 break;
             }
-            advance(",");
+            advance_and_signature_push(",");
         }
         if (is_brace) {
 
 // test_cause:
+// ["
+// function aa({bb,aa}){}
+// ", "check_ordered", "expected_a_b_before_c_d", "aa", 17]
 // ["let{bb,aa}=0", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
 
             check_ordered(role, name_list);
-            advance("}");
+            advance_and_signature_push("}");
         } else {
-            advance("]");
+            advance_and_signature_push("]");
         }
         names.push(...name_list);
         return the_destructure;
@@ -6046,24 +6065,22 @@ function jslint_phase3_parse(state) {
 
         const parameters = [];
         let optional;
-        let signature = "(";
-        function advance_and_signature_append(id) {
+        let signature = ["("];
+        function advance_and_signature_push(id) {
             advance(id);
-            signature += id;
+            signature.push(id);
             switch (id) {
             case ",":
             case ":":
-                signature += " ";
+                signature.push(" ");
                 break;
             }
         }
         function param_parse() {
-            const is_brace = token_nxt.id === "{";
             let param = token_nxt;
-            let subparam;
             switch (param.id) {
             case "...":
-                advance_and_signature_append("...");
+                advance_and_signature_push("...");
                 param = token_nxt;
                 if (optional !== undefined) {
 
@@ -6081,7 +6098,7 @@ function jslint_phase3_parse(state) {
                 }
                 enroll(param, "parameter", false);
                 parameters.push(param);
-                advance_and_signature_append(param.id);
+                advance_and_signature_push(param.id);
                 break;
             case "[":
             case "{":
@@ -6102,66 +6119,18 @@ function jslint_phase3_parse(state) {
                     warn("required_a_optional_b", param, param.id, optional.id);
                 }
                 param.names = [];
-                advance_and_signature_append(param.id);
-                while (true) {
-                    subparam = token_nxt;
-                    if (!subparam.identifier) {
 
-// test_cause:
-// ["function aa(aa=0,[]){}", "param_parse", "expected_identifier_a", "]", 19]
-// ["function aa(aa=0,{}){}", "param_parse", "expected_identifier_a", "}", 19]
-// ["function aa({0}){}", "param_parse", "expected_identifier_a", "0", 14]
+// PR-xxx - Unify ES2015-destructure-logic. - function([aa]) {...}
 
-                        return stop("expected_identifier_a", subparam);
-                    }
-                    advance_and_signature_append(subparam.id);
-                    if (is_brace) {
-                        survey(subparam);
-                        if (token_nxt.id === ":") {
-                            advance_and_signature_append(":");
-                            advance_and_signature_append(token_nxt.id);
-                            token_now.label = subparam;
-                            subparam = token_now;
-                            if (!subparam.identifier) {
-
-// test_cause:
-// ["function aa({aa:0}){}", "param_parse", "expected_identifier_a", "0", 17]
-
-                                return stop("expected_identifier_a", subparam);
-                            }
-                        }
-                    }
-                    enroll(subparam, "parameter", false);
-                    param.names.push(subparam);
-
-// test_cause:
-// ["function aa([aa=aa],aa){}", "param_parse", "equal", "", 0]
-// ["function aa({aa=aa},aa){}", "param_parse", "equal", "", 0]
-
-                    test_cause("equal");
-                    if (token_nxt.id === "=") {
-                        advance("=");
-                        subparam.expression = parse_expression(0);
-                        param.open = true;
-                    }
-                    if (token_nxt.id !== ",") {
-                        break;
-                    }
-                    advance_and_signature_append(",");
-                }
+                advance_and_signature_push(param.id);
+                prefix_destructure(
+                    enroll,
+                    "parameter",
+                    false,
+                    param.names,
+                    signature
+                );
                 parameters.push(param);
-                if (is_brace) {
-                    advance_and_signature_append("}");
-
-// test_cause:
-// ["
-// function aa({bb,aa}){}
-// ", "check_ordered", "expected_a_b_before_c_d", "aa", 17]
-
-                    check_ordered("parameter", param.names);
-                } else {
-                    advance_and_signature_append("]");
-                }
                 break;
             default:
                 if (!param.identifier) {
@@ -6173,7 +6142,7 @@ function jslint_phase3_parse(state) {
                 }
                 enroll(param, "parameter", false);
                 parameters.push(param);
-                advance_and_signature_append(param.id);
+                advance_and_signature_push(param.id);
                 if (token_nxt.id === "=") {
                     advance("=");
                     optional = param;
@@ -6201,12 +6170,12 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id !== ",") {
                     break;
                 }
-                advance_and_signature_append(",");
+                advance_and_signature_push(",");
             }
         }
-        advance_and_signature_append(")");
+        advance_and_signature_push(")");
         the_function.parameters = parameters;
-        the_function.signature = signature;
+        the_function.signature = signature.join("");
     }
 
     function prefix_lbrace() {
@@ -6387,28 +6356,25 @@ function jslint_phase3_parse(state) {
     }
 
     function prefix_lbracket() {
-        const the_token = token_now;
         let element;
-        let the_assignment;
+        let the_token = token_now;
         the_token.expression = [];
         if (the_token.assignment) {
-            the_assignment = Object.assign(token_now.assignment, {
-                arity: "assignment",
-                expression: [],
-                names: []
-            });
+            the_token = token_now.assignment;
+            the_token.names = [];
 
-// PR-xxx - Unify ES2015-destructure-logic.
+// PR-xxx - Unify ES2015-destructure-logic. - [aa] = ...;
 
             element = prefix_destructure(
                 undefined,
                 "variable",
                 false,
-                the_assignment.names
+                the_token.names,
+                []
             );
             advance("=");
             symbol("=").led_infix(element);
-            return the_assignment;
+            return the_token;
         }
         if (token_nxt.id !== "]") {
 
@@ -7444,13 +7410,14 @@ function jslint_phase3_parse(state) {
                 }
                 advance();
 
-// PR-xxx - Unify ES2015-destructure-logic.
+// PR-xxx - Unify ES2015-destructure-logic. - let [aa] = ...;
 
                 prefix_destructure(
                     enroll,
                     "variable",
                     readonly,
-                    the_variable.names
+                    the_variable.names,
+                    []
                 );
                 advance("=");
                 the_variable.expression = parse_expression(0);

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -6098,9 +6098,30 @@ function jslint_phase3_parse(state) {
 
                         return stop("expected_identifier_a");
                     }
-                    //
-                    advance();
-                    param.names.push(subparam);
+                    if (is_brace) {
+                        survey(subparam);
+                        advance();
+                        signature.push(subparam.id);
+                        if (token_nxt.id === ":") {
+                            advance(":");
+                            advance();
+                            token_now.label = subparam;
+                            subparam = token_now;
+                            if (!subparam.identifier) {
+
+// test_cause:
+// ["function aa({aa:0}){}", "param_parse", "expected_identifier_a", "}", 18]
+
+                                return stop(
+                                    "expected_identifier_a",
+                                    token_nxt
+                                );
+                            }
+                        }
+                    } else {
+                        advance();
+                        param.names.push(subparam);
+                    }
 
 // test_cause:
 // ["function aa([aa=aa],aa){}", "param_parse", "equal", "", 0]
@@ -6171,25 +6192,29 @@ function jslint_phase3_parse(state) {
 
                         return stop("expected_identifier_a");
                     }
-                    //
-                    survey(subparam);
-                    advance();
-                    signature.push(subparam.id);
-                    if (token_nxt.id === ":") {
-                        advance(":");
+                    if (is_brace) {
+                        survey(subparam);
                         advance();
-                        token_now.label = subparam;
-                        subparam = token_now;
-                        if (!subparam.identifier) {
+                        signature.push(subparam.id);
+                        if (token_nxt.id === ":") {
+                            advance(":");
+                            advance();
+                            token_now.label = subparam;
+                            subparam = token_now;
+                            if (!subparam.identifier) {
 
 // test_cause:
 // ["function aa({aa:0}){}", "param_parse", "expected_identifier_a", "}", 18]
 
-                            return stop(
-                                "expected_identifier_a",
-                                token_nxt
-                            );
+                                return stop(
+                                    "expected_identifier_a",
+                                    token_nxt
+                                );
+                            }
                         }
+                    } else {
+                        advance();
+                        param.names.push(subparam);
                     }
 
 // test_cause:

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -3105,7 +3105,7 @@ function jslint_phase2_lex(state) {
                             char_after();
                             break;
 
-// PR-xxx - Add ES2025-feature RegExp Modifiers.
+// PR-499 - Add ES2025-feature RegExp Modifiers.
 
                         case "-":
                         case "i":
@@ -3300,7 +3300,7 @@ function jslint_phase2_lex(state) {
 
             switch (!flag[char] && char) {
 
-// PR-xxx - Add ES2022-feature RegExp Match Indices.
+// PR-499 - Add ES2022-feature RegExp Match Indices.
 
             case "d":
                 break;
@@ -3311,14 +3311,14 @@ function jslint_phase2_lex(state) {
             case "m":
                 break;
 
-// PR-xxx - Add ES2018-feature s (dotall) flag for regular expressions.
+// PR-499 - Add ES2018-feature s (dotall) flag for regular expressions.
 
             case "s":
                 break;
             case "u":
                 break;
 
-// PR-xxx - Add ES2024-feature RegExp v flag with set-notation + str-properties.
+// PR-499 - Add ES2024-feature RegExp v flag with set-notation + str-properties.
 
             case "v":
                 break;
@@ -5248,7 +5248,7 @@ function jslint_phase3_parse(state) {
                 return stop("wrap_fart_parameter", token_now);
             }
 
-// PR-xxx - Update ES2015-feature arrow, to continue parsing unwrapped-form
+// PR-499 - Update ES2015-feature arrow, to continue parsing unwrapped-form
 // with warning, instead of stopping.
 
 // test_cause:
@@ -8162,7 +8162,7 @@ function jslint_phase4_walk(state) {
         } else if (thing.id === "." || thing.id === "?.") {
             if (thing.expression.id === "RegExp") {
 
-// PR-xxx - Relax warning for ES2025-feature RegExp.escape().
+// PR-499 - Relax warning for ES2025-feature RegExp.escape().
 
                 if (!thing.name || thing.name.id !== "escape") {
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -6036,11 +6036,11 @@ function jslint_phase3_parse(state) {
         }
         function param_parse() {
             const is_brace = token_nxt.id === "{";
-            let param;
-            switch (token_nxt.id) {
+            let param = token_nxt;
+            switch (param.id) {
             case "...":
-                signature.push("...");
                 advance("...");
+                signature.push("...");
                 if (optional !== undefined) {
 
 // test_cause:
@@ -6061,104 +6061,11 @@ function jslint_phase3_parse(state) {
                     return stop("expected_identifier_a");
                 }
                 param = token_nxt;
-                parameters.push(param);
                 advance();
+                parameters.push(param);
                 signature.push(param.id);
                 break;
             case "[":
-                if (optional !== undefined) {
-
-// test_cause:
-// ["function aa(aa=0,[]){}", "param_parse", "required_a_optional_b", "aa", 18]
-// ["function aa(aa=0,{}){}", "param_parse", "required_a_optional_b", "aa", 18]
-
-                    warn(
-                        "required_a_optional_b",
-                        token_nxt,
-                        token_nxt.id,
-                        optional.id
-                    );
-                }
-                param = token_nxt;
-                param.names = [];
-                advance();
-                if (is_brace) {
-                    signature.push("{");
-                } else {
-                    signature.push("[]");
-                }
-                while (true) {
-                    subparam = token_nxt;
-                    if (!subparam.identifier) {
-
-// test_cause:
-// ["function aa(aa=0,[]){}", "param_parse", "expected_identifier_a", "]", 19]
-// ["function aa(aa=0,{}){}", "param_parse", "expected_identifier_a", "}", 19]
-// ["function aa({0}){}", "param_parse", "expected_identifier_a", "0", 14]
-
-                        return stop("expected_identifier_a");
-                    }
-                    if (is_brace) {
-                        survey(subparam);
-                        advance();
-                        signature.push(subparam.id);
-                        if (token_nxt.id === ":") {
-                            advance(":");
-                            advance();
-                            token_now.label = subparam;
-                            subparam = token_now;
-                            if (!subparam.identifier) {
-
-// test_cause:
-// ["function aa({aa:0}){}", "param_parse", "expected_identifier_a", "}", 18]
-
-                                return stop(
-                                    "expected_identifier_a",
-                                    token_nxt
-                                );
-                            }
-                        }
-                    } else {
-                        advance();
-                        param.names.push(subparam);
-                    }
-
-// test_cause:
-// ["function aa([aa=aa],aa){}", "param_parse", "equal", "", 0]
-// ["function aa({aa=aa},aa){}", "param_parse", "equal", "", 0]
-
-                    test_cause("equal");
-                    if (token_nxt.id === "=") {
-                        advance("=");
-                        subparam.expression = parse_expression();
-                        param.open = true;
-                    }
-                    if (is_brace) {
-                        param.names.push(subparam);
-                    }
-                    if (token_nxt.id !== ",") {
-                        break;
-                    }
-                    advance(",");
-                    if (is_brace) {
-                        signature.push(", ");
-                    }
-                }
-                parameters.push(param);
-                if (is_brace) {
-
-// test_cause:
-// ["
-// function aa({bb,aa}){}
-// ", "check_ordered", "expected_a_b_before_c_d", "aa", 17]
-
-                    check_ordered("parameter", param.names);
-                    advance("}");
-                    signature.push("}");
-                } else {
-                    advance("]");
-                }
-                break;
             case "{":
                 if (optional !== undefined) {
 
@@ -6173,14 +6080,9 @@ function jslint_phase3_parse(state) {
                         optional.id
                     );
                 }
-                param = token_nxt;
-                param.names = [];
                 advance();
-                if (is_brace) {
-                    signature.push("{");
-                } else {
-                    signature.push("[]");
-                }
+                param.names = [];
+                signature.push(param.id);
                 while (true) {
                     subparam = token_nxt;
                     if (!subparam.identifier) {
@@ -6192,9 +6094,9 @@ function jslint_phase3_parse(state) {
 
                         return stop("expected_identifier_a");
                     }
+                    advance();
                     if (is_brace) {
                         survey(subparam);
-                        advance();
                         signature.push(subparam.id);
                         if (token_nxt.id === ":") {
                             advance(":");
@@ -6213,7 +6115,6 @@ function jslint_phase3_parse(state) {
                             }
                         }
                     } else {
-                        advance();
                         param.names.push(subparam);
                     }
 
@@ -6240,6 +6141,8 @@ function jslint_phase3_parse(state) {
                 }
                 parameters.push(param);
                 if (is_brace) {
+                    advance("}");
+                    signature.push("}");
 
 // test_cause:
 // ["
@@ -6247,8 +6150,6 @@ function jslint_phase3_parse(state) {
 // ", "check_ordered", "expected_a_b_before_c_d", "aa", 17]
 
                     check_ordered("parameter", param.names);
-                    advance("}");
-                    signature.push("}");
                 } else {
                     advance("]");
                 }
@@ -6262,12 +6163,12 @@ function jslint_phase3_parse(state) {
                     return stop("expected_identifier_a");
                 }
                 param = token_nxt;
-                parameters.push(param);
                 advance();
+                parameters.push(param);
                 signature.push(param.id);
                 if (token_nxt.id === "=") {
-                    optional = param;
                     advance("=");
+                    optional = param;
                     param.expression = parse_expression(0);
                 } else {
                     if (optional !== undefined) {

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -6103,22 +6103,40 @@ function jslint_phase3_parse(state) {
                     param.names.push(subparam);
 
 // test_cause:
-// ["function aa([aa=aa],aa){}", "param_parse", "id", "", 0]
+// ["function aa([aa=aa],aa){}", "param_parse", "equal", "", 0]
+// ["function aa({aa=aa},aa){}", "param_parse", "equal", "", 0]
 
-                    test_cause("id");
+                    test_cause("equal");
                     if (token_nxt.id === "=") {
                         advance("=");
                         subparam.expression = parse_expression();
                         param.open = true;
                     }
+                    if (is_brace) {
+                        param.names.push(subparam);
+                    }
                     if (token_nxt.id !== ",") {
                         break;
                     }
                     advance(",");
+                    if (is_brace) {
+                        signature.push(", ");
+                    }
                 }
-                //
                 parameters.push(param);
-                advance("]");
+                if (is_brace) {
+
+// test_cause:
+// ["
+// function aa({bb,aa}){}
+// ", "check_ordered", "expected_a_b_before_c_d", "aa", 17]
+
+                    check_ordered("parameter", param.names);
+                    advance("}");
+                    signature.push("}");
+                } else {
+                    advance("]");
+                }
                 break;
             case "{":
                 if (optional !== undefined) {
@@ -6175,6 +6193,7 @@ function jslint_phase3_parse(state) {
                     }
 
 // test_cause:
+// ["function aa([aa=aa],aa){}", "param_parse", "equal", "", 0]
 // ["function aa({aa=aa},aa){}", "param_parse", "equal", "", 0]
 
                     test_cause("equal");
@@ -6183,24 +6202,31 @@ function jslint_phase3_parse(state) {
                         subparam.expression = parse_expression();
                         param.open = true;
                     }
-                    param.names.push(subparam);
+                    if (is_brace) {
+                        param.names.push(subparam);
+                    }
                     if (token_nxt.id !== ",") {
                         break;
                     }
                     advance(",");
-                    signature.push(", ");
+                    if (is_brace) {
+                        signature.push(", ");
+                    }
                 }
-                //
                 parameters.push(param);
+                if (is_brace) {
 
 // test_cause:
 // ["
 // function aa({bb,aa}){}
 // ", "check_ordered", "expected_a_b_before_c_d", "aa", 17]
 
-                check_ordered("parameter", param.names);
-                advance("}");
-                signature.push("}");
+                    check_ordered("parameter", param.names);
+                    advance("}");
+                    signature.push("}");
+                } else {
+                    advance("]");
+                }
                 break;
             default:
                 if (!token_nxt.identifier) {

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -90,7 +90,7 @@
 
 // WARNING: JSLint will hurt your feelings.
 
-/*jslint beta, node*/
+/*jslint beta, node, trace*/
 /*property
     JSLINT_BETA,
     NODE_V8_COVERAGE,
@@ -5736,10 +5736,20 @@ function jslint_phase3_parse(state) {
         return the_await;
     }
 
-    function prefix_destructure(enroll, role, readonly, names, signature) {
+    function prefix_destructure(
+        enroll,
+        role,
+        readonly,
+        names,
+        the_function,
+        the_function_toplevel
+    ) {
         const is_brace = token_now.id === "{";
         const name_list = [];
+        const parameters = the_function?.parameters || [];
+        const signature = the_function?.signature || [];
         const the_destructure = token_now;
+        let optional;
         function advance_and_signature_push(id) {
             advance(id);
             signature.push(id);
@@ -5766,12 +5776,20 @@ function jslint_phase3_parse(state) {
             switch (name.id) {
             case "...":
                 advance_and_signature_push("...");
-                if (token_nxt.id === "...") {
+                name = token_nxt;
+                if (name.id === "...") {
 
 // test_cause:
-// ["let[... ...]=0", "name_parse", "unexpected_a_after_b", "...", 5]
+// ["let[... ...]=0", "name_parse", "unexpected_a_after_b", "...", 9]
 
                     return stop("unexpected_a_after_b", name, name.id, "...");
+                }
+                if (optional) {
+
+// test_cause:
+// ["function aa(aa=0,...){}", "name_parse", "required_a_optional_b", "aa", 21]
+
+                    warn("required_a_optional_b", name, name.id, optional.id);
                 }
 
 // test_cause:
@@ -5783,21 +5801,46 @@ function jslint_phase3_parse(state) {
                 return true;
             case "[":
             case "{":
+                if (the_function?.id === "=>" && !option_dict.fart) {
+
+// test_cause:
+// ["([aa])=>0", "name_parse", "use_function_not_fart", "=>", 7]
+// ["({aa})=>0", "name_parse", "use_function_not_fart", "=>", 7]
+
+                    warn("use_function_not_fart", the_function);
+                }
+                if (optional) {
+
+// test_cause:
+// ["function aa(aa=0,[]){}", "name_parse", "required_a_optional_b", "aa", 18]
+// ["function aa(aa=0,{}){}", "name_parse", "required_a_optional_b", "aa", 18]
+
+                    warn("required_a_optional_b", name, name.id, optional.id);
+                }
 
 // test_cause:
 // ["let[[aa]]=0", "name_parse", "recurse_element", "", 0]
 // ["let[{aa}]=0", "name_parse", "recurse_element", "", 0]
 
                 test_cause("recurse_element");
+                parameters_push(name);
                 advance_and_signature_push(token_nxt.id);
-                prefix_destructure(enroll, role, readonly, names, signature);
+                prefix_destructure(
+                    enroll,             // enroll
+                    role,               // role
+                    readonly,           // readonly
+                    names,              // names
+                    the_function,       // the_function
+                    false               // the_function_toplevel
+                );
                 return;
             }
             if (!name.identifier) {
 
 // test_cause:
-// ["function aa(aa=0,[]){}", "name_parse", "expected_identifier_a", "]", 19]
-// ["function aa(aa=0,{}){}", "name_parse", "expected_identifier_a", "}", 19]
+// ["function aa(...0){}", "name_parse", "expected_identifier_a", "0", 16]
+// ["function aa(0){}", "name_parse", "expected_identifier_a", "0", 13]
+// ["function aa([0]){}", "name_parse", "expected_identifier_a", "0", 14]
 // ["function aa({0}){}", "name_parse", "expected_identifier_a", "0", 14]
 // ["function aa({aa:0}){}", "name_parse", "expected_identifier_a", "0", 17]
 // ["let[...0]=0", "name_parse", "expected_identifier_a", "0", 8]
@@ -5809,10 +5852,11 @@ function jslint_phase3_parse(state) {
             if (is_brace) {
                 survey(name);
             }
+            parameters_push(name);
             advance_and_signature_push(token_nxt.id);
             if (is_brace && token_nxt.id === ":") {
                 advance_and_signature_push(":");
-                the_destructure.open = true;
+                the_destructure.open = !the_function_toplevel;
                 if (token_nxt.id === "...") {
 
 // test_cause:
@@ -5843,17 +5887,33 @@ function jslint_phase3_parse(state) {
 // ["const{aa}=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
 
             if (token_nxt.id === "=") {
+                optional = the_function_toplevel && token_now;
                 advance_and_signature_push("=");
-                the_destructure.open = true;
+                the_destructure.open = !the_function_toplevel;
                 name.expression = parse_expression(0);
 
 // test_cause:
-// ["function aa([aa=aa],aa){}", "name_parse", "default", "", 0]
-// ["function aa({aa=aa},aa){}", "name_parse", "default", "", 0]
-// ["let[aa=0]=0", "name_parse", "default", "", 0]
-// ["let{aa=0}=0", "name_parse", "default", "", 0]
+// ["function aa([aa=aa]){}", "name_parse", "optional", "", 0]
+// ["function aa({aa=aa}){}", "name_parse", "optional", "", 0]
+// ["let[aa=0]=0", "name_parse", "optional", "", 0]
+// ["let{aa=0}=0", "name_parse", "optional", "", 0]
 
-                test_cause("default");
+                test_cause("optional");
+                return;
+            }
+            if (optional) {
+
+// test_cause:
+// ["function aa(aa=0,bb){}", "name_parse", "required_a_optional_b", "aa", 18]
+
+                warn("required_a_optional_b", name, name.id, optional.id);
+            }
+        }
+        function parameters_push(name) {
+            if (the_function_toplevel) {
+                names = [];
+                name.names = names;
+                parameters.push(name);
             }
         }
         while (true) {
@@ -5866,10 +5926,10 @@ function jslint_phase3_parse(state) {
                 test_cause("ignore");
                 advance_and_signature_push(",");
             }
-
-// Break from ellipsis.
-
             if (name_parse()) {
+
+// Break early from ellipsis.
+
                 break;
             }
             if (token_nxt.id !== ",") {
@@ -5877,7 +5937,9 @@ function jslint_phase3_parse(state) {
             }
             advance_and_signature_push(",");
         }
-        if (is_brace) {
+        if (the_function_toplevel) {
+            advance_and_signature_push(")");
+        } else if (is_brace) {
 
 // test_cause:
 // ["
@@ -6063,119 +6125,26 @@ function jslint_phase3_parse(state) {
 
 // This function will parse input <parameters> at beginning of <the_function>
 
-        const parameters = [];
-        let optional;
-        let signature = ["("];
-        function advance_and_signature_push(id) {
-            advance(id);
-            signature.push(id);
-            switch (id) {
-            case ",":
-            case ":":
-                signature.push(" ");
-                break;
-            }
-        }
-        function param_parse() {
-            let param = token_nxt;
-            switch (param.id) {
-            case "...":
-                advance_and_signature_push("...");
-                param = token_nxt;
-                if (optional !== undefined) {
-
-// test_cause:
-// ["function aa(aa=0,...){}", "param_parse", "required_a_optional_b", "aa", 21]
-
-                    warn("required_a_optional_b", param, param.id, optional.id);
-                }
-                if (!param.identifier) {
-
-// test_cause:
-// ["function aa(...0){}", "param_parse", "expected_identifier_a", "0", 16]
-
-                    return stop("expected_identifier_a", param);
-                }
-                enroll(param, "parameter", false);
-                parameters.push(param);
-                advance_and_signature_push(param.id);
-                break;
-            case "[":
-            case "{":
-
-// test_cause:
-// ["([aa])=>0", "param_parse", "use_function_not_fart", "=>", 7]
-// ["({aa})=>0", "param_parse", "use_function_not_fart", "=>", 7]
-
-                if (the_function.id === "=>" && !option_dict.fart) {
-                    warn("use_function_not_fart", the_function);
-                }
-                if (optional !== undefined) {
-
-// test_cause:
-// ["function aa(aa=0,[]){}", "param_parse", "required_a_optional_b", "aa", 18]
-// ["function aa(aa=0,{}){}", "param_parse", "required_a_optional_b", "aa", 18]
-
-                    warn("required_a_optional_b", param, param.id, optional.id);
-                }
-                param.names = [];
+        the_function.parameters = [];
+        the_function.signature = ["("];
+        token_now.free = false;
+        if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
 
 // PR-xxx - Unify ES2015-destructure-logic. - function([aa]) {...}
 
-                advance_and_signature_push(param.id);
-                prefix_destructure(
-                    enroll,
-                    "parameter",
-                    false,
-                    param.names,
-                    signature
-                );
-                parameters.push(param);
-                break;
-            default:
-                if (!param.identifier) {
-
-// test_cause:
-// ["function aa(0){}", "param_parse", "expected_identifier_a", "0", 13]
-
-                    return stop("expected_identifier_a", param);
-                }
-                enroll(param, "parameter", false);
-                parameters.push(param);
-                advance_and_signature_push(param.id);
-                if (token_nxt.id === "=") {
-                    advance("=");
-                    optional = param;
-                    param.expression = parse_expression(0);
-                } else {
-                    if (optional !== undefined) {
-
-// test_cause:
-// ["function aa(aa=0,bb){}", "param_parse", "required_a_optional_b", "aa", 18]
-
-                        warn(
-                            "required_a_optional_b",
-                            param,
-                            param.id,
-                            optional.id
-                        );
-                    }
-                }
-            }
+            prefix_destructure(
+                enroll,                 // enroll
+                "parameter",            // role
+                false,                  // readonly
+                [],                     // names
+                the_function,           // the_function
+                true                    // the_function_toplevel
+            );
+        } else {
+            advance(")");
+            the_function.signature.push(")");
         }
-        token_now.free = false;
-        if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
-            while (true) {
-                param_parse();
-                if (token_nxt.id !== ",") {
-                    break;
-                }
-                advance_and_signature_push(",");
-            }
-        }
-        advance_and_signature_push(")");
-        the_function.parameters = parameters;
-        the_function.signature = signature.join("");
+        the_function.signature = the_function.signature.join("");
     }
 
     function prefix_lbrace() {
@@ -6366,11 +6335,12 @@ function jslint_phase3_parse(state) {
 // PR-xxx - Unify ES2015-destructure-logic. - [aa] = ...;
 
             element = prefix_destructure(
-                undefined,
-                "variable",
-                false,
-                the_token.names,
-                []
+                undefined,              // enroll
+                "variable",             // role
+                false,                  // readonly
+                the_token.names,        // names
+                undefined,              // the_function
+                false                   // the_function_toplevel
             );
             advance("=");
             symbol("=").led_infix(element);
@@ -7413,11 +7383,12 @@ function jslint_phase3_parse(state) {
 // PR-xxx - Unify ES2015-destructure-logic. - let [aa] = ...;
 
                 prefix_destructure(
-                    enroll,
-                    "variable",
-                    readonly,
-                    the_variable.names,
-                    []
+                    enroll,             // enroll
+                    "variable",         // role
+                    readonly,           // readonly
+                    the_variable.names, // names
+                    undefined,          // the_function
+                    false               // the_function_toplevel
                 );
                 advance("=");
                 the_variable.expression = parse_expression(0);

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -297,7 +297,7 @@
     package_name,
     padEnd,
     padStart,
-    parameters,
+    parameter_count,
     parent,
     parentIi,
     parse,
@@ -2443,7 +2443,7 @@ function jslint_phase2_lex(state) {
                                 // ... literal.
     let mode_regexp;            // true if regular expression literal seen on
                                 // ... this line.
-    let opener_popped = empty();        // Last popped token from opener_stack.
+    let opener_popped = empty();        // Last token popped from opener_stack.
     let opener_stack = [];      // Stack of opener tokens: (, [.
     let snippet = "";           // A piece of string.
     let token_1;                // The first token.
@@ -4872,7 +4872,7 @@ function jslint_phase3_parse(state) {
         the_symbol.led_infix = function (left) {
             const the_token = token_now;
             the_token.arity = "binary";
-            if (typeof f === "function") {
+            if (f) {
                 return f(left);
             }
             the_token.expression = [left, parse_expression(bp)];
@@ -5275,7 +5275,7 @@ function jslint_phase3_parse(state) {
             warn("wrap_fart_parameter", token_now);
             the_fart.name = "anonymous";
             the_fart.names = [token_prv];
-            the_fart.parameters = [token_prv];
+            the_fart.parameter_count = 1;
             the_fart.signature = token_prv.id;
             enroll(token_prv, "parameter", false);
         } else {
@@ -5651,7 +5651,7 @@ function jslint_phase3_parse(state) {
         the_symbol.nud_prefix = function () {
             const the_token = token_now;
             the_token.arity = "unary";
-            if (typeof f === "function") {
+            if (f) {
                 return f();
             }
             the_token.expression = parse_expression(150);
@@ -5762,14 +5762,14 @@ function jslint_phase3_parse(state) {
         }
         function name_list_push(name) {
             name_list.push(name);
-            if (typeof enroll === "function") {
-                enroll(name, role, readonly);
-                name.init = true;
-            }
 
 // PR-xxx - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
 
             name.arity = role;
+            if (enroll) {
+                enroll(name, role, readonly);
+                name.init = true;
+            }
         }
         function name_parse() {
             let name = token_nxt;
@@ -5824,20 +5824,6 @@ function jslint_phase3_parse(state) {
 
                 test_cause("recurse_element");
                 advance_and_signature_push(token_nxt.id);
-                if (the_function_toplevel) {
-                    the_function.parameters.push(name);
-                    name.names = [];
-                    prefix_destructure(
-                        enroll,         // enroll
-                        role,           // role
-                        readonly,       // readonly
-                        name.names,     // name_list
-                        the_function,   // the_function
-                        false           // the_function_toplevel
-                    );
-                    name_list.push(...name.names);
-                    return;
-                }
                 prefix_destructure(
                     enroll,             // enroll
                     role,               // role
@@ -5888,15 +5874,9 @@ function jslint_phase3_parse(state) {
                 }
                 token_nxt.label = name;
                 name = token_nxt;
-                if (the_function_toplevel) {
-                    the_function.parameters.push(name);
-                }
                 name_list_push(name);
                 advance_and_signature_push(token_nxt.id);
                 return;
-            }
-            if (the_function_toplevel) {
-                the_function.parameters.push(name);
             }
             name_list_push(name);
 
@@ -5928,14 +5908,19 @@ function jslint_phase3_parse(state) {
             }
         }
         while (true) {
-            if (!is_brace && token_nxt.id === ",") {
+            if (!is_brace && !the_function_toplevel && token_nxt.id === ",") {
 
 // test_cause:
+// ["(,aa)=>0", "name_parse", "expected_identifier_a", ",", 2]
+// ["([,aa])=>0", "prefix_destructure", "ignore", "", 0]
 // [";[,aa]=0", "prefix_destructure", "ignore", "", 0]
 // ["let[,aa]=0", "prefix_destructure", "ignore", "", 0]
 
                 test_cause("ignore");
                 advance_and_signature_push(",");
+            }
+            if (the_function_toplevel) {
+                the_function.parameter_count += 1;
             }
             if (name_parse()) {
 
@@ -6136,7 +6121,7 @@ function jslint_phase3_parse(state) {
 // This function will parse input <parameters> at beginning of <the_function>
 
         the_function.names = [];
-        the_function.parameters = [];
+        the_function.parameter_count = 0;
         the_function.signature = ["("];
         token_now.free = false;
         if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
@@ -8016,9 +8001,9 @@ function jslint_phase4_walk(state) {
 // PR-xxx - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
 
 // test_cause:
-// [";[aa]=0", "post_a", "[aa]=0", "", 0]
+// [";[aa]=0", "post_a", ";[aa]=0", "", 0]
 
-                    test_cause("[aa]=0");
+                    test_cause(";[aa]=0");
                     thing.names.forEach(init_variable);
                 } else {
 
@@ -8460,21 +8445,20 @@ function jslint_phase4_walk(state) {
     function post_s_var(thing) {
         thing.names.forEach(function (name) {
             name.dead = false;
-            if (name.expression !== undefined) {
+            if (name.expression) {
+
+// test_cause:
+// ["let aa=0", "post_s_var", "let aa=0", "", 0]
+
+                test_cause("let aa=0");
                 walk_expression(name.expression);
-
-// Probably deadcode.
-// if (name.id === "{" || name.id === "[") {
-//     name.names.forEach(subactivate);
-// } else {
-//     name.init = true;
-// }
-
-                jslint_assert(
-                    !(name.id === "{" || name.id === "["),
-                    `Expected !(name.id === "{" || name.id === "[").`
-                );
                 name.init = true;
+            } else {
+
+// test_cause:
+// ["let aa", "post_s_var", "let aa", "", 0]
+
+                test_cause("let aa");
             }
             blockage.live.push(name);
         });
@@ -8816,7 +8800,7 @@ function jslint_phase4_walk(state) {
             thing.name.init = true;
         }
         if (thing.extra === "get") {
-            if (thing.parameters.length !== 0) {
+            if (thing.parameter_count !== 0) {
 
 // test_cause:
 // ["
@@ -8827,7 +8811,7 @@ function jslint_phase4_walk(state) {
                 warn("bad_get", thing);
             }
         } else if (thing.extra === "set") {
-            if (thing.parameters.length !== 1) {
+            if (thing.parameter_count !== 1) {
 
 // test_cause:
 // ["
@@ -8838,14 +8822,27 @@ function jslint_phase4_walk(state) {
                 warn("bad_set", thing);
             }
         }
-        thing.parameters.forEach(function (name) {
-            walk_expression(name.expression);
-            if (name.id === "{" || name.id === "[") {
-                name.names.forEach(subactivate);
+
+// PR-xxx - Unify property the_function.parameters into the_function.names.
+
+        thing.names.forEach(function (name) {
+            if (name.expression) {
+
+// test_cause:
+// ["(aa=0)=>0", "pre_s_function", "(aa=0)=>0", "", 0]
+
+                test_cause("(aa=0)=>0");
             } else {
-                name.dead = false;
-                name.init = true;
+
+// test_cause:
+// ["(aa)=>0", "pre_s_function", "(aa)=>0", "", 0]
+// ["aa=>0", "pre_s_function", "(aa)=>0", "", 0]
+
+                test_cause("(aa)=>0");
             }
+            walk_expression(name.expression);
+            name.dead = false;
+            name.init = true;
         });
     }
 
@@ -8871,12 +8868,6 @@ function jslint_phase4_walk(state) {
             thing.variable = the_variable;
             the_variable.used += 1;
         }
-    }
-
-    function subactivate(name) {
-        name.init = true;
-        name.dead = false;
-        blockage.live.push(name);
     }
 
     function walk_expression(thing) {

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -5243,9 +5243,9 @@ function jslint_phase3_parse(state) {
             if (!token_prv.identifier) {
 
 // test_cause:
-// ["0=>0", "parse_fart", "wrap_fart_parameter", "=>", 2]
+// ["0=>0", "parse_fart", "expected_identifier_a", "0", 1]
 
-                return stop("wrap_fart_parameter", token_now);
+                return stop("expected_identifier_a", token_prv);
             }
 
 // PR-499 - Update ES2015-feature arrow, to continue parsing unwrapped-form
@@ -5255,6 +5255,7 @@ function jslint_phase3_parse(state) {
 // ["aa=>0", "parse_fart", "wrap_fart_parameter", "=>", 3]
 
             warn("wrap_fart_parameter", token_now);
+            the_fart.name = "anonymous";
             the_fart.parameters = [token_prv];
             the_fart.signature = token_prv.id;
             enroll(token_prv, "parameter", false);
@@ -6012,9 +6013,9 @@ function jslint_phase3_parse(state) {
 
 // This function will parse input <parameters> at beginning of <the_function>
 
+        const parameters = [];
+        const signature = ["("];
         let optional;
-        let parameters = [];
-        let signature = ["("];
         function advance_and_signature_push(id) {
             advance(id);
             switch (id) {
@@ -6025,16 +6026,6 @@ function jslint_phase3_parse(state) {
             default:
                 signature.push(id);
             }
-        }
-        function param_enroll(name) {
-            if (name.identifier) {
-                enroll(name, "parameter", false);
-                return;
-            }
-
-// Recurse param_enroll().
-
-            name.names.forEach(param_enroll);
         }
         function param_parse() {
             const is_brace = token_nxt.id === "{";
@@ -6058,6 +6049,7 @@ function jslint_phase3_parse(state) {
 
                     return stop("expected_identifier_a", param);
                 }
+                enroll(param, "parameter", false);
                 parameters.push(param);
                 advance_and_signature_push(param.id);
                 break;
@@ -6101,6 +6093,7 @@ function jslint_phase3_parse(state) {
                             }
                         }
                     }
+                    enroll(subparam, "parameter", false);
                     param.names.push(subparam);
 
 // test_cause:
@@ -6140,6 +6133,7 @@ function jslint_phase3_parse(state) {
 
                     return stop("expected_identifier_a", param);
                 }
+                enroll(param, "parameter", false);
                 parameters.push(param);
                 advance_and_signature_push(param.id);
                 if (token_nxt.id === "=") {
@@ -6181,7 +6175,6 @@ function jslint_phase3_parse(state) {
             }
         }
         advance_and_signature_push(")");
-        parameters.forEach(param_enroll);
         the_function.parameters = parameters;
         the_function.signature = signature.join("");
     }

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -103,6 +103,7 @@
     assertJsonEqual,
     assertOrThrow,
     assign,
+    assignment,
     async,
     b,
     beta,
@@ -2442,9 +2443,8 @@ function jslint_phase2_lex(state) {
                                 // ... literal.
     let mode_regexp;            // true if regular expression literal seen on
                                 // ... this line.
-    let paren_backtrack_list = [];      // List of most recent "(" tokens at any
-                                        // ... paren-depth.
-    let paren_depth = 0;        // Keeps track of current paren-depth.
+    let opener_popped = empty();        // Last popped token from opener_stack.
+    let opener_stack = [];      // Stack of opener tokens: (, [.
     let snippet = "";           // A piece of string.
     let token_1;                // The first token.
     let token_prv = token_global;       // The previous token including
@@ -2695,9 +2695,14 @@ function jslint_phase2_lex(state) {
 
 // Lex directives in comment.
 
-        [
-            the_comment.directive, body
-        ] = Array.from(snippet.match(jslint_rgx_directive) || []).slice(1);
+        snippet.replace(jslint_rgx_directive, function (
+            ignore,
+            match1,
+            match2
+        ) {
+            the_comment.directive = match1;
+            body = match2;
+        });
         if (the_comment.directive === undefined) {
             return the_comment;
         }
@@ -4158,19 +4163,32 @@ import moduleHttps from "https";
 
         switch (id) {
         case "(":
-            paren_backtrack_list[paren_depth] = the_token;
-            paren_depth += 1;
+        case "[":
+            opener_stack.push(the_token);
             break;
         case ")":
-            paren_depth -= 1;
-            break;
-        case "=>":
-            if (
-                token_prv_expr.id === ")"
-                && paren_backtrack_list[paren_depth]
-            ) {
-                paren_backtrack_list[paren_depth].fart = the_token;
+        case "]":
+            opener_popped = opener_stack.pop();
+            if (noop(
+                id === ")"
+                ? opener_popped.id !== "("
+                : opener_popped.id !== "["
+            )) {
+
+// test_cause:
+// [";(]", "token_create", "unexpected_a", "]", 3]
+// [";[)", "token_create", "unexpected_a", ")", 3]
+
+                return stop("unexpected_a", the_token);
             }
+            break;
+        }
+        switch (token_prv_expr.id + " " + id) {
+        case ") =>":
+            opener_popped.fart = the_token;
+            break;
+        case "] =":
+            opener_popped.assignment = the_token;
             break;
         }
 
@@ -5363,11 +5381,6 @@ function jslint_phase3_parse(state) {
 
                     container.expression.push(parse_json());
                     if (token_nxt.id !== ",") {
-
-// test_cause:
-// ["[0,0]", "parse_json", "comma", "", 0]
-
-                        test_cause("comma");
                         break;
                     }
                     advance(",");
@@ -5822,24 +5835,16 @@ function jslint_phase3_parse(state) {
                 enroll(name, role, readonly);
                 name.init = true;
             }
-            if (role === "variable") {
 
 // PR-xxx - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
 
-                name.arity = "variable";
-            }
+            name.arity = role;
         }
-        //!! if (token_now.id !== "[" && token_now.id !== "{") {
-
-//!! // test_cause:
-//!! // ["(aa)=0", "prefix_destructure", "unexpected_a", "aa", 2]
-
-            //!! return stop("unexpected_a", token_now);
-        //!! }
         while (true) {
             if (!is_brace && token_nxt.id === ",") {
 
 // test_cause:
+// [";[,aa]=0", "prefix_destructure", "ignore", "", 0]
 // ["let[,aa]=0", "prefix_destructure", "ignore", "", 0]
 
                 test_cause("ignore");
@@ -6350,11 +6355,6 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id !== ",") {
                     break;
                 }
-
-// test_cause:
-// ["aa={\"aa\":0,\"bb\":0}", "prefix_lbrace", "comma", "", 0]
-
-                test_cause("comma");
                 advance(",");
                 if (token_nxt.id === "}") {
 
@@ -6389,20 +6389,32 @@ function jslint_phase3_parse(state) {
     function prefix_lbracket() {
         const the_token = token_now;
         let element;
+        let the_assignment;
         the_token.expression = [];
+        if (the_token.assignment) {
+            the_assignment = Object.assign(token_now.assignment, {
+                arity: "assignment",
+                expression: [],
+                names: []
+            });
+
+// PR-xxx - Unify ES2015-destructure-logic.
+
+            element = prefix_destructure(
+                undefined,
+                "variable",
+                false,
+                the_assignment.names
+            );
+            advance("=");
+            symbol("=").led_infix(element);
+            return the_assignment;
+        }
         if (token_nxt.id !== "]") {
 
 // Parse/loop through each element in [...].
 
             while (true) {
-                if (!state.mode_json && token_nxt.id === ",") {
-
-// test_cause:
-// [";[,aa]=0", "prefix_lbracket", "ignore", "", 0]
-
-                    test_cause("ignore");
-                    advance(",");
-                }
                 if (!state.mode_json && token_nxt.id === "...") {
 
 // test_cause:
@@ -7431,6 +7443,9 @@ function jslint_phase3_parse(state) {
                     warn("unexpected_a", the_variable);
                 }
                 advance();
+
+// PR-xxx - Unify ES2015-destructure-logic.
+
                 prefix_destructure(
                     enroll,
                     "variable",
@@ -8051,8 +8066,8 @@ function jslint_phase4_walk(state) {
 
 // PR-xxx - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
 
-//!! // test_cause:
-//!! // ["[aa]=0", "post_a", "[aa]=0", "", 0]
+// test_cause:
+// [";[aa]=0", "post_a", "[aa]=0", "", 0]
 
                     test_cause("[aa]=0");
                     thing.names.forEach(init_variable);

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -4394,7 +4394,7 @@ function jslint_phase3_parse(state) {
         ) {
             token_nxt.statement = true;
             advance("(string)");
-            advance(";");
+            semicolon();
         }
         stmts = parse_statements();
         the_block.block = stmts;
@@ -5722,6 +5722,127 @@ function jslint_phase3_parse(state) {
         return the_await;
     }
 
+    function prefix_destructure(the_variable) {
+        const is_brace = token_nxt.id === "{";
+        const mode_const = the_variable.id === "const";
+        const the_destructure = token_nxt;
+        let ellipsis;
+        let name;
+        advance();
+        while (true) {
+            if (!is_brace && token_nxt.id === ",") {
+
+// test_cause:
+// ["let[,aa]=0", "prefix_destructure", "ignore", "", 0]
+
+                test_cause("ignore");
+                advance(",");
+            }
+            ellipsis = token_nxt.id === "...";
+            if (ellipsis) {
+
+// test_cause:
+// ["let[...aa]=0", "prefix_destructure", "ellipsis", "", 0]
+// ["let{...aa}=0", "prefix_destructure", "ellipsis", "", 0]
+
+                test_cause("ellipsis");
+                advance("...");
+            }
+            name = token_nxt;
+            if (!name.identifier) {
+
+// test_cause:
+// ["let[0]", "prefix_destructure", "expected_identifier_a", "0", 5]
+// ["let{0}", "prefix_destructure", "expected_identifier_a", "0", 5]
+
+                return stop("expected_identifier_a");
+            }
+            if (is_brace) {
+                survey(name);
+            }
+            advance();
+            if (is_brace && token_nxt.id === ":") {
+                advance(":");
+
+// Recurse prefix_destructure().
+
+                if (token_nxt.id === "{" || token_nxt.id === "[") {
+
+// test_cause:
+// ["let{aa:{aa}}", "prefix_destructure", "recurse", "", 0]
+
+                    test_cause("recurse");
+                    prefix_destructure();
+                } else {
+                    if (!token_nxt.identifier) {
+
+// test_cause:
+// ["let{aa:0}", "prefix_destructure", "expected_identifier_a", "0", 8]
+
+                        return stop("expected_identifier_a");
+                    }
+
+// PR-363 - Bugfix
+// Add test against false-warning <uninitialized 'bb'> in code
+// '/*jslint node*/\nlet {aa:bb} = {}; bb();'.
+//
+//                         token_nxt.label = name;
+//                         the_variable.names.push(token_nxt);
+//                         enroll(token_nxt, "variable", mode_const);
+
+                    name = token_nxt;
+                    the_variable.names.push(name);
+                    survey(name);
+                    enroll(name, "variable", mode_const);
+                    advance();
+                    the_destructure.open = true;
+                }
+            } else {
+                the_variable.names.push(name);
+                enroll(name, "variable", mode_const);
+            }
+
+// Issue #458 - Regression - Warn about variable usage before initialization.
+
+//                    name.dead = false;
+
+            name.init = true;
+            if (ellipsis) {
+                break;
+            }
+
+// test_cause:
+// ["const[aa]=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
+// ["const{aa}=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
+
+            if (token_nxt.id === "=") {
+
+// test_cause:
+// ["let[aa=0]", "prefix_destructure", "assign", "", 0]
+// ["let{aa=0}", "prefix_destructure", "assign", "", 0]
+
+                test_cause("assign");
+                advance("=");
+                name.expression = parse_expression();
+                the_destructure.open = true;
+            }
+            if (token_nxt.id !== ",") {
+                break;
+            }
+            advance(",");
+        }
+        if (is_brace) {
+
+// test_cause:
+// ["let{bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
+
+            check_ordered(the_variable.id, the_variable.names);
+            advance("}");
+        } else {
+            advance("]");
+        }
+    }
+
     function prefix_ellipsis() {
         let after_ellipsis;
         advance("...");
@@ -5981,11 +6102,10 @@ function jslint_phase3_parse(state) {
                         subparam.expression = parse_expression();
                         param.open = true;
                     }
-                    if (token_nxt.id === ",") {
-                        advance(",");
-                    } else {
+                    if (token_nxt.id !== ",") {
                         break;
                     }
+                    advance(",");
                 }
                 parameters.push(param);
                 advance("]");
@@ -6047,12 +6167,11 @@ function jslint_phase3_parse(state) {
                         param.open = true;
                     }
                     param.names.push(subparam);
-                    if (token_nxt.id === ",") {
-                        advance(",");
-                        signature.push(", ");
-                    } else {
+                    if (token_nxt.id !== ",") {
                         break;
                     }
+                    advance(",");
+                    signature.push(", ");
                 }
                 parameters.push(param);
 
@@ -6106,12 +6225,11 @@ function jslint_phase3_parse(state) {
         if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
             while (true) {
                 param_parse();
-                if (token_nxt.id === ",") {
-                    advance(",");
-                    signature.push(", ");
-                } else {
+                if (token_nxt.id !== ",") {
                     break;
                 }
+                advance(",");
+                signature.push(", ");
             }
         }
         advance(")");
@@ -6504,7 +6622,7 @@ function jslint_phase3_parse(state) {
             the_break.label = token_nxt;
             advance();
         }
-        advance(";");
+        semicolon();
         return the_break;
     }
 
@@ -6523,7 +6641,7 @@ function jslint_phase3_parse(state) {
         check_not_top_level(the_continue);
         the_continue.disrupt = true;
         warn("unexpected_a", the_continue);
-        advance(";");
+        semicolon();
         return the_continue;
     }
 
@@ -6700,11 +6818,10 @@ function jslint_phase3_parse(state) {
                     }
                     advance();
                     the_export.expression.push(the_thing);
-                    if (token_nxt.id === ",") {
-                        advance(",");
-                    } else {
+                    if (token_nxt.id !== ",") {
                         break;
                     }
+                    advance(",");
                 }
 
 // PR-439 - Check exported properties are ordered.
@@ -6989,7 +7106,7 @@ function jslint_phase3_parse(state) {
         if (token_nxt.id !== ";" && the_return.line === token_nxt.line) {
             the_return.expression = parse_expression(10);
         }
-        advance(";");
+        semicolon();
         return the_return;
     }
 
@@ -7269,129 +7386,10 @@ function jslint_phase3_parse(state) {
     }
 
     function stmt_var() {
-        let ellipsis;
         let mode_const;
         let name;
-        let the_destructure;
         let the_variable = token_now;
         let variable_prv;
-        function destructure_parse() {
-            const is_brace = token_nxt.id === "{";
-            the_destructure = token_nxt;
-            advance();
-            while (true) {
-                if (!is_brace && token_nxt.id === ",") {
-
-// test_cause:
-// ["let[,aa]=0", "destructure_parse", "ignore", "", 0]
-
-                    test_cause("ignore");
-                    advance(",");
-                }
-                ellipsis = token_nxt.id === "...";
-                if (ellipsis) {
-
-// test_cause:
-// ["let[...aa]=0", "destructure_parse", "ellipsis", "", 0]
-// ["let{...aa}=0", "destructure_parse", "ellipsis", "", 0]
-
-                    test_cause("ellipsis");
-                    advance("...");
-                }
-                name = token_nxt;
-                if (!name.identifier) {
-
-// test_cause:
-// ["let[0]", "destructure_parse", "expected_identifier_a", "0", 5]
-// ["let{0}", "destructure_parse", "expected_identifier_a", "0", 5]
-
-                    return stop("expected_identifier_a");
-                }
-                if (is_brace) {
-                    survey(name);
-                }
-                advance();
-                if (is_brace && token_nxt.id === ":") {
-                    advance(":");
-
-// Recurse destructure_parse().
-
-                    if (token_nxt.id === "{" || token_nxt.id === "[") {
-
-// test_cause:
-// ["let{aa:{aa}}", "destructure_parse", "recurse", "", 0]
-
-                        test_cause("recurse");
-                        destructure_parse();
-                    } else {
-                        if (!token_nxt.identifier) {
-
-// test_cause:
-// ["let{aa:0}", "destructure_parse", "expected_identifier_a", "0", 8]
-
-                            return stop("expected_identifier_a");
-                        }
-
-// PR-363 - Bugfix
-// Add test against false-warning <uninitialized 'bb'> in code
-// '/*jslint node*/\nlet {aa:bb} = {}; bb();'.
-//
-//                         token_nxt.label = name;
-//                         the_variable.names.push(token_nxt);
-//                         enroll(token_nxt, "variable", mode_const);
-
-                        name = token_nxt;
-                        the_variable.names.push(name);
-                        survey(name);
-                        enroll(name, "variable", mode_const);
-                        advance();
-                        the_destructure.open = true;
-                    }
-                } else {
-                    the_variable.names.push(name);
-                    enroll(name, "variable", mode_const);
-                }
-
-// Issue #458 - Regression - Warn about variable usage before initialization.
-
-//                    name.dead = false;
-
-                name.init = true;
-                if (ellipsis) {
-                    break;
-                }
-
-// test_cause:
-// ["const[aa]=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
-// ["const{aa}=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
-
-                if (token_nxt.id === "=") {
-
-// test_cause:
-// ["let[aa=0]", "destructure_parse", "assign", "", 0]
-// ["let{aa=0}", "destructure_parse", "assign", "", 0]
-
-                    test_cause("assign");
-                    advance("=");
-                    name.expression = parse_expression();
-                    the_destructure.open = true;
-                }
-                if (token_nxt.id !== ",") {
-                    break;
-                }
-                advance(",");
-            }
-            if (is_brace) {
-
-// test_cause:
-// ["let{bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
-
-                check_ordered(the_variable.id, the_variable.names);
-                advance("}");
-            } else {
-                advance("]");
-            }
-        }
         mode_const = the_variable.id === "const";
         the_variable.names = [];
 
@@ -7468,7 +7466,7 @@ function jslint_phase3_parse(state) {
 
                     warn("unexpected_a", the_variable);
                 }
-                destructure_parse();
+                prefix_destructure(the_variable);
                 advance("=");
                 the_variable.expression = parse_expression(0);
             } else if (token_nxt.identifier) {
@@ -7839,7 +7837,7 @@ function jslint_phase3_parse(state) {
 
     } else if (token_nxt.value === "use strict") {
         advance("(string)");
-        advance(";");
+        semicolon();
     }
     state.token_tree = parse_statements();
     advance("(end)");

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -5854,7 +5854,9 @@ function jslint_phase3_parse(state) {
             advance_and_signature_push(token_nxt.id);
             if (is_brace && token_nxt.id === ":") {
                 advance_and_signature_push(":");
-                the_destructure.open = !the_function_toplevel;
+                if (!the_function_toplevel) {
+                    the_destructure.open = true;
+                }
                 if (token_nxt.id === "...") {
 
 // test_cause:
@@ -5887,7 +5889,9 @@ function jslint_phase3_parse(state) {
             if (token_nxt.id === "=") {
                 optional = the_function_toplevel && token_now;
                 advance_and_signature_push("=");
-                the_destructure.open = !the_function_toplevel;
+                if (!the_function_toplevel) {
+                    the_destructure.open = true;
+                }
                 name.expression = parse_expression(0);
 
 // test_cause:
@@ -7979,7 +7983,9 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
+// ["(aa=aa)=>0", "lookup", "out_of_scope_a", "aa", 5]
 // ["let aa;if(aa){let bb;}bb;", "lookup", "out_of_scope_a", "bb", 23]
+// ["let aa=bb;let bb=0;", "lookup", "out_of_scope_a", "bb", 8]
 
             warn("out_of_scope_a", thing);
         }
@@ -8452,6 +8458,21 @@ function jslint_phase4_walk(state) {
 
                 test_cause("let aa=0");
                 walk_expression(name.expression);
+
+// Probably deadcode.
+// if (name.id === "{" || name.id === "[") {
+//     name.names.forEach(subactivate);
+// } else {
+//     name.init = true;
+// }
+
+// PR-500 - Unify property the_function.parameters into the_function.names.
+
+// jslint_assert(
+// !(name.id === "{" || name.id === "["),
+// `Expected !(name.id === "{" || name.id === "[").`
+// );
+
                 name.init = true;
             } else {
 
@@ -8825,6 +8846,16 @@ function jslint_phase4_walk(state) {
 
 // PR-500 - Unify property the_function.parameters into the_function.names.
 
+// thing.parameters.forEach(function (name) {
+//     walk_expression(name.expression);
+//     if (name.id === "{" || name.id === "[") {
+//         name.names.forEach(subactivate);
+//     } else {
+//         name.dead = false;
+//         name.init = true;
+//     }
+// });
+
         thing.names.forEach(function (name) {
             if (name.expression) {
 
@@ -8869,6 +8900,14 @@ function jslint_phase4_walk(state) {
             the_variable.used += 1;
         }
     }
+
+// PR-500 - Unify property the_function.parameters into the_function.names.
+
+// function subactivate(name) {
+//     name.init = true;
+//     name.dead = false;
+//     blockage.live.push(name);
+// }
 
     function walk_expression(thing) {
         if (thing) {
@@ -9060,7 +9099,7 @@ function jslint_phase5_whitage(state) {
 // "switch(){}"
 // "while(){}"
 
-    let indent_method_dict = {};
+    let indent_method_dict = empty();
     let indentage;
     let left = token_global;
     let margin = 0;

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -4941,7 +4941,7 @@ function jslint_phase3_parse(state) {
 // ["aa.0", "infix_dot", "expected_identifier_a", "0", 4]
 // ["aa?.0", "infix_dot", "expected_identifier_a", "0", 5]
 
-            return stop("expected_identifier_a");
+            return stop("expected_identifier_a", name);
         }
         advance();
         survey(name);
@@ -5755,7 +5755,7 @@ function jslint_phase3_parse(state) {
 // ["let[0]", "prefix_destructure", "expected_identifier_a", "0", 5]
 // ["let{0}", "prefix_destructure", "expected_identifier_a", "0", 5]
 
-                return stop("expected_identifier_a");
+                return stop("expected_identifier_a", name);
             }
             if (is_brace) {
                 survey(name);
@@ -5779,7 +5779,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["let{aa:0}", "prefix_destructure", "expected_identifier_a", "0", 8]
 
-                        return stop("expected_identifier_a");
+                        return stop("expected_identifier_a", token_nxt);
                     }
 
 // PR-363 - Bugfix
@@ -5872,7 +5872,7 @@ function jslint_phase3_parse(state) {
 // ["function(){}", "prefix_function", "expected_identifier_a", "(", 9]
 // ["function*aa(){}", "prefix_function", "expected_identifier_a", "*", 9]
 
-                    return stop("expected_identifier_a");
+                    return stop("expected_identifier_a", token_nxt);
                 }
                 name = token_nxt;
                 enroll(name, "variable", true);
@@ -6015,55 +6015,51 @@ function jslint_phase3_parse(state) {
         let optional;
         let parameters = [];
         let signature = ["("];
-        let subparam;
+        function advance_and_signature_push(id) {
+            advance(id);
+            switch (id) {
+            case ",":
+            case ":":
+                signature.push(id + " ");
+                break;
+            default:
+                signature.push(id);
+            }
+        }
         function param_enroll(name) {
             if (name.identifier) {
                 enroll(name, "parameter", false);
-            } else {
-
-// test_cause:
-// ["([aa])=>0", "param_enroll", "use_function_not_fart", "=>", 7]
-// ["({aa})=>0", "param_enroll", "use_function_not_fart", "=>", 7]
-
-                if (the_function.id === "=>" && !option_dict.fart) {
-                    warn("use_function_not_fart", the_function);
-                }
+                return;
+            }
 
 // Recurse param_enroll().
 
-                name.names.forEach(param_enroll);
-            }
+            name.names.forEach(param_enroll);
         }
         function param_parse() {
             const is_brace = token_nxt.id === "{";
             let param = token_nxt;
+            let subparam;
             switch (param.id) {
             case "...":
-                advance("...");
-                signature.push("...");
+                advance_and_signature_push("...");
+                param = token_nxt;
                 if (optional !== undefined) {
 
 // test_cause:
 // ["function aa(aa=0,...){}", "param_parse", "required_a_optional_b", "aa", 21]
 
-                    warn(
-                        "required_a_optional_b",
-                        token_nxt,
-                        token_nxt.id,
-                        optional.id
-                    );
+                    warn("required_a_optional_b", param, param.id, optional.id);
                 }
-                if (!token_nxt.identifier) {
+                if (!param.identifier) {
 
 // test_cause:
 // ["function aa(...0){}", "param_parse", "expected_identifier_a", "0", 16]
 
-                    return stop("expected_identifier_a");
+                    return stop("expected_identifier_a", param);
                 }
-                param = token_nxt;
-                advance();
                 parameters.push(param);
-                signature.push(param.id);
+                advance_and_signature_push(param.id);
                 break;
             case "[":
             case "{":
@@ -6073,16 +6069,10 @@ function jslint_phase3_parse(state) {
 // ["function aa(aa=0,[]){}", "param_parse", "required_a_optional_b", "aa", 18]
 // ["function aa(aa=0,{}){}", "param_parse", "required_a_optional_b", "aa", 18]
 
-                    warn(
-                        "required_a_optional_b",
-                        token_nxt,
-                        token_nxt.id,
-                        optional.id
-                    );
+                    warn("required_a_optional_b", param, param.id, optional.id);
                 }
-                advance();
                 param.names = [];
-                signature.push(param.id);
+                advance_and_signature_push(param.id);
                 while (true) {
                     subparam = token_nxt;
                     if (!subparam.identifier) {
@@ -6092,31 +6082,26 @@ function jslint_phase3_parse(state) {
 // ["function aa(aa=0,{}){}", "param_parse", "expected_identifier_a", "}", 19]
 // ["function aa({0}){}", "param_parse", "expected_identifier_a", "0", 14]
 
-                        return stop("expected_identifier_a");
+                        return stop("expected_identifier_a", subparam);
                     }
-                    advance();
+                    advance_and_signature_push(subparam.id);
                     if (is_brace) {
                         survey(subparam);
-                        signature.push(subparam.id);
                         if (token_nxt.id === ":") {
-                            advance(":");
-                            advance();
+                            advance_and_signature_push(":");
+                            advance_and_signature_push(token_nxt.id);
                             token_now.label = subparam;
                             subparam = token_now;
                             if (!subparam.identifier) {
 
 // test_cause:
-// ["function aa({aa:0}){}", "param_parse", "expected_identifier_a", "}", 18]
+// ["function aa({aa:0}){}", "param_parse", "expected_identifier_a", "0", 17]
 
-                                return stop(
-                                    "expected_identifier_a",
-                                    token_nxt
-                                );
+                                return stop("expected_identifier_a", subparam);
                             }
                         }
-                    } else {
-                        param.names.push(subparam);
                     }
+                    param.names.push(subparam);
 
 // test_cause:
 // ["function aa([aa=aa],aa){}", "param_parse", "equal", "", 0]
@@ -6128,21 +6113,14 @@ function jslint_phase3_parse(state) {
                         subparam.expression = parse_expression();
                         param.open = true;
                     }
-                    if (is_brace) {
-                        param.names.push(subparam);
-                    }
                     if (token_nxt.id !== ",") {
                         break;
                     }
-                    advance(",");
-                    if (is_brace) {
-                        signature.push(", ");
-                    }
+                    advance_and_signature_push(",");
                 }
                 parameters.push(param);
                 if (is_brace) {
-                    advance("}");
-                    signature.push("}");
+                    advance_and_signature_push("}");
 
 // test_cause:
 // ["
@@ -6151,21 +6129,19 @@ function jslint_phase3_parse(state) {
 
                     check_ordered("parameter", param.names);
                 } else {
-                    advance("]");
+                    advance_and_signature_push("]");
                 }
                 break;
             default:
-                if (!token_nxt.identifier) {
+                if (!param.identifier) {
 
 // test_cause:
 // ["function aa(0){}", "param_parse", "expected_identifier_a", "0", 13]
 
-                    return stop("expected_identifier_a");
+                    return stop("expected_identifier_a", param);
                 }
-                param = token_nxt;
-                advance();
                 parameters.push(param);
-                signature.push(param.id);
+                advance_and_signature_push(param.id);
                 if (token_nxt.id === "=") {
                     advance("=");
                     optional = param;
@@ -6188,9 +6164,12 @@ function jslint_phase3_parse(state) {
         }
 
 // test_cause:
-// ["function aa(){}", "prefix_function_parameter", "opener", "(", 0]
+// ["([aa])=>0", "prefix_function_parameter", "use_function_not_fart", "=>", 7]
+// ["({aa})=>0", "prefix_function_parameter", "use_function_not_fart", "=>", 7]
 
-        test_cause("opener", token_now.id);
+        if (the_function.id === "=>" && !option_dict.fart) {
+            warn("use_function_not_fart", the_function);
+        }
         token_now.free = false;
         if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
             while (true) {
@@ -6198,12 +6177,10 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id !== ",") {
                     break;
                 }
-                advance(",");
-                signature.push(", ");
+                advance_and_signature_push(",");
             }
         }
-        advance(")");
-        signature.push(")");
+        advance_and_signature_push(")");
         parameters.forEach(param_enroll);
         the_function.parameters = parameters;
         the_function.signature = signature.join("");
@@ -6764,7 +6741,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["export {}", "stmt_export", "expected_identifier_a", "}", 9]
 
-                        return stop("expected_identifier_a");
+                        return stop("expected_identifier_a", token_nxt);
                     }
                     the_id = token_nxt.id;
                     export_list.push(token_nxt);
@@ -6954,7 +6931,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["import * as", "stmt_import", "expected_identifier_a", "(end)", 1]
 
-                    return stop("expected_identifier_a");
+                    return stop("expected_identifier_a", token_nxt);
                 }
             }
             if (token_nxt.identifier) {
@@ -6978,7 +6955,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["import {", "stmt_import", "expected_identifier_a", "(end)", 1]
 
-                            return stop("expected_identifier_a");
+                            return stop("expected_identifier_a", token_nxt);
                         }
                         name = token_nxt;
                         advance();
@@ -7314,7 +7291,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["try{}catch(){}", "stmt_try", "expected_identifier_a", ")", 12]
 
-                    return stop("expected_identifier_a");
+                    return stop("expected_identifier_a", token_nxt);
                 }
                 if (token_nxt.id !== "ignore") {
                     ignored = undefined;
@@ -7472,7 +7449,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["let 0", "stmt_var", "expected_identifier_a", "0", 5]
 
-                return stop("expected_identifier_a");
+                return stop("expected_identifier_a", token_nxt);
             }
             if (token_nxt.id !== ",") {
                 break;
@@ -7547,49 +7524,55 @@ function jslint_phase3_parse(state) {
 // Tally the property name. If it is a string, only tally strings that conform
 // to the identifier rules.
 
-        if (id === "(string)") {
+        switch (id) {
+        case "(string)":
             id = name.value;
             if (!jslint_rgx_identifier.test(id)) {
                 return id;
             }
-        } else if (id === "`") {
+            break;
+        case "`":
             if (name.value.length === 1) {
                 id = name.value[0].value;
                 if (!jslint_rgx_identifier.test(id)) {
                     return id;
                 }
             }
-        } else if (!name.identifier) {
+            break;
+        default:
+            if (!name.identifier) {
 
 // test_cause:
 // ["let aa={0:0}", "survey", "expected_identifier_a", "0", 9]
 
-            return stop("expected_identifier_a", name);
+                return stop("expected_identifier_a", name);
+            }
         }
 
 // If we have seen this name before, increment its count.
 
         if (typeof property_dict[id] === "number") {
             property_dict[id] += 1;
+            return id;
+        }
 
 // If this is the first time seeing this property name, and if there is a
 // tenure list, then it must be on the list. Otherwise, it must conform to
 // the rules for good property names.
 
-        } else {
-            if (state.mode_property) {
-                if (tenure[id] !== true) {
+        if (state.mode_property) {
+            if (tenure[id] !== true) {
 
 // test_cause:
 // ["/*property aa*/\naa.bb", "survey", "unregistered_property_a", "bb", 4]
 
-                    warn("unregistered_property_a", name);
-                }
-            } else if (
-                !option_dict.nomen
-                && name.identifier
-                && jslint_rgx_weird_property.test(id)
-            ) {
+                warn("unregistered_property_a", name);
+            }
+        } else if (
+            !option_dict.nomen
+            && name.identifier
+            && jslint_rgx_weird_property.test(id)
+        ) {
 
 // test_cause:
 // ["aa.$", "survey", "weird_property_a", "$", 4]
@@ -7598,10 +7581,9 @@ function jslint_phase3_parse(state) {
 // ["aa.aaSync", "survey", "weird_property_a", "aaSync", 4]
 // ["aa.aa_", "survey", "weird_property_a", "aa_", 4]
 
-                warn("weird_property_a", name);
-            }
-            property_dict[id] = 1;
+            warn("weird_property_a", name);
         }
+        property_dict[id] = 1;
         return id;
     }
 

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -970,122 +970,6 @@ import moduleChildProcess from "child_process";
 ' "$@" # '
 )}
 
-shGitPullrequest() {(set -e
-# This function will create-and-push a github-pull-commit to origin/alpha.
-    node --input-type=module --eval '
-// init debugInline
-(function () {
-    let consoleError = console.error;
-    globalThis.debugInline = globalThis.debugInline || function (...argList) {
-
-// This function will print <argv> to stderr and then return <argv>[0].
-
-        consoleError("\n\ndebugInline");
-        consoleError(...argList);
-        consoleError("\n");
-        return argList[0];
-    };
-}());
-import moduleAssert from "assert";
-import moduleChildProcess from "child_process";
-import moduleFs from "fs";
-(async function () {
-    let branchCheckpoint = process.argv[2] || "HEAD";
-    let branchMerge = process.argv[1] || "beta";
-    let branchPull;
-    let commitMessage;
-    let data;
-    let version = process.argv[3] || new Date().toISOString().slice(0, 10);
-    version = version.replace((/-0?/g), ".");
-    // security - sanitize branchXxx
-    [
-        branchCheckpoint, branchMerge, version
-    ] = [
-        branchCheckpoint, branchMerge, version
-    ].map(function (branch) {
-        return branch.trim().replace((/[^\w.\-]/g), "_");
-    });
-    data = await moduleFs.promises.readFile("CHANGELOG.md", "utf8");
-    switch (branchMerge) {
-    case "master":
-        version = `v${version}`;
-        // update CHANGELOG.md
-        data = data.replace(
-            /\n\n# v\d\d\d\d\.\d\d?\.\d\d?(?:-.*?)?\n/,
-            `\n\n# ${version}\n`
-        );
-        await moduleFs.promises.writeFile("CHANGELOG.md", data);
-        commitMessage = new RegExp(
-            `\n\n# ${version}\n[\\S\\s]+?\n\n`
-        ).exec(data)[0];
-        break;
-    default:
-        version = `p${version}`;
-        commitMessage = (
-            /\n\n# v\d\d\d\d\.\d\d?\.\d\d?(?:-.*?)?\n(- [\S\s]+?)(?:\n- |\n\n)/
-        ).exec(data)[1];
-    }
-    branchPull = `branch-${version}`;
-    // update README.md
-    data = await moduleFs.promises.readFile("README.md", "utf8");
-    data = data.replace(
-        new RegExp(
-            (
-                "(\\bhttps:\\/\\/github\\.com\\/[\\w.\\-\\/]+?"
-                + "\\/compare"
-                + "\\/[\\w.\\-\\/]+?\\.\\.\\.[\\w.:\\-\\/]+?)"
-                + `:branch-${version[0]}\\d\\d\\d\\d\\.\\d\\d?\\.\\d\\d?\\b`
-            ),
-            "g"
-        ),
-        `$1:${branchPull}`
-    );
-    await moduleFs.promises.writeFile("README.md", data);
-    // security - sanitize commitMessage
-    commitMessage = commitMessage.trim().replace((/[$\u0027`]/g), "?");
-    moduleChildProcess.spawn(
-        "sh",
-        [
-            "-c",
-            (`
-(set -e
-    . ./jslint_ci.sh
-    npm run test2
-    git push . HEAD:__pr_${branchMerge}_pre -f
-    shGitSquashPop ${branchCheckpoint} \u0027${commitMessage}\u0027
-    git diff origin/${branchPull} || true
-    git push origin alpha:${branchPull} -f
-    git push origin alpha -f
-    shDirHttplinkValidate
-    git push . HEAD:__pr_${branchMerge} -f
-)
-            `)
-        ],
-        {stdio: ["ignore", 1, 2]}
-    ).on("exit", function (exitCode) {
-        moduleAssert.ok(
-            exitCode === 0,
-            `shGitPullrequest - exitCode=${exitCode}`
-        );
-    });
-}());
-' "$@" # '
-)}
-
-shGitPullrequestCleanup() {(set -e
-# This function will cleanup pull-request after merge.
-    git checkout alpha
-    git push . alpha:__pr_upstream_pre -f
-    git fetch upstream beta
-    # verify no diff between alpha..upstream/beta
-    git diff alpha..upstream/beta
-    git reset upstream/beta
-    git push . alpha:beta -f
-    git push origin alpha beta -f
-    sh jslint_ci.sh shMyciUpdate
-    git push . alpha:__pr_upstream -f
-)}
-
 shGitSquashPop() {(set -e
 # This function will squash HEAD to given $COMMIT.
 # http://stackoverflow.com/questions/5189560
@@ -1249,6 +1133,122 @@ shGithubFileUpload() {(set -e
 # example usage:
 # shGithubFileUpload octocat/hello-world/master/hello.txt hello.txt
     shGithubFileDownloadUpload upload "$1" "$2"
+)}
+
+shGithubPrCreate() {(set -e
+# This function will create-and-push a github-pull-commit to origin/alpha.
+    node --input-type=module --eval '
+// init debugInline
+(function () {
+    let consoleError = console.error;
+    globalThis.debugInline = globalThis.debugInline || function (...argList) {
+
+// This function will print <argv> to stderr and then return <argv>[0].
+
+        consoleError("\n\ndebugInline");
+        consoleError(...argList);
+        consoleError("\n");
+        return argList[0];
+    };
+}());
+import moduleAssert from "assert";
+import moduleChildProcess from "child_process";
+import moduleFs from "fs";
+(async function () {
+    let branchCheckpoint = process.argv[2] || "HEAD";
+    let branchMerge = process.argv[1] || "beta";
+    let branchPull;
+    let commitMessage;
+    let data;
+    let version = process.argv[3] || new Date().toISOString().slice(0, 10);
+    version = version.replace((/-0?/g), ".");
+    // security - sanitize branchXxx
+    [
+        branchCheckpoint, branchMerge, version
+    ] = [
+        branchCheckpoint, branchMerge, version
+    ].map(function (branch) {
+        return branch.trim().replace((/[^\w.\-]/g), "_");
+    });
+    data = await moduleFs.promises.readFile("CHANGELOG.md", "utf8");
+    switch (branchMerge) {
+    case "master":
+        version = `v${version}`;
+        // update CHANGELOG.md
+        data = data.replace(
+            /\n\n# v\d\d\d\d\.\d\d?\.\d\d?(?:-.*?)?\n/,
+            `\n\n# ${version}\n`
+        );
+        await moduleFs.promises.writeFile("CHANGELOG.md", data);
+        commitMessage = new RegExp(
+            `\n\n# ${version}\n[\\S\\s]+?\n\n`
+        ).exec(data)[0];
+        break;
+    default:
+        version = `p${version}`;
+        commitMessage = (
+            /\n\n# v\d\d\d\d\.\d\d?\.\d\d?(?:-.*?)?\n(- [\S\s]+?)(?:\n- |\n\n)/
+        ).exec(data)[1];
+    }
+    branchPull = `branch-${version}`;
+    // update README.md
+    data = await moduleFs.promises.readFile("README.md", "utf8");
+    data = data.replace(
+        new RegExp(
+            (
+                "(\\bhttps:\\/\\/github\\.com\\/[\\w.\\-\\/]+?"
+                + "\\/compare"
+                + "\\/[\\w.\\-\\/]+?\\.\\.\\.[\\w.:\\-\\/]+?)"
+                + `:branch-${version[0]}\\d\\d\\d\\d\\.\\d\\d?\\.\\d\\d?\\b`
+            ),
+            "g"
+        ),
+        `$1:${branchPull}`
+    );
+    await moduleFs.promises.writeFile("README.md", data);
+    // security - sanitize commitMessage
+    commitMessage = commitMessage.trim().replace((/[$\u0027`]/g), "?");
+    moduleChildProcess.spawn(
+        "sh",
+        [
+            "-c",
+            (`
+(set -e
+    . ./jslint_ci.sh
+    npm run test2
+    git push . HEAD:__pr_${branchMerge}_pre -f
+    shGitSquashPop ${branchCheckpoint} \u0027${commitMessage}\u0027
+    git diff origin/${branchPull} || true
+    git push origin alpha:${branchPull} -f
+    git push origin alpha -f
+    shDirHttplinkValidate
+    git push . HEAD:__pr_${branchMerge} -f
+)
+            `)
+        ],
+        {stdio: ["ignore", 1, 2]}
+    ).on("exit", function (exitCode) {
+        moduleAssert.ok(
+            exitCode === 0,
+            `shGithubPrCreate - exitCode=${exitCode}`
+        );
+    });
+}());
+' "$@" # '
+)}
+
+shGithubPrCleanup() {(set -e
+# This function will cleanup pull-request after merge.
+    git checkout alpha
+    git push . alpha:__pr_upstream_pre -f
+    git fetch upstream beta
+    # verify no diff between alpha..upstream/beta
+    git diff alpha..upstream/beta
+    git reset upstream/beta
+    git push . alpha:beta -f
+    git push origin alpha beta -f
+    sh jslint_ci.sh shMyciUpdate
+    git push . alpha:__pr_upstream -f
 )}
 
 shGithubTokenExport() {

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -58,7 +58,7 @@
 
 shBashrcDebianInit() {
 # This function will init debian:stable /etc/skel/.bashrc.
-# https://sources.debian.org/src/bash/4.4-5/debian/skel.bashrc/
+# https://salsa.debian.org/debian/bash/-/blob/e17f75c7869a4a00dbad36503c1965040b22ef32/debian/skel.bashrc
     # ~/.bashrc: executed by bash(1) for non-login shells.
     # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
     # for examples
@@ -89,7 +89,7 @@ shBashrcDebianInit() {
     #shopt -s globstar
 
     # make less more friendly for non-text input files, see lesspipe(1)
-    [ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+    #[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
 
     # set variable identifying the chroot you work in (used in the prompt below)
     if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
@@ -107,7 +107,7 @@ shBashrcDebianInit() {
     #force_color_prompt=yes
 
     if [ -n "$force_color_prompt" ]; then
-        if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+        if [ -x /usr/bin/tput ] && tput setaf 1 >/dev/null 2>&1; then
         # We have color support; assume it's compliant with Ecma-48
         # (ISO/IEC-6429). (Lack of such support is extremely rare, and such
         # a case would tend to support setf rather than setaf.)
@@ -140,7 +140,7 @@ shBashrcDebianInit() {
         #alias dir='dir --color=auto'
         #alias vdir='vdir --color=auto'
 
-        alias grep='grep --color=auto'
+        #alias grep='grep --color=auto'
         #alias fgrep='fgrep --color=auto'
         #alias egrep='egrep --color=auto'
     fi
@@ -149,7 +149,7 @@ shBashrcDebianInit() {
     #export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
 
     # some more ls aliases
-    alias ll='ls -alF'
+    #alias ll='ls -l'
     #alias la='ls -A'
     #alias l='ls -CF'
 
@@ -166,11 +166,11 @@ shBashrcDebianInit() {
     # this, if it's already enabled in /etc/bash.bashrc and /etc/profile
     # sources /etc/bash.bashrc).
     if ! shopt -oq posix; then
-        if [ -f /usr/share/bash-completion/bash_completion ]; then
-            . /usr/share/bash-completion/bash_completion
-        elif [ -f /etc/bash_completion ]; then
-            . /etc/bash_completion
-        fi
+      if [ -f /usr/share/bash-completion/bash_completion ]; then
+        . /usr/share/bash-completion/bash_completion
+      elif [ -f /etc/bash_completion ]; then
+        . /etc/bash_completion
+      fi
     fi
 }
 
@@ -370,12 +370,13 @@ shCiArtifactUpload() {(set -e
         done
     fi
     # update README.md with branch-$GITHUB_BRANCH0 and $GITHUB_REPOSITORY
-    sed -i \
+    sed -i.bak \
         -e "s|/branch-[a-z]*/|/branch-$GITHUB_BRANCH0/|g" \
         -e "s|\\b$UPSTREAM_GITHUB_IO\\b|$GITHUB_GITHUB_IO|g" \
         -e "s|\\b$UPSTREAM_REPOSITORY\\b|$GITHUB_REPOSITORY|g" \
         -e "s|_2fbranch-[a-z]*_2f|_2fbranch-${GITHUB_BRANCH0}_2f|g" \
-        "branch-$GITHUB_BRANCH0/README.md"
+        "branch-$GITHUB_BRANCH0/README.md" && \
+        rm -f "branch-$GITHUB_BRANCH0/README.md".bak
     git status
     # git push
     shGitCommitPushOrSquash "" 50
@@ -607,9 +608,10 @@ shCiPublishNpm() {(set -e
     # update package-name
     if [ "$NPM_REGISTRY" = github ]
     then
-        sed -i \
-            "s|^    \"name\":.*|    \"name\": \"@$GITHUB_REPOSITORY\",|" \
-            package.json
+        sed -i.bak \
+            -e "s|^    \"name\":.*|    \"name\": \"@$GITHUB_REPOSITORY\",|" \
+            package.json && \
+            rm -f package.json.bak
     fi
     if (command -v shCiPublishNpmCustom >/dev/null)
     then
@@ -784,8 +786,8 @@ shGitCmdWithGithubToken() {(set -e
     if [ -f .git/config ]
     then
         # security - scrub token from url
-        sed -i.bak "s|://.*@|://|g" .git/config
-        rm -f .git/config.bak
+        sed -i.bak -e "s|://.*@|://|g" .git/config && \
+            rm -f .git/config.bak
     fi
     CMD="$1"
     case "$CMD" in
@@ -887,8 +889,8 @@ shGitInitBase() {(set -e
         git branch -D "$BRANCH" 2>/dev/null || true
         git checkout -b "$BRANCH" base/base
     done
-    sed -i.bak "s|owner/repo|${1:-owner/repo}|" .gitconfig
-    rm -f .gitconfig.bak
+    sed -i.bak -e "s|owner/repo|${1:-owner/repo}|" .gitconfig && \
+        rm -f .gitconfig.bak
     cp .gitconfig .git/config
     git commit -am "update owner/repo to $1" || true
 )}

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -304,10 +304,10 @@ shCiArtifactUpload() {(set -e
     export GITHUB_BRANCH0="$(git branch --show-current)"
     git pull --unshallow origin "$GITHUB_BRANCH0"
     # init $UPSTREAM_XXX
-    export UPSTREAM_REPOSITORY="$(node -p '(
-    /^(?:git\+)?https:\/\/github\.com\/([^\/]*?\/[^.]*?)\.git$/
-).exec(require("./package.json").repository.url)[1]
-')" # '
+    export UPSTREAM_REPOSITORY="$(sed -En \
+        -e 's|.*"git\+https://github\.com/([^.]+)\.git".*|\1|p' \
+        package.json
+    )"
     export UPSTREAM_GITHUB_IO="$(
         printf "$UPSTREAM_REPOSITORY" | sed -e "s|/|.github.io/|"
     )"
@@ -641,10 +641,10 @@ shDirHttplinkValidate() {(set -e
     # init $GITHUB_BRANCH0
     export GITHUB_BRANCH0="${GITHUB_BRANCH0:-alpha}"
     # init $UPSTREAM_XXX
-    export UPSTREAM_REPOSITORY="$(node -p '(
-    /^(?:git\+)?https:\/\/github\.com\/([^\/]*?\/[^.]*?)\.git$/
-).exec(require("./package.json").repository.url)[1]
-')" # '
+    export UPSTREAM_REPOSITORY="$(sed -En \
+        -e 's|.*"git\+https://github\.com/([^.]+)\.git".*|\1|p' \
+        package.json
+    )"
     export UPSTREAM_GITHUB_IO="$(
         printf "$UPSTREAM_REPOSITORY" | sed -e "s|/|.github.io/|"
     )"
@@ -1145,7 +1145,7 @@ shGithubPrCreate() {(set -e
     let consoleError = console.error;
     globalThis.debugInline = globalThis.debugInline || function (...argList) {
 
-// This function will print <argv> to stderr and then return <argv>[0].
+// This function will print <argList> to stderr and then return <argList>[0].
 
         consoleError("\n\ndebugInline");
         consoleError(...argList);
@@ -1253,6 +1253,44 @@ shGithubPrCleanup() {(set -e
     git push . alpha:__pr_upstream -f
 )}
 
+shGithubPrUpdatePrxxx() {(set -e
+# This function will update 'PR-xxx' placeholder in codebase
+# to next sequential github issue/pull number.
+    if ! (git grep -Ei -e '^ *?(//|#) pr-xxx')
+    then
+        return
+    fi
+    export UPSTREAM_REPOSITORY="$(sed -En \
+        -e 's|.*"git\+https://github\.com/([^.]+)\.git".*|\1|p' \
+        package.json
+    )"
+    PR_XXX="$(curl -fs --ssl-no-revoke \
+"https://api.github.com/repos/$UPSTREAM_REPOSITORY/issues?per_page=1&state=all"
+    )"
+    PR_XXX="$(
+        printf "$PR_XXX" | sed -En -e 's/.*"number": ([0-9]+).*/\1/p'
+    )"
+    if [ ! "$PR_XXX" ]
+    then
+        return
+    fi
+    PR_XXX="PR-$((PR_XXX + 1))"
+    FILE_LIST="$(
+        git grep -Ei -e '^ *?(//|#) pr-xxx - ' | sed -E -e 's/:.*//' | sort -u
+    )"
+    for FILE in $FILE_LIST
+    do
+        sed -Ei.bak \
+            -e "s/^ *?(\/\/|#) pr-xxx - /\1 $PR_XXX - /gi" \
+            "$FILE" && \
+            rm -f "$FILE".bak
+    done
+    git diff
+    git grep -Ei -e '^ *?(//|#) pr-xxx' || true
+    git commit -am "- ci - Update 'PR-xxx' placeholder to '${PR_XXX}'."
+    git log -n 2
+)}
+
 shGithubTokenExport() {
 # This function will export $MY_GITHUB_TOKEN from file.
     if [ ! "$MY_GITHUB_TOKEN" ]
@@ -1273,6 +1311,7 @@ shGithubWorkflowDispatch() {(set -e
     EXIT_CODE=0
     curl \
 "https://api.github.com/repos/$REPO/actions/workflows/ci.yml/dispatches" \
+        --ssl-no-revoke \
         -H "accept: application/vnd.github.v3+json" \
         -H "authorization: Bearer $MY_GITHUB_TOKEN" \
         -X POST \

--- a/test.mjs
+++ b/test.mjs
@@ -691,7 +691,7 @@ jstestDescribe((
             ],
             destructure: [
 
-// PR-xxx - Unify ES2015-destructure-logic.
+// PR-500 - Unify ES2015-destructure-logic.
 
                 [
                     `(function ({expr}) {\n    aa(bb, cc, dd, zz);\n}());`,

--- a/test.mjs
+++ b/test.mjs
@@ -690,27 +690,34 @@ jstestDescribe((
                 "let aa = aa.aa().getTime();"
             ],
             destructure: [
-                [
 
 // PR-xxx - Unify ES2015-destructure-logic.
 
-                    "\nlet aa;\nlet bb;\nlet cc;\nlet dd;\nlet zz;\n",
-                    "const ",
-                    "let "
-                ].map(function (prefix) {
-                    return (
-                        `/\*jslint node*\/\n`
-                        + `${prefix}[{\n`
+                [
+                    `(function ({expr}) {\n    aa(bb, cc, dd, zz);\n}());`,
+                    `const {expr}`,
+                    `let [aa, bb, cc, dd, zz] = 0;\n{expr}`,
+                    `let {expr}`
+                ].map(function (source) {
+                    source = source.replace("{expr}", (
+                        `[{\n`
                         + `    aa,\n`
                         + `    bb = 0,\n`
                         + `    bb: cc,\n`
                         + `    dd: [{dd}],\n`
                         + `    ...zz\n`
-                        + `}] = (function () {\n`
-                        + `    return;\n`
-                        + `}());\n`
-                        + `aa(bb, cc, dd, zz);\n`
-                    );
+                        + `}]`
+                    ));
+                    if (!(/function/).test(source)) {
+                        source = (
+                            `${source} = (function () {\n`
+                            + `    return;\n`
+                            + `}());\n`
+                            + `aa(bb, cc, dd, zz);\n`
+                        );
+                    }
+                    source = `/*jslint node*/\n${source}`;
+                    return source;
                 }),
 
 // PR-459 - Allow destructuring-assignment after function-definition.

--- a/test.mjs
+++ b/test.mjs
@@ -690,7 +690,32 @@ jstestDescribe((
                 "let aa = aa.aa().getTime();"
             ],
             destructure: [
-                "let [\n    , aa, bb = 0, ...cc\n] = 0;\naa(bb, cc);",
+
+// PR-363 - Bugfix
+// Add test against false-warning <uninitialized 'bb'> in source
+// '/*jslint node*/\nlet {aa:bb} = {}; bb();'.
+
+// PR-xxx - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
+
+                [
+                    //!! "\nlet aa;\nlet bb;\nlet cc;\nlet dd;\nlet zz;\n(",
+                    "const ",
+                    "let "
+                ].map(function (prefix) {
+                    return (
+                        `/\*jslint node*\/\n`
+                        + `${prefix}[{\n`
+                        + `    aa,\n`
+                        + `    bb = 0,\n`
+                        + `    bb: cc,\n`
+                        + `    dd: [{dd}],\n`
+                        + `    ...zz\n`
+                        + `}] = (function () {\n`
+                        + `    return;\n`
+                        + `}());\n`
+                        + `aa(bb, cc, dd, zz);\n`
+                    );
+                }),
 
 // PR-459 - Allow destructuring-assignment after function-definition.
 
@@ -701,16 +726,8 @@ jstestDescribe((
                     + "    return;\n"
                     + "}\n"
                     + "[aa, bb] = cc();\n"
-                ),
-                (
-                    "let {\n"
-                    + "    aa,\n"
-                    + "    bb = 0,\n"
-                    + "    cc: dd,\n"
-                    + "    ...ee\n"
-                    + "} = 0;\n"
                 )
-            ],
+            ].flat(),
             directive: [
                 "#!\n/*jslint browser:false, node*/\n\"use strict\";",
                 "/*property aa bb*/"
@@ -928,11 +945,6 @@ jstestDescribe((
                 )
             ],
             var: [
-
-// PR-363 - Bugfix
-// Add test against false-warning <uninitialized 'bb'> in code
-// '/*jslint node*/\nlet {aa:bb} = {}; bb();'.
-
                 "/*jslint node*/\n",
                 ""
             ].map(function (directive) {
@@ -940,29 +952,29 @@ jstestDescribe((
                     "const aa = 0;\naa();\n",
                     "let aa = 0;\naa();\n",
                     "var aa = 0;\naa();\n"
-                ].map(function (code) {
-                    return directive + code;
+                ].map(function (source) {
+                    return directive + source;
                 });
             }).flat()
         }).forEach(function (codeList) {
             let elemPrv = "";
-            codeList.forEach(function (code) {
+            codeList.forEach(function (source) {
                 let warnings;
                 // Assert codeList is sorted.
-                assertOrThrow(elemPrv < code, JSON.stringify([
-                    elemPrv, code
+                assertOrThrow(elemPrv < source, JSON.stringify([
+                    elemPrv, source
                 ], undefined, 4));
-                elemPrv = code;
+                elemPrv = source;
                 [
                     jslint.jslint,
                     jslintCjs.jslint
                 ].forEach(function (jslint) {
-                    warnings = jslint(code, {
+                    warnings = jslint(source, {
                         beta: true
                     }).warnings;
                     assertOrThrow(
                         warnings.length === 0,
-                        JSON.stringify([code, warnings])
+                        `${source}\n${JSON.stringify(warnings, undefined, 4)}`
                     );
                 });
             });
@@ -1093,15 +1105,14 @@ jstestDescribe((
                 jslintCjs.jslint
             ].forEach(function (jslint) {
                 // test jslint's option handling-behavior
+                let warnings = jslint(
+                    source,
+                    option_dict,
+                    global_list
+                ).warnings;
                 assertOrThrow(
-                    jslint(
-                        source,
-                        option_dict,
-                        global_list
-                    ).warnings.length === warningsLength,
-                    "jslint.jslint(" + JSON.stringify([
-                        source, option_dict, global_list
-                    ]) + ")"
+                    warnings.length === warningsLength,
+                    `${source}\n${JSON.stringify(warnings, undefined, 4)}`
                 );
                 // test jslint's directive handling-behavior
                 source = (

--- a/test.mjs
+++ b/test.mjs
@@ -690,15 +690,11 @@ jstestDescribe((
                 "let aa = aa.aa().getTime();"
             ],
             destructure: [
-
-// PR-363 - Bugfix
-// Add test against false-warning <uninitialized 'bb'> in source
-// '/*jslint node*/\nlet {aa:bb} = {}; bb();'.
-
-// PR-xxx - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
-
                 [
-                    //!! "\nlet aa;\nlet bb;\nlet cc;\nlet dd;\nlet zz;\n(",
+
+// PR-xxx - Unify ES2015-destructure-logic.
+
+                    "\nlet aa;\nlet bb;\nlet cc;\nlet dd;\nlet zz;\n",
                     "const ",
                     "let "
                 ].map(function (prefix) {


### PR DESCRIPTION
This PR will:
- jslint-ecma - Unify ES2015-destructure-logic into function prefix_destructure().

This PR will additionally:
- jslint-ci - Add shell-function shGithubPrUpdatePrxxx() to auto-update 'PR-xxx' placeholder to next sequential github issue/pull number.
- jslint-ci - Rename shell-functions shGitPullrequestXxx() to shGithubPrXxx().

e.g. destructuring in functions and non-variable-assignments, will have same capability as variable-assignments:

```js
/*jslint node*/
(function ([{
    aa,
    bb = 0,
    bb: cc,
    dd: [{dd}],
    ...zz
}]) {
    aa(bb, cc, dd, zz);
}());

let [{
    aa,
    bb = 0,
    bb: cc,
    dd: [{dd}],
    ...zz
}] = (function () {
    return;
}());
aa(bb, cc, dd, zz);

[{
    aa,
    bb = 0,
    bb: cc,
    dd: [{dd}],
    ...zz
}] = (function () {
    return;
}());
aa(bb, cc, dd, zz);

```

<img width="653" height="1204" alt="image" src="https://github.com/user-attachments/assets/10f417cc-6f54-495d-b123-05bd46ae6794" />

