### PR TITLE
- jslint-regression - Fix long-running regression where 'let x = x;' doesn't warn about temporal-dead-zone.

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -156,7 +156,7 @@ import moduleChildProcess from "child_process";
     GITHUB_REPO_BASENAME="$(printf "$GITHUB_GITHUB_IO" | cut -d'/' -f2)"
     if [ "$GITHUB_REPO_BASENAME" != jslint ]
     then
-        for FILE in $(ls .artifact/*_2f"${GITHUB_REPO_BASENAME}"_2f*)
+        for FILE in .artifact/*_2f"$GITHUB_REPO_BASENAME"_2f*
         do
             mv "$FILE" "$(printf "$FILE" | \
                 sed -e "s|_2f${GITHUB_REPO_BASENAME}_2f|_2fjslint_2f|")"

--- a/.ci.sh
+++ b/.ci.sh
@@ -456,7 +456,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2026.6.1"
+                "version": "2026.6.30"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/.ci.sh
+++ b/.ci.sh
@@ -456,7 +456,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2026.6.30"
+                "version": "2026.6.1"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/.ci.sh
+++ b/.ci.sh
@@ -456,7 +456,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2026.6.30"
+                "version": "2026.7.1"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/.gitconfig
+++ b/.gitconfig
@@ -2,9 +2,6 @@
 [branch "alpha"]
     merge = refs/heads/alpha
     remote = origin
-[branch "alpha2"]
-    merge = refs/heads/alpha2
-    remote = origin
 [branch "base"]
     merge = refs/heads/base
     remote = origin

--- a/.gitconfig
+++ b/.gitconfig
@@ -2,6 +2,9 @@
 [branch "alpha"]
     merge = refs/heads/alpha
     remote = origin
+[branch "alpha2"]
+    merge = refs/heads/alpha2
+    remote = origin
 [branch "base"]
     merge = refs/heads/base
     remote = origin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 # v2026.6.1-beta
 - jslint - regression-fix - Revisit warn about variable usage before initialization.
+- jslint - Wrap all property-updates 'name.init = true/false' with calls to:
+    name_lookup() - 'aa=0'
+    name_push()   - 'let aa=0'
 - jslint-ecma - Unify ES2015-destructure-logic into function prefix_destructure().
 - jslint-ci - Add shell-function shGithubPrUpdatePrxxx() to auto-update 'PR-xxx' placeholder to next sequential github issue/pull number.
 - jslint-ci - Rename shell-functions shGitPullrequestXxx() to shGithubPrXxx().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 # Todo
+- jslint-regression - Fix multiline-method-chaining whitespace-check not working when function-call's parameter-list spans more than one line.
+- jslint-warning - Tighten warning of unused variables to be always on, regardless of module / nodejs mode.
 - jslint-warning - Relax warnings for console.log() and friends.
 - jslint-warning - Relax fat-arrow-warning "use_function_not_fart".
 - jslint-ci - Automate linting of shell-scripts with shellcheck.
@@ -13,7 +15,7 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.6.1-beta
-- jslint - regression-fix - Revisit warn about variable usage before initialization.
+- jslint-regression - Fix long-running regression where 'let x = x;' doesn't warn about uninitialized variables.
 - jslint - Wrap all property-updates 'name.init = true/false' with calls to:
     name_lookup() - 'aa=0'
     name_push()   - 'let aa=0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,19 @@
 - jslint - Add new warning requiring paren around plus-separated concatenations.
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
-# v2026.6.1-beta
+# v2026.7.1-beta
 - jslint-regression - Fix long-running regression where 'let x = x;' doesn't warn about uninitialized variables.
 - jslint-warning - Tighten warning of unused variables to be always on, regardless of module / nodejs mode.
 - jslint-warning - Relax fat-arrow-warning "use_function_not_fart".
 - jslint - Wrap all property-updates 'name.init = true/false' with calls to:
     name_lookup() - 'aa=0'
     name_push()   - 'let aa=0'
+
+# v2026.6.30
+- jslint-ecma - Update README.md, documenting supported ES2015+ features.
 - jslint-ecma - Unify ES2015-destructure-logic into function prefix_destructure().
 - jslint-ci - Add shell-function shGithubPrUpdatePrxxx() to auto-update 'PR-xxx' placeholder to next sequential github issue/pull number.
 - jslint-ci - Rename shell-functions shGitPullrequestXxx() to shGithubPrXxx().
-- jslint-ecma - Update README.md, documenting supported ES2015+ features.
 - jslint - Update warning infix_in to recommend Object.hasOwn() over hasOwnProperty().
 - jslint-ecma - Add ES2025-feature RegExp Modifiers.
 - jslint-ecma - Add ES2022-feature RegExp Match Indices.
@@ -40,10 +42,10 @@
 - jslint-ecma - Add ES2021-feature WeakRef to global-scope.
 - jslint-ecma - Update ES2015-feature arrow, to continue parsing unwrapped-form with warning, instead of stopping.
 - jslint - Relax warning on multiline-method-chaining.
-- jslint - Replace all non-return "stop(...);" with "return stop(...)".
+- jslint - Replace all non-return 'stop(...);' with 'return stop(...)'.
 - jslint - Unify ES2018-syntax-spread-operator with function prefix_ellipsis().
 - jslint - Add ES2018-syntax for object-literal-spread-operator.
-- jslint - Add ES2025-syntax "import ... with {...}".
+- jslint - Add ES2025-syntax 'import ... with {...}'.
 - jslint - Allow more methods to be called on literal strings and arrays; make allowed methods for . and ?. consistent.
 
 # v2026.4.30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 # v2026.7.1-beta
 - jslint-regression - Fix long-running regression where 'let x = x;' doesn't warn about temporal-dead-zone.
 - jslint-warning - Tighten warning of unused variables to be always on, regardless of module / nodejs mode.
-- jslint-warning - Relax fat-arrow-warning "use_function_not_fart".
 - jslint - Wrap all property-updates 'name.init = true/false' with calls to:
     name_lookup() - 'aa=0'
     name_push()   - 'let aa=0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 # Todo
+- jslint-warning - Relax warnings for console.log() and friends.
 - jslint-warning - Relax fat-arrow-warning "use_function_not_fart".
 - jslint-ci - Automate linting of shell-scripts with shellcheck.
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@
 - jslint - Add new warning requiring paren around plus-separated concatenations.
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
-# v2026.6.30
-- jslint-ecma - Update README.md, documenting supported ES2015+ features.
+# v2026.6.1-beta
 - jslint-ecma - Unify ES2015-destructure-logic into function prefix_destructure().
 - jslint-ci - Add shell-function shGithubPrUpdatePrxxx() to auto-update 'PR-xxx' placeholder to next sequential github issue/pull number.
 - jslint-ci - Rename shell-functions shGitPullrequestXxx() to shGithubPrXxx().
+- jslint-ecma - Update README.md, documenting supported ES2015+ features.
 - jslint - Update warning infix_in to recommend Object.hasOwn() over hasOwnProperty().
 - jslint-ecma - Add ES2025-feature RegExp Modifiers.
 - jslint-ecma - Add ES2022-feature RegExp Match Indices.
@@ -32,10 +32,10 @@
 - jslint-ecma - Add ES2021-feature WeakRef to global-scope.
 - jslint-ecma - Update ES2015-feature arrow, to continue parsing unwrapped-form with warning, instead of stopping.
 - jslint - Relax warning on multiline-method-chaining.
-- jslint - Replace all non-return 'stop(...);' with 'return stop(...)'.
+- jslint - Replace all non-return "stop(...);" with "return stop(...)".
 - jslint - Unify ES2018-syntax-spread-operator with function prefix_ellipsis().
 - jslint - Add ES2018-syntax for object-literal-spread-operator.
-- jslint - Add ES2025-syntax 'import ... with {...}'.
+- jslint - Add ES2025-syntax "import ... with {...}".
 - jslint - Allow more methods to be called on literal strings and arrays; make allowed methods for . and ?. consistent.
 
 # v2026.4.30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 # Todo
+- jslint-warning - Relax fat-arrow-warning "use_function_not_fart".
 - jslint-ci - Automate linting of shell-scripts with shellcheck.
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
 - jslint - Relax warning expected_line_break_a_b for ternary-operator inside template-literal.
@@ -11,6 +12,7 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.6.1-beta
+- jslint - regression-fix - Revisit warn about variable usage before initialization.
 - jslint-ecma - Unify ES2015-destructure-logic into function prefix_destructure().
 - jslint-ci - Add shell-function shGithubPrUpdatePrxxx() to auto-update 'PR-xxx' placeholder to next sequential github issue/pull number.
 - jslint-ci - Rename shell-functions shGitPullrequestXxx() to shGithubPrXxx().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.7.1-beta
-- jslint-regression - Fix long-running regression where 'let x = x;' doesn't warn about uninitialized variables.
+- jslint-regression - Fix long-running regression where 'let x = x;' doesn't warn about temporal-dead-zone.
 - jslint-warning - Tighten warning of unused variables to be always on, regardless of module / nodejs mode.
 - jslint-warning - Relax fat-arrow-warning "use_function_not_fart".
 - jslint - Wrap all property-updates 'name.init = true/false' with calls to:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 # Todo
 - jslint-regression - Fix multiline-method-chaining whitespace-check not working when function-call's parameter-list spans more than one line.
-- jslint-warning - Tighten warning of unused variables to be always on, regardless of module / nodejs mode.
 - jslint-warning - Relax warnings for console.log() and friends.
-- jslint-warning - Relax fat-arrow-warning "use_function_not_fart".
 - jslint-ci - Automate linting of shell-scripts with shellcheck.
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
 - jslint - Relax warning expected_line_break_a_b for ternary-operator inside template-literal.
@@ -16,6 +14,8 @@
 
 # v2026.6.1-beta
 - jslint-regression - Fix long-running regression where 'let x = x;' doesn't warn about uninitialized variables.
+- jslint-warning - Tighten warning of unused variables to be always on, regardless of module / nodejs mode.
+- jslint-warning - Relax fat-arrow-warning "use_function_not_fart".
 - jslint - Wrap all property-updates 'name.init = true/false' with calls to:
     name_lookup() - 'aa=0'
     name_push()   - 'let aa=0'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2026.6.30)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2026.4.30)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/index.html) |
@@ -1016,30 +1016,24 @@ if (false) {
     - verify `<CHANGELOG.md entry #1>` is most-relevant to pull-request.
     - run
         ```shell
-        # re-run until version propagates
-        npm run test2
+        npm run test2 # re-run until version propagates
 
-        # update 'PR-xxx' placeholder
+        git commit -am "<CHANGELOG.md entries>"
+        ```
+    - run
+        ```shell
         sh jslint_ci.sh shGithubPrUpdatePrxxx
 
-        # re-run until version propagates
-        sh jslint_ci.sh shGithubPrCreate alpha beta # v20xx.xx.xx
+        git push . HEAD:beta -f
 
-        # squash intermediary commits
-        sh jslint_ci.sh shGitSquashPop __pr_beta_pre "- ci - shGithubPrUpdatePrxxx."
-
-        # squash intermediary commits
-        sh jslint_ci.sh shGithubPrCreate alpha beta # v20xx.xx.xx
-
-        # squash intermediary commits
-        git push . __pr_beta_pre~:__pr_beta_pre -f
+        sh jslint_ci.sh shGithubPrCreate beta beta # 20xx-xx-xx
 
         git push upstream alpha -f
         ```
         - verify ci-success @ https://github.com/kaizhu256/jslint/actions
         - verify ci-success @ https://github.com/jslint-org/jslint/actions
 
-1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.7.1
+1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.6.28
     - click `Create pull request`
     - input `Add a title *` with: `<CHANGELOG.md entry #1>`
     - input `Add a description` with:
@@ -1054,7 +1048,6 @@ if (false) {
 
         <screenshot>
         ```
-    - click `Preview` and review
     - verify:
         - base respository: `jslint-org/jslint`
         - base: `beta`
@@ -1083,30 +1076,24 @@ if (false) {
     - verify `<CHANGELOG.md entry #1>` is most-relevant to pull-request.
     - run
         ```shell
-        # re-run until version propagates
-        npm run test2
+        npm run test2 # re-run until version propagates
 
-        # update 'PR-xxx' placeholder
+        git commit -am "<CHANGELOG.md entries>"
+        ```
+    - run
+        ```shell
         sh jslint_ci.sh shGithubPrUpdatePrxxx
 
-        # re-run until version propagates
-        sh jslint_ci.sh shGithubPrCreate alpha master # v20xx.xx.xx
+        git push . HEAD:beta -f
 
-        # squash intermediary commits
-        sh jslint_ci.sh shGitSquashPop __pr_master_pre "- ci - shGithubPrUpdatePrxxx."
-
-        # squash intermediary commits
-        sh jslint_ci.sh shGithubPrCreate alpha master # v20xx.xx.xx
-
-        # squash intermediary commits
-        git push . __pr_master_pre~:__pr_master_pre -f
+        sh jslint_ci.sh shGithubPrCreate master beta
 
         git push upstream alpha -f
         ```
         - verify ci-success @ https://github.com/kaizhu256/jslint/actions
         - verify ci-success @ https://github.com/jslint-org/jslint/actions
 
-1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-v2026.6.30
+1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-v2026.4.30
     - click `Create pull request`
     - input `Add a title *` with: `# v20yy.mm.dd`
     - input `Add a description` with:
@@ -1114,7 +1101,6 @@ if (false) {
         <CHANGELOG.md entry #1>
         <CHANGELOG.md entry extra>
         ```
-    - click `Preview` and review
     - verify:
         - base respository: `jslint-org/jslint`
         - base: `beta`
@@ -1172,7 +1158,7 @@ if (false) {
 
         **Full Changelog**: ...
         ```
-    - click `Preview` and review
+        - click `Preview` and review
     - click `Latest`
     - click `Publish release`
         - verify ci-success @ https://github.com/jslint-org/jslint/actions

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2026.4.30)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2026.6.30)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/index.html) |
@@ -1016,24 +1016,30 @@ if (false) {
     - verify `<CHANGELOG.md entry #1>` is most-relevant to pull-request.
     - run
         ```shell
-        npm run test2 # re-run until version propagates
+        # re-run until version propagates
+        npm run test2
 
-        git commit -am "<CHANGELOG.md entries>"
-        ```
-    - run
-        ```shell
+        # update 'PR-xxx' placeholder
         sh jslint_ci.sh shGithubPrUpdatePrxxx
 
-        git push . HEAD:beta -f
+        # re-run until version propagates
+        sh jslint_ci.sh shGithubPrCreate alpha beta # v20xx.xx.xx
 
-        sh jslint_ci.sh shGithubPrCreate beta beta # 20xx-xx-xx
+        # squash intermediary commits
+        sh jslint_ci.sh shGitSquashPop __pr_beta_pre "- ci - shGithubPrUpdatePrxxx."
+
+        # squash intermediary commits
+        sh jslint_ci.sh shGithubPrCreate alpha beta # v20xx.xx.xx
+
+        # squash intermediary commits
+        git push . __pr_beta_pre~:__pr_beta_pre -f
 
         git push upstream alpha -f
         ```
         - verify ci-success @ https://github.com/kaizhu256/jslint/actions
         - verify ci-success @ https://github.com/jslint-org/jslint/actions
 
-1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.6.28
+1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.7.1
     - click `Create pull request`
     - input `Add a title *` with: `<CHANGELOG.md entry #1>`
     - input `Add a description` with:
@@ -1048,6 +1054,7 @@ if (false) {
 
         <screenshot>
         ```
+    - click `Preview` and review
     - verify:
         - base respository: `jslint-org/jslint`
         - base: `beta`
@@ -1076,24 +1083,30 @@ if (false) {
     - verify `<CHANGELOG.md entry #1>` is most-relevant to pull-request.
     - run
         ```shell
-        npm run test2 # re-run until version propagates
+        # re-run until version propagates
+        npm run test2
 
-        git commit -am "<CHANGELOG.md entries>"
-        ```
-    - run
-        ```shell
+        # update 'PR-xxx' placeholder
         sh jslint_ci.sh shGithubPrUpdatePrxxx
 
-        git push . HEAD:beta -f
+        # re-run until version propagates
+        sh jslint_ci.sh shGithubPrCreate alpha master # v20xx.xx.xx
 
-        sh jslint_ci.sh shGithubPrCreate master beta
+        # squash intermediary commits
+        sh jslint_ci.sh shGitSquashPop __pr_master_pre "- ci - shGithubPrUpdatePrxxx."
+
+        # squash intermediary commits
+        sh jslint_ci.sh shGithubPrCreate alpha master # v20xx.xx.xx
+
+        # squash intermediary commits
+        git push . __pr_master_pre~:__pr_master_pre -f
 
         git push upstream alpha -f
         ```
         - verify ci-success @ https://github.com/kaizhu256/jslint/actions
         - verify ci-success @ https://github.com/jslint-org/jslint/actions
 
-1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-v2026.4.30
+1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-v2026.6.30
     - click `Create pull request`
     - input `Add a title *` with: `# v20yy.mm.dd`
     - input `Add a description` with:
@@ -1101,6 +1114,7 @@ if (false) {
         <CHANGELOG.md entry #1>
         <CHANGELOG.md entry extra>
         ```
+    - click `Preview` and review
     - verify:
         - base respository: `jslint-org/jslint`
         - base: `beta`
@@ -1158,7 +1172,7 @@ if (false) {
 
         **Full Changelog**: ...
         ```
-        - click `Preview` and review
+    - click `Preview` and review
     - click `Latest`
     - click `Publish release`
         - verify ci-success @ https://github.com/jslint-org/jslint/actions

--- a/README.md
+++ b/README.md
@@ -1023,16 +1023,7 @@ if (false) {
         sh jslint_ci.sh shGithubPrUpdatePrxxx
 
         # re-run until version propagates
-        sh jslint_ci.sh shGithubPrCreate alpha beta # v20xx.xx.xx
-
-        # squash intermediary commits
-        sh jslint_ci.sh shGitSquashPop __pr_beta_pre "- ci - shGithubPrUpdatePrxxx."
-
-        # squash intermediary commits
-        sh jslint_ci.sh shGithubPrCreate alpha beta # v20xx.xx.xx
-
-        # squash intermediary commits
-        git push . __pr_beta_pre~:__pr_beta_pre -f
+        sh jslint_ci.sh shGithubPrCreate alpha beta # v20yy.mm.dd __pr_beta_pre
 
         git push upstream alpha -f
         ```
@@ -1090,16 +1081,7 @@ if (false) {
         sh jslint_ci.sh shGithubPrUpdatePrxxx
 
         # re-run until version propagates
-        sh jslint_ci.sh shGithubPrCreate alpha master # v20xx.xx.xx
-
-        # squash intermediary commits
-        sh jslint_ci.sh shGitSquashPop __pr_master_pre "- ci - shGithubPrUpdatePrxxx."
-
-        # squash intermediary commits
-        sh jslint_ci.sh shGithubPrCreate alpha master # v20xx.xx.xx
-
-        # squash intermediary commits
-        git push . __pr_master_pre~:__pr_master_pre -f
+        sh jslint_ci.sh shGithubPrCreate alpha master # v20yy.mm.dd __pr_master_pre
 
         git push upstream alpha -f
         ```

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -4891,7 +4891,22 @@ function jslint_phase3_parse(state) {
     }
 
     function infix_fart_unwrapped() {
-        return parse_fart(token_now, true);
+        if (!token_prv.identifier) {
+
+// test_cause:
+// ["0=>0", "infix_fart_unwrapped", "expected_identifier_a", "0", 1]
+
+            return stop("expected_identifier_a", token_prv);
+        }
+
+// PR-499 - Update ES2015-feature arrow, to continue parsing unwrapped-form
+// with warning, instead of stopping.
+
+// test_cause:
+// ["aa=>0", "infix_fart_unwrapped", "wrap_fart_parameter", "=>", 3]
+
+        warn("wrap_fart_parameter", token_now);
+        return prefix_function(token_now, true, true);
     }
 
     function infix_grave(left) {
@@ -5250,87 +5265,6 @@ function jslint_phase3_parse(state) {
             left = the_symbol.led_infix(left);
         }
         return left;
-    }
-
-    function parse_fart(the_fart, mode_infix_fart) {
-
-// Give the function properties storing its names and for observing the depth
-// of loops and switches.
-
-        Object.assign(the_fart, {
-            arity: "binary",
-            context: empty(),
-            finally: 0,
-            level: functionage.level + 1,
-            loop: 0,
-            name: anon,
-            switch: 0,
-            try: 0
-        });
-
-// PR-384 - Relax warning "function_in_loop".
-//
-//         if (functionage.loop > 0) {
-
-// // test_cause:
-// // ["while(0){aa.map(()=>0);}", "parse_fart", "function_in_loop", "=>", 19]
-//
-//             warn("function_in_loop", the_fart);
-//         }
-
-// Push the current function context and establish a new one.
-
-        function_list.push(the_fart);
-        function_stack.push(functionage);
-        functionage = the_fart;
-
-// Parse the parameter list.
-
-        prefix_function_parameter(the_fart, mode_infix_fart);
-        if (!mode_infix_fart) {
-            advance("=>");
-        }
-
-// The function's body is a block.
-
-        if (token_nxt.id === "{") {
-            if (!option_dict.fart) {
-
-// test_cause:
-// ["()=>{}", "parse_fart", "use_function_not_fart", "=>", 3]
-
-                warn("use_function_not_fart", the_fart);
-            }
-            the_fart.block = block("body");
-
-// The function's body is an expression.
-
-        } else {
-
-// PR-384 - Bugfix - Fixes issue #379 - warn against naked-statement in fart.
-
-            if (
-                syntax_dict[token_nxt.id] !== undefined
-                && syntax_dict[token_nxt.id].fud_stmt !== undefined
-            ) {
-
-// test_cause:
-// ["()=>delete aa", "parse_fart", "unexpected_a_after_b", "=>", 5]
-
-                return stop(
-                    "unexpected_a_after_b",
-                    token_nxt,
-                    token_nxt.id,
-                    "=>"
-                );
-            }
-            the_fart.expression = parse_expression(0);
-        }
-
-// Restore the previous context.
-
-        functionage = function_stack.pop();
-        return the_fart;
     }
 
     function parse_json() {
@@ -5968,9 +5902,12 @@ function jslint_phase3_parse(state) {
         return stop("expected_a_before_b", token_now, "()", "=>");
     }
 
-    function prefix_function(the_function) {
-        let name = the_function && the_function.name;
-        if (the_function === undefined) {
+    function prefix_function(the_function, mode_fart, mode_infix_fart) {
+        let name = the_function?.name;
+        if (mode_fart) {
+            the_function.arity = "binary";
+            the_function.name = anon;
+        } else if (!the_function) {
             the_function = token_now;
 
 // A function statement must have a name that will be in the parent's scope.
@@ -5995,7 +5932,7 @@ function jslint_phase3_parse(state) {
                     init: true
                 });
                 advance();
-            } else if (name === undefined) {
+            } else if (!name) {
 
 // A function expression may have an optional name.
 
@@ -6006,6 +5943,21 @@ function jslint_phase3_parse(state) {
                     advance();
                 }
             }
+        }
+        if (
+            !mode_fart
+            && the_function.arity !== "statement"
+            && typeof name === "object"
+        ) {
+
+// test_cause:
+// ["let aa=function bb(){return;};", "prefix_function", "expression", "bb", 0]
+
+            test_cause("expression", name.id);
+            name_enroll(name, "function", true);
+            name.dead = false;
+            name.init = true;
+            name.used = 1;
         }
 
 //  Probably deadcode.
@@ -6042,19 +5994,17 @@ function jslint_phase3_parse(state) {
             switch: 0,
             try: 0
         });
-        if (the_function.arity !== "statement" && typeof name === "object") {
 
-// test_cause:
-// ["let aa=function bb(){return;};", "prefix_function", "expression", "bb", 0]
+// PR-384 - Relax warning "function_in_loop".
+//
+//         if (functionage.loop > 0) {
 
-            test_cause("expression", name.id);
-            name_enroll(name, "function", true);
-            name.dead = false;
-            name.init = true;
-            name.used = 1;
-        }
+// // test_cause:
+// // ["while(0){aa.map(()=>0);}", "parse_fart", "function_in_loop", "=>", 19]
+//
+//             warn("function_in_loop", the_function);
+//         }
 
-// PR-334 - Bugfix - fix function-redefinition not warned inside function-call.
 // Push the current function context and establish a new one.
 
         function_list.push(the_function);
@@ -6063,54 +6013,94 @@ function jslint_phase3_parse(state) {
 
 // Parse the parameter list.
 
-        advance("(");
-        token_now.arity = "function";
-        prefix_function_parameter(the_function);
+        if (mode_fart) {
+            prefix_function_parameter(the_function, mode_infix_fart);
+            if (!mode_infix_fart) {
+                advance("=>");
+            }
+        } else {
+            advance("(");
+            token_now.arity = "function";
+            prefix_function_parameter(the_function);
+        }
+        if (mode_fart && token_nxt.id !== "{") {
+
+// The function's body is an expression.
+
+// PR-384 - Bugfix - Fixes issue #379 - warn against naked-statement in fart.
+
+            if (
+                syntax_dict[token_nxt.id]
+                && syntax_dict[token_nxt.id].fud_stmt
+            ) {
+
+// test_cause:
+// ["()=>delete aa", "prefix_function", "unexpected_a_after_b", "=>", 5]
+
+                return stop(
+                    "unexpected_a_after_b",
+                    token_nxt,
+                    token_nxt.id,
+                    "=>"
+                );
+            }
+            the_function.expression = parse_expression(0);
+        } else if (mode_fart) {
 
 // The function's body is a block.
 
-        the_function.block = block("body");
-        if (
-            the_function.arity === "statement"
-            && token_nxt.line === token_now.line
-        ) {
+            if (!option_dict.fart) {
+
+// test_cause:
+// ["()=>{}", "prefix_function", "use_function_not_fart", "=>", 3]
+
+                warn("use_function_not_fart", the_function);
+            }
+            the_function.block = block("body");
+        } else {
+            the_function.block = block("body");
+            if (
+                the_function.arity === "statement"
+                && token_nxt.line === token_now.line
+            ) {
 
 // test_cause:
 // ["function aa(){}0", "prefix_function", "unexpected_a", "0", 16]
 
-            return stop("unexpected_a");
-        }
-        if (
-            token_nxt.id === "."
-            || token_nxt.id === "?."
+                return stop("unexpected_a");
+            }
+            if (
+                token_nxt.id === "."
+                || token_nxt.id === "?."
 
 // PR-459 - Allow destructuring-assignment after function-definition.
 
-            // || token_nxt.id === "["
-        ) {
+                // || token_nxt.id === "["
+            ) {
 
 // test_cause:
 // ["function aa(){}\n.aa", "prefix_function", "unexpected_a", ".", 1]
 // ["function aa(){}\n?.aa", "prefix_function", "unexpected_a", "?.", 1]
 
-            warn("unexpected_a");
-        }
+                warn("unexpected_a");
+            }
 
 // Check functions are ordered.
 
-        check_ordered(
-            "function",
-            function_list.slice(
-                function_list.indexOf(the_function) + 1
-            ).map(function ({
-                level,
-                name
-            }) {
-                return (level === the_function.level + 1) && name;
-            }).filter(function (name) {
-                return option_dict.beta && name && name.id;
-            })
-        );
+            check_ordered(
+                "function",
+                function_list.slice(
+                    function_list.indexOf(the_function) + 1
+                ).map(function ({
+                    level,
+                    name
+                }) {
+                    return (level === the_function.level + 1) && name;
+                }).filter(function (name) {
+                    return option_dict.beta && name && name.id;
+                })
+            );
+        }
 
 // Restore the previous context.
 
@@ -6124,21 +6114,6 @@ function jslint_phase3_parse(state) {
 
         the_function.name_list = [];    // 2. name_list for "function (aa)"
         if (mode_infix_fart) {
-            if (!token_prv.identifier) {
-
-// test_cause:
-// ["0=>0", "prefix_function_parameter", "expected_identifier_a", "0", 1]
-
-                return stop("expected_identifier_a", token_prv);
-            }
-
-// PR-499 - Update ES2015-feature arrow, to continue parsing unwrapped-form
-// with warning, instead of stopping.
-
-// test_cause:
-// ["aa=>0", "prefix_function_parameter", "wrap_fart_parameter", "=>", 3]
-
-            warn("wrap_fart_parameter", token_now);
             the_function.name = "anonymous";
             the_function.parameter_count = 1;
             the_function.signature = token_prv.id;
@@ -6414,7 +6389,7 @@ function jslint_phase3_parse(state) {
 // PR-385 - Bugfix - Fixes issue #382 - failure to detect destructured fart.
 
         if (token_now.fart) {
-            return parse_fart(token_now.fart);
+            return prefix_function(token_now.fart, true, false);
         }
 
 // test_cause:

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -425,7 +425,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2026.6.30";
+let jslint_edition = "v2026.6.1-beta";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.
@@ -4507,20 +4507,13 @@ function jslint_phase3_parse(state) {
 
 // This function will warn if <token_list> is unordered.
 
-        token_list
-            .filter(function (token) {
-
-// Issue #401 - Regression - Ignore tokens prefixed by ellipsis for sorting.
-
-                return token && !token.ellipsis;
-            })
-            .reduce(function (aa, token) {
-                const bb = artifact(token);
-                if (!option_dict.unordered && aa > bb) {
-                    warn("expected_a_b_before_c_d", token, type, bb, type, aa);
-                }
-                return bb;
-            }, "");
+        token_list.reduce(function (aa, token) {
+            const bb = artifact(token);
+            if (!option_dict.unordered && aa > bb) {
+                warn("expected_a_b_before_c_d", token, type, bb, type, aa);
+            }
+            return bb;
+        }, "");
     }
 
     function check_ordered_case(case_list) {
@@ -5047,6 +5040,7 @@ function jslint_phase3_parse(state) {
 
                     test_cause("aa(...aa)");
                     the_argument = prefix_ellipsis();
+                    the_argument.ellipsis = true;
                 } else {
                     the_argument = parse_expression(10);
                 }
@@ -5346,10 +5340,8 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["[-.0]", "parse_json", "unexpected_a", ".", 3]
 // ["[-0x0]", "parse_json", "unexpected_a", "0x0", 3]
-// ["[...]", "parse_json", "unexpected_a", "...", 2]
 // ["[.0]", "parse_json", "unexpected_a", ".", 2]
 // ["[0x0]", "parse_json", "unexpected_a", "0x0", 2]
-// ["{...}", "parse_json", "unexpected_a", "...", 2]
 
                 warn("unexpected_a");
             }
@@ -5754,7 +5746,6 @@ function jslint_phase3_parse(state) {
         the_function_toplevel
     ) {
         const is_brace = token_now.id === "{";
-        const sub_list = [];
         const the_destructure = token_now;
         let optional;
         function advance_and_signature_push(id) {
@@ -5770,7 +5761,7 @@ function jslint_phase3_parse(state) {
             }
         }
         function name_list_push(name) {
-            sub_list.push(name);
+            name_list.push(name);
 
 // PR-500 - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
 
@@ -5786,7 +5777,6 @@ function jslint_phase3_parse(state) {
             case "...":
                 advance_and_signature_push("...");
                 name = token_nxt;
-                name.ellipsis = true;
                 if (name.id === "...") {
 
 // test_cause:
@@ -5947,7 +5937,6 @@ function jslint_phase3_parse(state) {
             }
             advance_and_signature_push(",");
         }
-        name_list.push(...sub_list);
         if (the_function_toplevel) {
             advance_and_signature_push(")");
         } else if (is_brace) {
@@ -5958,7 +5947,7 @@ function jslint_phase3_parse(state) {
 // ", "check_ordered", "expected_a_b_before_c_d", "aa", 17]
 // ["let{bb,aa}=0", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
 
-            check_ordered(role, sub_list);
+            check_ordered(role, name_list);
             advance_and_signature_push("}");
         } else {
             advance_and_signature_push("]");
@@ -5970,7 +5959,6 @@ function jslint_phase3_parse(state) {
         let after_ellipsis;
         advance("...");
         after_ellipsis = parse_expression(0);
-        after_ellipsis.ellipsis = true;
         return after_ellipsis;
     }
 
@@ -6186,6 +6174,7 @@ function jslint_phase3_parse(state) {
 
                 test_cause("ellipsis");
                 value = prefix_ellipsis();
+                value.ellipsis = true;
                 return value;
             }
             advance();
@@ -6321,7 +6310,11 @@ function jslint_phase3_parse(state) {
 
         check_ordered(
             "property",
-            the_brace.expression.map(function ({
+            the_brace.expression.filter(function ({
+                ellipsis
+            }) {
+                return !ellipsis;
+            }).map(function ({
                 label
             }) {
                 return label;
@@ -6361,16 +6354,15 @@ function jslint_phase3_parse(state) {
                 if (!state.mode_json && token_nxt.id === "...") {
 
 // test_cause:
-// ["aa=[...aa]", "prefix_lbracket", "ellipsis", "...", 0]
+// ["aa=[...aa]", "prefix_lbracket", "ellipsis", "", 0]
 
-                    test_cause("ellipsis", token_nxt.id);
-                    the_token.expression.push(prefix_ellipsis());
-
-// Issue #401 - Regression - Allow multiple-ellipsis in array-literal.
-
-                } else {
-                    the_token.expression.push(parse_expression(10));
+                    test_cause("ellipsis");
+                    element = prefix_ellipsis();
+                    the_token.expression.push(element);
+                    break;
                 }
+                element = parse_expression(10);
+                the_token.expression.push(element);
                 if (token_nxt.id !== ",") {
                     break;
                 }
@@ -6378,7 +6370,7 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id === "]") {
 
 // test_cause:
-// ["aa=[0,]", "prefix_lbracket", "unexpected_a", ",", 6]
+// ["let aa=[0,]", "prefix_lbracket", "unexpected_a", ",", 10]
 
                     warn("unexpected_a", token_now);
                     break;

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -279,7 +279,7 @@
     moduleName,
     module_list,
     name,
-    names,
+    name_list,
     node,
     nomen,
     noop,
@@ -4365,7 +4365,7 @@ function jslint_phase3_parse(state) {
             the_token.arity = "assignment";
             right = parse_expression(20 - 1);
             if (id === "=" && left.arity === "variable") {
-                the_token.names = left;
+                the_token.name_list = [left];
                 the_token.expression = right;
             } else {
                 the_token.expression = [left, right];
@@ -5274,7 +5274,7 @@ function jslint_phase3_parse(state) {
 
             warn("wrap_fart_parameter", token_now);
             the_fart.name = "anonymous";
-            the_fart.names = [token_prv];
+            the_fart.name_list = [token_prv];
             the_fart.parameter_count = 1;
             the_fart.signature = token_prv.id;
             enroll(token_prv, "parameter", false);
@@ -5745,7 +5745,7 @@ function jslint_phase3_parse(state) {
         the_function,
         the_function_toplevel
     ) {
-        const is_brace = token_now.id === "{";
+        const is_lbrace = token_now.id === "{";
         const the_destructure = token_now;
         let optional;
         function advance_and_signature_push(id) {
@@ -5848,11 +5848,11 @@ function jslint_phase3_parse(state) {
 
                 return stop("expected_identifier_a", name);
             }
-            if (is_brace) {
+            if (is_lbrace) {
                 survey(name);
             }
             advance_and_signature_push(token_nxt.id);
-            if (is_brace && token_nxt.id === ":") {
+            if (is_lbrace && token_nxt.id === ":") {
                 advance_and_signature_push(":");
                 if (!the_function_toplevel) {
                     the_destructure.open = true;
@@ -5912,7 +5912,7 @@ function jslint_phase3_parse(state) {
             }
         }
         while (true) {
-            if (!is_brace && !the_function_toplevel && token_nxt.id === ",") {
+            if (!is_lbrace && !the_function_toplevel && token_nxt.id === ",") {
 
 // test_cause:
 // ["(,aa)=>0", "name_parse", "expected_identifier_a", ",", 2]
@@ -5939,7 +5939,7 @@ function jslint_phase3_parse(state) {
         }
         if (the_function_toplevel) {
             advance_and_signature_push(")");
-        } else if (is_brace) {
+        } else if (is_lbrace) {
 
 // test_cause:
 // ["
@@ -6124,7 +6124,7 @@ function jslint_phase3_parse(state) {
 
 // This function will parse input <parameters> at beginning of <the_function>
 
-        the_function.names = [];
+        the_function.name_list = [];
         the_function.parameter_count = 0;
         the_function.signature = ["("];
         token_now.free = false;
@@ -6136,7 +6136,7 @@ function jslint_phase3_parse(state) {
                 enroll,                 // enroll
                 "parameter",            // role
                 false,                  // readonly
-                the_function.names,     // name_list
+                the_function.name_list, // name_list
                 the_function,           // the_function
                 true                    // the_function_toplevel
             );
@@ -6330,7 +6330,7 @@ function jslint_phase3_parse(state) {
         the_token.expression = [];
         if (the_token.assignment) {
             the_token = token_now.assignment;
-            the_token.names = [];
+            the_token.name_list = [];
 
 // PR-500 - Unify ES2015-destructure-logic. - [aa] = ...;
 
@@ -6338,7 +6338,7 @@ function jslint_phase3_parse(state) {
                 undefined,              // enroll
                 "variable",             // role
                 false,                  // readonly
-                the_token.names,        // name_list
+                the_token.name_list,    // name_list
                 undefined,              // the_function
                 false                   // the_function_toplevel
             );
@@ -6872,7 +6872,7 @@ function jslint_phase3_parse(state) {
     function stmt_import() {
         const the_import = token_now;
         let name;
-        the_import.name = [];
+        the_import.name_list = [];
         state.mode_module = true;
         while (true) {
 
@@ -6911,7 +6911,7 @@ function jslint_phase3_parse(state) {
                     warn("unexpected_a", name);
                 }
                 enroll(name, "variable", true);
-                the_import.name.push(name);
+                the_import.name_list.push(name);
             } else {
                 advance("{");
                 if (token_nxt.id !== "}") {
@@ -6938,7 +6938,7 @@ function jslint_phase3_parse(state) {
                             warn("unexpected_a", name);
                         }
                         enroll(name, "variable", true);
-                        the_import.name.push(name);
+                        the_import.name_list.push(name);
                         if (token_nxt.id !== ",") {
                             break;
                         }
@@ -7303,7 +7303,7 @@ function jslint_phase3_parse(state) {
         let name;
         let the_variable = token_now;
         let variable_prv;
-        the_variable.names = [];
+        the_variable.name_list = [];
 
 // A program may use var or let, but not both.
 
@@ -7386,7 +7386,7 @@ function jslint_phase3_parse(state) {
                     enroll,             // enroll
                     "variable",         // role
                     readonly,           // readonly
-                    the_variable.names, // name_list
+                    the_variable.name_list,     // name_list
                     undefined,          // the_function
                     false               // the_function_toplevel
                 );
@@ -7419,7 +7419,7 @@ function jslint_phase3_parse(state) {
 
                     name.expression = parse_expression(0);
                 }
-                the_variable.names.push(name);
+                the_variable.name_list.push(name);
             } else {
 
 // test_cause:
@@ -7446,8 +7446,8 @@ function jslint_phase3_parse(state) {
             && !option_dict.variable
             && variable_prv
             && (
-                variable_prv.id + " " + variable_prv.names[0].id
-                > the_variable.id + " " + the_variable.names[0].id
+                variable_prv.id + " " + variable_prv.name_list[0].id
+                > the_variable.id + " " + the_variable.name_list[0].id
             )
         ) {
 
@@ -7460,9 +7460,9 @@ function jslint_phase3_parse(state) {
                 "expected_a_b_before_c_d",
                 the_variable,
                 the_variable.id,
-                the_variable.names[0].id,
+                the_variable.name_list[0].id,
                 variable_prv.id,
-                variable_prv.names[0].id
+                variable_prv.name_list[0].id
             );
         }
         semicolon();
@@ -7900,15 +7900,6 @@ function jslint_phase4_walk(state) {
         };
     }
 
-    function init_variable(name) {
-        let the_variable = lookup(name);
-        if (!the_variable || the_variable.readonly) {
-            warn("bad_assignment_a", name);
-            return;
-        }
-        the_variable.init = true;
-    }
-
     function lookup(thing) {
         let id = thing.id;
         let the_variable;
@@ -8000,57 +7991,24 @@ function jslint_phase4_walk(state) {
 
         const lvalue = thing.expression[0];
         let right;
-        if (thing.id === "=") {
-            if (thing.names !== undefined) {
-                if (Array.isArray(thing.names)) {
-
-// PR-500 - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
-
-// test_cause:
-// [";[aa]=0", "post_a", ";[aa]=0", "", 0]
-
-                    test_cause(";[aa]=0");
-                    thing.names.forEach(init_variable);
-                } else {
+        if (thing.id !== "=") {
+            if (
+                lvalue.arity === "variable"
+                && (!lvalue.variable || lvalue.variable.readonly)
+            ) {
 
 // test_cause:
-// ["aa=0", "post_a", "aa=0", "", 0]
+// ["aa+=0", "post_a", "+=", "aa", 0]
+// ["aa+=0", "post_a", "bad_assignment_a", "aa", 1]
+// ["const aa=0;aa+=0", "post_a", "+=", "aa", 0]
+// ["const aa=0;aa+=0", "post_a", "bad_assignment_a", "aa", 12]
 
-                    test_cause("aa=0");
-                    init_variable(thing.names);
-                }
-            } else {
-                if (lvalue.id === "[" || lvalue.id === "{") {
-                    lvalue.expression.forEach(function (thing) {
-                        if (thing.variable) {
-                            thing.variable.init = true;
-                        }
-                    });
-                } else if (
-                    lvalue.id === "."
-                    && thing.expression[1].id === "undefined"
-                ) {
-
-// test_cause:
-// ["aa.aa=undefined", "post_a", "expected_a_b", "undefined", 1]
-
-                    warn(
-                        "expected_a_b",
-                        lvalue.expression,
-                        "delete",
-                        "undefined"
-                    );
-                }
-            }
-        } else {
-            if (lvalue.arity === "variable") {
-                if (!lvalue.variable || lvalue.variable.readonly) {
-                    warn("bad_assignment_a", lvalue);
-                }
+                test_cause("+=", lvalue.id);
+                warn("bad_assignment_a", lvalue);
             }
             right = syntax_dict[thing.expression[1].id];
             if (
-                right !== undefined
+                right
                 && (
                     right.id === "function"
                     || right.id === "=>"
@@ -8067,6 +8025,34 @@ function jslint_phase4_walk(state) {
 
                 warn("unexpected_a", thing.expression[1]);
             }
+            return;
+        }
+        if (thing.name_list) {
+            thing.name_list.forEach(function (name) {
+                const the_variable = lookup(name);
+                if (!the_variable || the_variable.readonly) {
+
+// test_cause:
+// ["aa=0", "post_a", "=", "aa", 0]
+// ["aa=0", "post_a", "bad_assignment_a", "aa", 1]
+// ["const aa=0;aa=0", "post_a", "=", "aa", 0]
+// ["const aa=0;aa=0", "post_a", "bad_assignment_a", "aa", 12]
+
+                    test_cause("=", name.id);
+                    warn("bad_assignment_a", name);
+                    return;
+                }
+                the_variable.init = true;
+            });
+            return;
+        }
+        if (lvalue.id === "." && thing.expression[1].id === "undefined") {
+
+// test_cause:
+// ["aa.aa=undefined", "post_a", "expected_a_b", "undefined", 1]
+
+            warn("expected_a_b", lvalue.expression, "delete", "undefined");
+            return;
         }
     }
 
@@ -8413,7 +8399,7 @@ function jslint_phase4_walk(state) {
     }
 
     function post_s_import(the_thing) {
-        the_thing.name.forEach(function (name) {
+        the_thing.name_list.forEach(function (name) {
             name.dead = false;
             name.init = true;
             blockage.live.push(name);
@@ -8449,7 +8435,7 @@ function jslint_phase4_walk(state) {
     }
 
     function post_s_var(thing) {
-        thing.names.forEach(function (name) {
+        thing.name_list.forEach(function (name) {
             name.dead = false;
             if (name.expression) {
 
@@ -8461,12 +8447,12 @@ function jslint_phase4_walk(state) {
 
 // Probably deadcode.
 // if (name.id === "{" || name.id === "[") {
-//     name.names.forEach(subactivate);
+//     name.name_list.forEach(subactivate);
 // } else {
 //     name.init = true;
 // }
 
-// PR-500 - Unify property the_function.parameters into the_function.names.
+// PR-500 - Unify property the_function.parameters into the_function.name_list.
 
 // jslint_assert(
 // !(name.id === "{" || name.id === "["),
@@ -8844,19 +8830,19 @@ function jslint_phase4_walk(state) {
             }
         }
 
-// PR-500 - Unify property the_function.parameters into the_function.names.
+// PR-500 - Unify property the_function.parameters into the_function.name_list.
 
 // thing.parameters.forEach(function (name) {
 //     walk_expression(name.expression);
 //     if (name.id === "{" || name.id === "[") {
-//         name.names.forEach(subactivate);
+//         name.name_list.forEach(subactivate);
 //     } else {
 //         name.dead = false;
 //         name.init = true;
 //     }
 // });
 
-        thing.names.forEach(function (name) {
+        thing.name_list.forEach(function (name) {
             if (name.expression) {
 
 // test_cause:
@@ -8901,7 +8887,7 @@ function jslint_phase4_walk(state) {
         }
     }
 
-// PR-500 - Unify property the_function.parameters into the_function.names.
+// PR-500 - Unify property the_function.parameters into the_function.name_list.
 
 // function subactivate(name) {
 //     name.init = true;
@@ -10314,7 +10300,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
             level,
             line,
             name,
-            names = [],
+            name_list = [],
             signature
         } = the_function;
         let list = Object.keys(context);
@@ -10337,7 +10323,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
             )
             + "</dfn>"
         );
-        html += detail("parameter", names.map(function ({id}) {
+        html += detail("parameter", name_list.map(function ({id}) {
             return id;
         }).sort());
         list.sort();

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -4366,10 +4366,10 @@ function jslint_phase3_parse(state) {
             right = parse_expression(20 - 1);
             if (id === "=" && left.arity === "variable") {
                 the_token.name_list = [];       // 1. name_list for "aa = ..."
-                name_list_push(
+                name_push(
                     the_token.name_list,        // name_list
                     left,               // name
-                    undefined,          // enroll
+                    false,              // enroll
                     "variable",         // role
                     false,              // readonly
                     true                // init
@@ -4783,95 +4783,6 @@ function jslint_phase3_parse(state) {
         return token_now;
     }
 
-    function enroll(name, role, readonly) {
-
-// Enroll a name into the current function context. The role can be exception,
-// function, label, parameter, or variable. We look for variable redefinition
-// because it causes confusion.
-
-        let earlier;
-        let id = name.id;
-
-// Reserved words may not be enrolled.
-
-        if (syntax_dict[id] !== undefined && id !== "ignore") {
-
-// test_cause:
-// ["let undefined", "enroll", "reserved_a", "undefined", 5]
-
-            warn("reserved_a", name);
-            return;
-        }
-
-// Has the name been enrolled in this context?
-
-        earlier = functionage.context[id] || catchage.context[id];
-        if (earlier) {
-
-// test_cause:
-// ["let aa;let aa", "enroll", "redefinition_a_b", "1", 12]
-
-            warn("redefinition_a_b", name, id, earlier.line);
-            return;
-        }
-
-// Has the name been enrolled in an outer context?
-
-        function_stack.forEach(function ({
-            context
-        }) {
-            earlier = context[id] || earlier;
-        });
-        if (earlier && id === "ignore") {
-            if (earlier.role === "variable") {
-
-// test_cause:
-// ["let ignore;function aa(ignore){}", "enroll", "redefinition_a_b", "1", 24]
-
-                warn("redefinition_a_b", name, id, earlier.line);
-            }
-        } else if (
-            earlier
-            && role !== "parameter" && role !== "function"
-            && (role !== "exception" || earlier.role !== "exception")
-        ) {
-
-// test_cause:
-// ["
-// function aa(){try{aa();}catch(aa){aa();}}
-// ", "enroll", "redefinition_a_b", "1", 31]
-// ["function aa(){var aa;}", "enroll", "redefinition_a_b", "1", 19]
-
-            warn("redefinition_a_b", name, id, earlier.line);
-        } else if (
-            option_dict.beta
-            && global_dict[id]
-            && role !== "parameter"
-        ) {
-
-// test_cause:
-// ["let Array", "enroll", "redefinition_global_a_b", "Array", 5]
-
-            warn("redefinition_global_a_b", name, global_dict[id], id);
-        }
-
-// Enroll it.
-
-        Object.assign(name, {
-            dead: true,
-            init: false,
-            parent: (
-                role === "exception"
-                ? catchage
-                : functionage
-            ),
-            readonly,
-            role,
-            used: 0
-        });
-        name.parent.context[id] = name;
-    }
-
     function infix(bp, id, f) {
 
 // Create an infix operator.
@@ -5114,19 +5025,108 @@ function jslint_phase3_parse(state) {
         return the_symbol;
     }
 
-// PR-xxx - Unify name_list.push() logic with helper-function name_list_push().
+    function name_enroll(name, role, readonly) {
 
-    function name_list_push(name_list, name, enroll, role, readonly, init) {
+// Enroll a name into the current function context. The role can be exception,
+// function, label, parameter, or variable. We look for variable redefinition
+// because it causes confusion.
+
+        let earlier;
+        let id = name.id;
+
+// Reserved words may not be enrolled.
+
+        if (syntax_dict[id] !== undefined && id !== "ignore") {
+
+// test_cause:
+// ["let undefined", "name_enroll", "reserved_a", "undefined", 5]
+
+            warn("reserved_a", name);
+            return;
+        }
+
+// Has the name been enrolled in this context?
+
+        earlier = functionage.context[id] || catchage.context[id];
+        if (earlier) {
+
+// test_cause:
+// ["let aa;let aa", "name_enroll", "redefinition_a_b", "1", 12]
+
+            warn("redefinition_a_b", name, id, earlier.line);
+            return;
+        }
+
+// Has the name been enrolled in an outer context?
+
+        function_stack.forEach(function ({
+            context
+        }) {
+            earlier = context[id] || earlier;
+        });
+        if (earlier && id === "ignore") {
+            if (earlier.role === "variable") {
+
+// test_cause:
+// ["let ignore;(ignore)=>0", "name_enroll", "redefinition_a_b", "1", 13]
+
+                warn("redefinition_a_b", name, id, earlier.line);
+            }
+        } else if (
+            earlier
+            && role !== "parameter" && role !== "function"
+            && (role !== "exception" || earlier.role !== "exception")
+        ) {
+
+// test_cause:
+// ["
+// function aa(){try{aa();}catch(aa){aa();}}
+// ", "name_enroll", "redefinition_a_b", "1", 31]
+// ["function aa(){var aa;}", "name_enroll", "redefinition_a_b", "1", 19]
+
+            warn("redefinition_a_b", name, id, earlier.line);
+        } else if (
+            option_dict.beta
+            && global_dict[id]
+            && role !== "parameter"
+        ) {
+
+// test_cause:
+// ["let Array", "name_enroll", "redefinition_global_a_b", "Array", 5]
+
+            warn("redefinition_global_a_b", name, global_dict[id], id);
+        }
+
+// Enroll it.
+
+        Object.assign(name, {
+            dead: true,
+            init: false,
+            parent: (
+                role === "exception"
+                ? catchage
+                : functionage
+            ),
+            readonly,
+            role,
+            used: 0
+        });
+        name.parent.context[id] = name;
+    }
+
+// PR-xxx - Unify name_list.push() logic with helper-function name_push().
+
+    function name_push(name_list, name, enroll, role, readonly, init) {
 
 // This function will:
-// 1. Push variable or function-parameter token <name> to <name_list>.
+// 1. Push variable or function-parameter <name> to <name_list>.
 // 2. Enroll <name> if its either a declared-variable or function-parameter.
 // 3. Set <name>.init = true, if its either an assigned-variable or
 //    function-parameter.
 
         name_list.push(name);
         if (enroll) {
-            enroll(name, role, readonly);
+            name_enroll(name, role, readonly);
         }
         name.arity = role;
         name.init = init;
@@ -5513,7 +5513,7 @@ function jslint_phase3_parse(state) {
 // ["aa:while{}", "parse_statement", "the_statement_label", "while", 0]
 
                 test_cause("the_statement_label", token_nxt.id);
-                enroll(the_label, "label", true);
+                name_enroll(the_label, "label", true);
                 the_label.dead = false;
                 the_label.init = true;
                 the_statement = parse_statement();
@@ -5871,16 +5871,11 @@ function jslint_phase3_parse(state) {
                 }
                 token_nxt.label = name;
                 name = token_nxt;
-                name_list_push(sub_list, name, enroll, role, readonly, true);
+                name_push(sub_list, name, enroll, role, readonly, true);
                 advance_and_signature_push(token_nxt.id);
                 return;
             }
-            name_list_push(sub_list, name, enroll, role, readonly, true);
-
-// test_cause:
-// ["const[aa]=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
-// ["const{aa}=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
-
+            name_push(sub_list, name, enroll, role, readonly, true);
             if (token_nxt.id === "=") {
                 optional = the_function_toplevel && token_now;
                 advance_and_signature_push("=");
@@ -5890,12 +5885,16 @@ function jslint_phase3_parse(state) {
                 name.expression = parse_expression(0);
 
 // test_cause:
-// ["function aa([aa=aa]){}", "name_parse", "optional", "", 0]
-// ["function aa({aa=aa}){}", "name_parse", "optional", "", 0]
-// ["let[aa=0]=0", "name_parse", "optional", "", 0]
-// ["let{aa=0}=0", "name_parse", "optional", "", 0]
+// ["function aa([aa=aa]){}", "name_lookup", "out_of_scope_a", "aa", 17]
+// ["function aa([aa=aa]){}", "name_parse", "optional", "aa", 0]
+// ["function aa({aa=aa}){}", "name_lookup", "out_of_scope_a", "aa", 17]
+// ["function aa({aa=aa}){}", "name_parse", "optional", "aa", 0]
+// ["let[aa=bb]=0;let bb", "name_lookup", "out_of_scope_a", "bb", 8]
+// ["let[aa=bb]=0;let bb", "name_parse", "optional", "aa", 0]
+// ["let{aa=bb}=0;let bb", "name_lookup", "out_of_scope_a", "bb", 8]
+// ["let{aa=bb}=0;let bb", "name_parse", "optional", "aa", 0]
 
-                test_cause("optional");
+                test_cause("optional", name.id);
                 return;
             }
             if (optional) {
@@ -5986,7 +5985,7 @@ function jslint_phase3_parse(state) {
                     return stop("expected_identifier_a", token_nxt);
                 }
                 name = token_nxt;
-                enroll(name, "variable", true);
+                name_enroll(name, "variable", true);
                 the_function.name = Object.assign(name, {
                     calls: empty(),
 
@@ -6049,7 +6048,7 @@ function jslint_phase3_parse(state) {
 // ["let aa=function bb(){return;};", "prefix_function", "expression", "bb", 0]
 
             test_cause("expression", name.id);
-            enroll(name, "function", true);
+            name_enroll(name, "function", true);
             name.dead = false;
             name.init = true;
             name.used = 1;
@@ -6143,10 +6142,10 @@ function jslint_phase3_parse(state) {
             the_function.name = "anonymous";
             the_function.parameter_count = 1;
             the_function.signature = token_prv.id;
-            name_list_push(
+            name_push(
                 the_function.name_list, // name_list
                 token_prv,              // name
-                enroll,                 // enroll
+                true,                   // enroll
                 "parameter",            // role
                 false,                  // readonly
                 true                    // init
@@ -6161,7 +6160,7 @@ function jslint_phase3_parse(state) {
 // PR-500 - Unify ES2015-destructure-logic. - function ([aa]) {...}
 
             prefix_destructure(
-                enroll,                 // enroll
+                true,                   // enroll
                 "parameter",            // role
                 false,                  // readonly
                 the_function.name_list, // name_list
@@ -6361,7 +6360,7 @@ function jslint_phase3_parse(state) {
 // PR-500 - Unify ES2015-destructure-logic. - [aa] = ...;
 
             element = prefix_destructure(
-                undefined,              // enroll
+                false,                  // enroll
                 "variable",             // role
                 false,                  // readonly
                 the_token.name_list,    // name_list
@@ -6937,10 +6936,10 @@ function jslint_phase3_parse(state) {
 
                     warn("unexpected_a", name);
                 }
-                name_list_push(
+                name_push(
                     the_import.name_list,       // name_list
                     name,               // name
-                    enroll,             // enroll
+                    true,               // enroll
                     "variable",         // role
                     true,               // readonly
                     true                // init
@@ -6970,10 +6969,10 @@ function jslint_phase3_parse(state) {
 
                             warn("unexpected_a", name);
                         }
-                        name_list_push(
+                        name_push(
                             the_import.name_list,       // name_list
                             name,       // name
-                            enroll,     // enroll
+                            true,       // enroll
                             "variable", // role
                             true,       // readonly
                             true        // init
@@ -7301,7 +7300,14 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id !== "ignore") {
                     ignored = undefined;
                     the_catch.name = token_nxt;
-                    enroll(token_nxt, "exception", true);
+                    name_push(
+                        [],             // name_list
+                        token_nxt,      // name
+                        true,           // enroll
+                        "exception",    // role
+                        true,           // readonly
+                        true            // init
+                    );
                 }
                 advance();
                 advance(")");
@@ -7423,7 +7429,7 @@ function jslint_phase3_parse(state) {
 // PR-500 - Unify ES2015-destructure-logic. - let [aa] = ...;
 
                 prefix_destructure(
-                    enroll,             // enroll
+                    true,               // enroll
                     "variable",         // role
                     readonly,           // readonly
                     the_variable.name_list,     // name_list
@@ -7449,10 +7455,10 @@ function jslint_phase3_parse(state) {
                     name.expression = parse_expression(0);
                     name_init = true;
                 }
-                name_list_push(
+                name_push(
                     the_variable.name_list,     // name_list
                     name,               // name
-                    enroll,             // enroll
+                    true,               // enroll
                     "variable",         // role
                     readonly,           // readonly
                     name_init           // init
@@ -7937,7 +7943,13 @@ function jslint_phase4_walk(state) {
         };
     }
 
-    function lookup(thing) {
+    function name_lookup(thing, init) {
+
+// This function will:
+// 1. Lookup and return variable or function-parameter <the_variable> in current
+//    context from given <thing>.id.
+// 2. Set <the_variable>.init = true, if lookup was from an assignment.
+
         let id = thing.id;
         let the_variable;
         if (thing.arity !== "variable") {
@@ -7954,7 +7966,7 @@ function jslint_phase4_walk(state) {
         if (the_variable && the_variable.role === "label") {
 
 // test_cause:
-// ["aa:while(0){aa;}", "lookup", "label_a", "aa", 13]
+// ["aa:while(0){aa;}", "name_lookup", "label_a", "aa", 13]
 
             warn("label_a", thing);
             return the_variable;
@@ -7974,14 +7986,14 @@ function jslint_phase4_walk(state) {
             if (!the_variable && global_dict[id] === undefined) {
 
 // test_cause:
-// ["aa", "lookup", "undeclared_a", "aa", 1]
-// ["class aa{}", "lookup", "undeclared_a", "aa", 7]
+// ["aa", "name_lookup", "undeclared_a", "aa", 1]
+// ["class aa{}", "name_lookup", "undeclared_a", "aa", 7]
 // ["
 // let aa=0;try{aa();}catch(bb){bb();}bb();
-// ", "lookup", "undeclared_a", "bb", 36]
+// ", "name_lookup", "undeclared_a", "bb", 36]
 // ["
 // let aa=0;try{aa();}catch(ignore){bb();}
-// ", "lookup", "undeclared_a", "bb", 34]
+// ", "name_lookup", "undeclared_a", "bb", 34]
 
                 warn("undeclared_a", thing);
                 return;
@@ -8011,11 +8023,17 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["(aa=aa)=>0", "lookup", "out_of_scope_a", "aa", 5]
-// ["let aa;if(aa){let bb;}bb;", "lookup", "out_of_scope_a", "bb", 23]
-// ["let aa=bb;let bb=0;", "lookup", "out_of_scope_a", "bb", 8]
+// ["(aa=aa)=>0", "name_lookup", "out_of_scope_a", "aa", 5]
+// ["let aa;if(aa){let bb;}bb;", "name_lookup", "out_of_scope_a", "bb", 23]
+// ["let aa=bb;let bb=0;", "name_lookup", "out_of_scope_a", "bb", 8]
 
             warn("out_of_scope_a", thing);
+        }
+
+// Set variable as initialized, if lookup was from an assignment.
+
+        if (init && the_variable && !the_variable.readonly) {
+            the_variable.init = true;
         }
         return the_variable;
     }
@@ -8066,7 +8084,7 @@ function jslint_phase4_walk(state) {
         }
         if (thing.name_list) {
             thing.name_list.forEach(function (name) {
-                const the_variable = lookup(name);
+                const the_variable = name_lookup(name, true);
                 if (!the_variable || the_variable.readonly) {
 
 // test_cause:
@@ -8079,7 +8097,6 @@ function jslint_phase4_walk(state) {
                     warn("bad_assignment_a", name);
                     return;
                 }
-                the_variable.init = true;
             });
             return;
         }
@@ -8452,22 +8469,20 @@ function jslint_phase4_walk(state) {
     }
 
     function post_s_try(thing) {
-        if (thing.catch) {
-            if (thing.catch.name) {
-                Object.assign(catchage.context[thing.catch.name.id], {
-                    dead: false,
-                    init: true
-                });
-            }
+        if (!thing.catch) {
+            return;
+        }
+        if (thing.catch.name) {
+            catchage.context[thing.catch.name.id].dead = false;
+        }
 
 // Recurse walk_statement().
 
-            walk_statement(thing.catch.block);
+        walk_statement(thing.catch.block);
 
 // Restore previous catch-scope after catch-block.
 
-            catchage = catch_stack.pop();
-        }
+        catchage = catch_stack.pop();
     }
 
     function post_s_var(thing) {
@@ -8784,7 +8799,7 @@ function jslint_phase4_walk(state) {
         let the_variable;
         if (thing.name !== undefined) {
             thing.name.dead = false;
-            the_variable = lookup(thing.name);
+            the_variable = name_lookup(thing.name, true);
             if (the_variable !== undefined) {
                 if (the_variable.init && the_variable.readonly) {
 
@@ -8793,7 +8808,6 @@ function jslint_phase4_walk(state) {
 
                     warn("bad_assignment_a", thing.name);
                 }
-                the_variable.init = true;
             }
         }
 
@@ -8885,7 +8899,7 @@ function jslint_phase4_walk(state) {
     }
 
     function pre_v(thing) {
-        const the_variable = lookup(thing);
+        const the_variable = name_lookup(thing, false);
         if (the_variable !== undefined) {
             thing.variable = the_variable;
             the_variable.used += 1;

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -2020,16 +2020,22 @@ function jslint_assert(condition, message) {
 
 // This function will throw <message> if <condition> is falsy.
 
+    let error;
     if (condition) {
-        return condition;
+        return;
     }
-    throw new Error(
+    error = new Error(
         `This was caused by a bug in JSLint.
 Please open an issue with this stack-trace (and possible example-code) at
 https://github.com/jslint-org/jslint/issues.
 edition = "${jslint_edition}";
 ${String(message).slice(0, 2000)}`
     );
+    if (message === "test_internal_error") {
+        error = {};
+    }
+    console.error(error);
+    throw error;
 }
 
 async function jslint_cli({
@@ -4368,8 +4374,8 @@ function jslint_phase3_parse(state) {
                 the_token.name_list = [];       // 1. name_list for "aa = ..."
                 name_push(
                     the_token.name_list,        // name_list
-                    left,               // name
                     false,              // enroll
+                    left,               // name
                     "variable",         // role
                     false,              // readonly
                     true                // init
@@ -5116,7 +5122,6 @@ function jslint_phase3_parse(state) {
 
         Object.assign(name, {
             dead: true,
-            init: false,
             parent: (
                 role === "exception"
                 ? catchage
@@ -5131,7 +5136,7 @@ function jslint_phase3_parse(state) {
 
 // PR-xxx - Unify name_list.push() logic with helper-function name_push().
 
-    function name_push(name_list, name, enroll, role, readonly, init) {
+    function name_push(name_list, enroll, name, role, readonly, init) {
 
 // This function will:
 // 1. Push variable or function-parameter <name> to <name_list>.
@@ -5143,7 +5148,9 @@ function jslint_phase3_parse(state) {
         if (enroll) {
             name_enroll(name, role, readonly);
         }
-        name.arity = role;
+        if (role === "variable") {
+            name.arity = "variable";
+        }
         name.init = init;
     }
 
@@ -5447,9 +5454,15 @@ function jslint_phase3_parse(state) {
 // ["aa:while{}", "parse_statement", "the_statement_label", "while", 0]
 
                 test_cause("the_statement_label", token_nxt.id);
-                name_enroll(the_label, "label", true);
+                name_push(
+                    [],                 // name_list
+                    true,               // enroll
+                    the_label,          // name
+                    "label",            // role
+                    true,               // readonly
+                    true                // init
+                );
                 the_label.dead = false;
-                the_label.init = true;
                 the_statement = parse_statement();
 
 // Issue #458 - Regression - Warn about variable usage before initialization.
@@ -5805,11 +5818,11 @@ function jslint_phase3_parse(state) {
                 }
                 token_nxt.label = name;
                 name = token_nxt;
-                name_push(sub_list, name, enroll, role, readonly, true);
+                name_push(sub_list, enroll, name, role, readonly, true);
                 advance_and_signature_push(token_nxt.id);
                 return;
             }
-            name_push(sub_list, name, enroll, role, readonly, true);
+            name_push(sub_list, enroll, name, role, readonly, true);
             if (token_nxt.id === "=") {
                 optional = the_function_toplevel && token_now;
                 advance_and_signature_push("=");
@@ -5902,84 +5915,52 @@ function jslint_phase3_parse(state) {
         return stop("expected_a_before_b", token_now, "()", "=>");
     }
 
-    function prefix_function(the_function, mode_fart, mode_infix_fart) {
-        let name = the_function?.name;
+    function prefix_function(the_function, mode_fart, mode_fart_infix) {
+        let name;
+        let role = "function";
+        the_function = the_function || token_now;
         if (mode_fart) {
             the_function.arity = "binary";
-            the_function.name = anon;
-        } else if (!the_function) {
-            the_function = token_now;
 
 // A function statement must have a name that will be in the parent's scope.
 
-            if (the_function.arity === "statement") {
-                if (!token_nxt.identifier) {
+        } else if (the_function.arity === "statement") {
+            if (!token_nxt.identifier) {
 
 // test_cause:
 // ["function(){}", "prefix_function", "expected_identifier_a", "(", 9]
 // ["function*aa(){}", "prefix_function", "expected_identifier_a", "*", 9]
 
-                    return stop("expected_identifier_a", token_nxt);
-                }
-                name = token_nxt;
-                name_enroll(name, "variable", true);
-                the_function.name = Object.assign(name, {
-                    calls: empty(),
-
-// PR-331 - Bugfix - Fixes issue #272 - function hoisting not allowed.
-
-                    dead: false,
-                    init: true
-                });
-                advance();
-            } else if (!name) {
+                return stop("expected_identifier_a", token_nxt);
+            }
+            name = token_nxt;
+            name.calls = empty();
+            role = "variable";
+            advance();
+        } else if (token_nxt.identifier) {
 
 // A function expression may have an optional name.
 
-                the_function.name = anon;
-                if (token_nxt.identifier) {
-                    name = token_nxt;
-                    the_function.name = name;
-                    advance();
-                }
-            }
-        }
-        if (
-            !mode_fart
-            && the_function.arity !== "statement"
-            && typeof name === "object"
-        ) {
-
 // test_cause:
-// ["let aa=function bb(){return;};", "prefix_function", "expression", "bb", 0]
+// ["(function bb(){}())", "prefix_function", "expression", "bb", 0]
+// ["aa=function bb(){}", "prefix_function", "expression", "bb", 0]
 
-            test_cause("expression", name.id);
-            name_enroll(name, "function", true);
-            name.dead = false;
-            name.init = true;
-            name.used = 1;
+            test_cause("expression", token_nxt.id);
+            name = token_nxt;
+            advance();
         }
-
-//  Probably deadcode.
-//  if (mode_mega) {
-//      warn("unexpected_a", the_function);
-//  }
-//  jslint_assert(!mode_mega, `Expected !mode_mega.`);
-
-// PR-378 - Relax warning "function_in_loop".
-//
-// // Don't create functions in loops. It is inefficient, and it can lead to
-// // scoping errors.
-//
-//         if (functionage.loop > 0) {
-//
-// // test_cause:
-// // ["
-// // while(0){aa.map(function(){});}
-// // ", "prefix_function", "function_in_loop", "function", 17]
-//
-//             warn("function_in_loop", the_function);
-//         }
+        if (name?.identifier) {
+            name_push(
+                [],                     // name_list
+                true,                   // enroll
+                name,                   // name
+                role,                   // role
+                false,                  // readonly
+                true                    // init
+            );
+            name.dead = the_function.arity !== "statement";
+            name.used = Number(the_function.arity !== "statement");
+        }
 
 // Give the function properties for storing its names and for observing the
 // depth of loops and switches.
@@ -5990,6 +5971,19 @@ function jslint_phase3_parse(state) {
             finally: 0,
             level: functionage.level + 1,
             loop: 0,
+            name: (
+                name?.identifier
+                ? name
+                : mode_fart_infix
+                ? "anonymous"
+                : anon
+            ),
+            parameter_count: Number(Boolean(mode_fart_infix)),
+            signature: (
+                mode_fart_infix
+                ? token_prv.id
+                : ["("]
+            ),
             statement_prv: undefined,
             switch: 0,
             try: 0
@@ -6013,15 +6007,40 @@ function jslint_phase3_parse(state) {
 
 // Parse the parameter list.
 
-        if (mode_fart) {
-            prefix_function_parameter(the_function, mode_infix_fart);
-            if (!mode_infix_fart) {
-                advance("=>");
-            }
-        } else {
+        if (!mode_fart) {
             advance("(");
             token_now.arity = "function";
-            prefix_function_parameter(the_function);
+        }
+        the_function.name_list = [];    // 2. name_list for "function (aa)"
+        if (mode_fart_infix) {
+            name_push(
+                the_function.name_list, // name_list
+                true,                   // enroll
+                token_prv,              // name
+                "parameter",            // role
+                false,                  // readonly
+                true                    // init
+            );
+        } else {
+            token_now.free = false;
+            if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
+
+// PR-500 - Unify ES2015-destructure-logic. - function ([aa]) {...}
+
+                prefix_destructure(
+                    true,               // enroll
+                    "parameter",        // role
+                    false,              // readonly
+                    the_function.name_list,     // name_list
+                    the_function,       // the_function
+                    true                // the_function_toplevel
+                );
+            }
+            advance(")");
+            the_function.signature = the_function.signature.join("") + ")";
+        }
+        if (mode_fart && !mode_fart_infix) {
+            advance("=>");
         }
         if (mode_fart && token_nxt.id !== "{") {
 
@@ -6106,45 +6125,6 @@ function jslint_phase3_parse(state) {
 
         functionage = function_stack.pop();
         return the_function;
-    }
-
-    function prefix_function_parameter(the_function, mode_infix_fart) {
-
-// This function will parse input <parameters> at beginning of <the_function>
-
-        the_function.name_list = [];    // 2. name_list for "function (aa)"
-        if (mode_infix_fart) {
-            the_function.name = "anonymous";
-            the_function.parameter_count = 1;
-            the_function.signature = token_prv.id;
-            name_push(
-                the_function.name_list, // name_list
-                token_prv,              // name
-                true,                   // enroll
-                "parameter",            // role
-                false,                  // readonly
-                true                    // init
-            );
-            return;
-        }
-        the_function.parameter_count = 0;
-        the_function.signature = ["("];
-        token_now.free = false;
-        if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
-
-// PR-500 - Unify ES2015-destructure-logic. - function ([aa]) {...}
-
-            prefix_destructure(
-                true,                   // enroll
-                "parameter",            // role
-                false,                  // readonly
-                the_function.name_list, // name_list
-                the_function,           // the_function
-                true                    // the_function_toplevel
-            );
-        }
-        advance(")");
-        the_function.signature = the_function.signature.join("") + ")";
     }
 
     function prefix_lbrace() {
@@ -6913,8 +6893,8 @@ function jslint_phase3_parse(state) {
                 }
                 name_push(
                     the_import.name_list,       // name_list
-                    name,               // name
                     true,               // enroll
+                    name,               // name
                     "variable",         // role
                     true,               // readonly
                     true                // init
@@ -6946,8 +6926,8 @@ function jslint_phase3_parse(state) {
                         }
                         name_push(
                             the_import.name_list,       // name_list
-                            name,       // name
                             true,       // enroll
+                            name,       // name
                             "variable", // role
                             true,       // readonly
                             true        // init
@@ -7277,8 +7257,8 @@ function jslint_phase3_parse(state) {
                     the_catch.name = token_nxt;
                     name_push(
                         [],             // name_list
-                        token_nxt,      // name
                         true,           // enroll
+                        token_nxt,      // name
                         "exception",    // role
                         true,           // readonly
                         true            // init
@@ -7321,7 +7301,6 @@ function jslint_phase3_parse(state) {
     function stmt_var() {
         const readonly = token_now.id === "const";
         let name;
-        let name_init;
         let the_variable = token_now;
         let variable_prv;
         the_variable.name_list = [];    // 5. name_list for "let [aa] = ..."
@@ -7428,15 +7407,14 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id === "=" || readonly) {
                     advance("=");
                     name.expression = parse_expression(0);
-                    name_init = true;
                 }
                 name_push(
                     the_variable.name_list,     // name_list
-                    name,               // name
                     true,               // enroll
+                    name,               // name
                     "variable",         // role
                     readonly,           // readonly
-                    name_init           // init
+                    Boolean(name.expression)    // init
                 );
             } else {
 
@@ -9122,24 +9100,11 @@ function jslint_phase5_whitage(state) {
 // ["function aa(aa) {return aa;}", "delve", "id", "", 0]
 
                 test_cause("id");
-                if (
-                    name.used === 0
-
-// Probably deadcode.
-// && (
-//     name.role !== "function"
-//     || name.parent.arity !== "unary"
-// )
-
-                    && jslint_assert(
-                        name.role !== "function",
-                        `Expected name.role !== "function".`
-                    )
-                ) {
+                if (!name.used) {
 
 // test_cause:
 // ["/*jslint node*/\nlet aa;", "delve", "unused_a", "aa", 5]
-// ["function aa(aa){return;}", "delve", "unused_a", "aa", 13]
+// ["function aa(bb){return;}", "delve", "unused_a", "bb", 13]
 // ["let aa=0;try{aa();}catch(bb){aa();}", "delve", "unused_a", "bb", 26]
 
                     warn("unused_a", name);

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -1420,15 +1420,6 @@ function jslint(
         case "use_double":
             mm = `Use double quotes, not single quotes.`;
             break;
-
-// PR-386 - Fix issue #382 - Make fart-related warnings more readable.
-
-        case "use_function_not_fart":
-            mm = (
-                `Use 'function (...)', not '(...) =>' when arrow functions`
-                + ` become too complex.`
-            );
-            break;
         case "use_open":
             mm = (
                 `Wrap a ternary expression in parens,`
@@ -4459,6 +4450,10 @@ function jslint_phase3_parse(state) {
         const id = left.id;
         if (
             !left.identifier
+
+// PR-xxx - Relax warning for ((...) => {...}());
+
+            && left.id !== "=>"
             && (
                 left.arity !== "ternary"
                 || (
@@ -5639,13 +5634,6 @@ function jslint_phase3_parse(state) {
             the_function = Object.assign(token_now.fart, {
                 async: 1
             });
-            if (!option_dict.fart) {
-
-// test_cause:
-// ["async()=>0", "prefix_async", "use_function_not_fart", "=>", 8]
-
-                warn("use_function_not_fart", the_function);
-            }
             prefix_lparen();
 
 // Parse async function.
@@ -5751,14 +5739,6 @@ function jslint_phase3_parse(state) {
                 return true;
             case "[":
             case "{":
-                if (the_function?.id === "=>" && !option_dict.fart) {
-
-// test_cause:
-// ["([aa])=>0", "name_parse", "use_function_not_fart", "=>", 7]
-// ["({aa})=>0", "name_parse", "use_function_not_fart", "=>", 7]
-
-                    warn("use_function_not_fart", the_function);
-                }
                 if (optional) {
 
 // test_cause:
@@ -6079,19 +6059,10 @@ function jslint_phase3_parse(state) {
                 );
             }
             the_function.expression = parse_expression(0);
-        } else if (mode_fart) {
+        } else {
 
 // The function's body is a block.
 
-            if (!option_dict.fart) {
-
-// test_cause:
-// ["()=>{}", "prefix_function", "use_function_not_fart", "=>", 3]
-
-                warn("use_function_not_fart", the_function);
-            }
-            the_function.block = block("body");
-        } else {
             the_function.block = block("body");
             if (
                 the_function.arity === "statement"
@@ -8468,6 +8439,9 @@ function jslint_phase4_walk(state) {
 
 // t0d0 - Move to after walk_expression().
 
+// PR-xxx - Fix long-running regression where 'let x = x;'
+// doesn't warn about uninitialized variables.
+
 // 1a. Mark not dead, the variable, after variable-initialization.
 
             name.dead = false;
@@ -9795,12 +9769,11 @@ function jslint_phase5_whitage(state) {
 // or used. If the file imports or exports, then its global object is also
 // delved.
 
-    if (state.mode_module === true || option_dict.node) {
-        delve(token_global);
-    }
+// PR-xxx - tighten warning of unused variables to be always on.
+
+    delve(token_global);
     catch_list.forEach(delve);
     function_list.forEach(delve);
-
     if (option_dict.white) {
         return;
     }

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -251,7 +251,7 @@
     lines,
     linesCovered,
     linesTotal,
-    live,
+    live_list,
     log,
     long,
     loop,
@@ -893,7 +893,7 @@ function jslint(
         id: "(global)",
         level: 0,
         line: jslint_fudge,
-        live: [],
+        live_list: [],
         loop: 0,
         switch: 0,
         thru: 0,
@@ -4521,13 +4521,20 @@ function jslint_phase3_parse(state) {
 
 // This function will warn if <token_list> is unordered.
 
-        token_list.reduce(function (aa, token) {
-            const bb = artifact(token);
-            if (!option_dict.unordered && aa > bb) {
-                warn("expected_a_b_before_c_d", token, type, bb, type, aa);
-            }
-            return bb;
-        }, "");
+        token_list
+            .filter(function (token) {
+
+// Issue #401 - Regression - Ignore tokens prefixed by ellipsis for sorting.
+
+                return token && !token.ellipsis;
+            })
+            .reduce(function (aa, token) {
+                const bb = artifact(token);
+                if (!option_dict.unordered && aa > bb) {
+                    warn("expected_a_b_before_c_d", token, type, bb, type, aa);
+                }
+                return bb;
+            }, "");
     }
 
     function check_ordered_case(case_list) {
@@ -4980,7 +4987,6 @@ function jslint_phase3_parse(state) {
 
                     test_cause("aa(...aa)");
                     the_argument = prefix_ellipsis();
-                    the_argument.ellipsis = true;
                 } else {
                     the_argument = parse_expression(10);
                 }
@@ -5121,6 +5127,9 @@ function jslint_phase3_parse(state) {
 // Enroll it.
 
         Object.assign(name, {
+
+// 1z. Mark as dead, the variable, during variable-initialization.
+
             dead: true,
             parent: (
                 role === "exception"
@@ -5286,8 +5295,10 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["[-.0]", "parse_json", "unexpected_a", ".", 3]
 // ["[-0x0]", "parse_json", "unexpected_a", "0x0", 3]
+// ["[...]", "parse_json", "unexpected_a", "...", 2]
 // ["[.0]", "parse_json", "unexpected_a", ".", 2]
 // ["[0x0]", "parse_json", "unexpected_a", "0x0", 2]
+// ["{...}", "parse_json", "unexpected_a", "...", 2]
 
                 warn("unexpected_a");
             }
@@ -5462,10 +5473,13 @@ function jslint_phase3_parse(state) {
                     true,               // readonly
                     true                // init
                 );
+
+// 2a. Mark not dead, the label-statement, before control-flow-block.
+
                 the_label.dead = false;
                 the_statement = parse_statement();
 
-// Issue #458 - Regression - Warn about variable usage before initialization.
+// 2z. Mark as dead, the label-statement, after control-flow-block.
 
                 the_label.dead = true;
                 functionage.statement_prv = the_statement;
@@ -5514,13 +5528,6 @@ function jslint_phase3_parse(state) {
             }
             semicolon();
         }
-
-// Issue #458 - Regression - Warn about variable usage before initialization.
-
-//        if (the_label !== undefined) {
-//            the_label.dead = true;
-//        }
-
         return the_statement;
     }
 
@@ -5719,6 +5726,7 @@ function jslint_phase3_parse(state) {
             case "...":
                 advance_and_signature_push("...");
                 name = token_nxt;
+                name.ellipsis = true;
                 if (name.id === "...") {
 
 // test_cause:
@@ -5904,6 +5912,7 @@ function jslint_phase3_parse(state) {
         let after_ellipsis;
         advance("...");
         after_ellipsis = parse_expression(0);
+        after_ellipsis.ellipsis = true;
         return after_ellipsis;
     }
 
@@ -5949,7 +5958,7 @@ function jslint_phase3_parse(state) {
             name = token_nxt;
             advance();
         }
-        if (name?.identifier) {
+        if (name) {
             name_push(
                 [],                     // name_list
                 true,                   // enroll
@@ -5958,8 +5967,14 @@ function jslint_phase3_parse(state) {
                 false,                  // readonly
                 true                    // init
             );
-            name.dead = the_function.arity !== "statement";
-            name.used = Number(the_function.arity !== "statement");
+            if (the_function.arity === "statement") {
+
+// 3a. Mark not dead, the function-name, in function-statement.
+
+                name.dead = false;
+            } else {
+                name.used += 1;
+            }
         }
 
 // Give the function properties for storing its names and for observing the
@@ -5972,11 +5987,11 @@ function jslint_phase3_parse(state) {
             level: functionage.level + 1,
             loop: 0,
             name: (
-                name?.identifier
-                ? name
-                : mode_fart_infix
-                ? "anonymous"
-                : anon
+                name || (
+                    mode_fart_infix
+                    ? "anonymous"
+                    : anon
+                )
             ),
             parameter_count: Number(Boolean(mode_fart_infix)),
             signature: (
@@ -6154,7 +6169,6 @@ function jslint_phase3_parse(state) {
 
                 test_cause("ellipsis");
                 value = prefix_ellipsis();
-                value.ellipsis = true;
                 return value;
             }
             advance();
@@ -6290,11 +6304,7 @@ function jslint_phase3_parse(state) {
 
         check_ordered(
             "property",
-            the_brace.expression.filter(function ({
-                ellipsis
-            }) {
-                return !ellipsis;
-            }).map(function ({
+            the_brace.expression.map(function ({
                 label
             }) {
                 return label;
@@ -6334,16 +6344,16 @@ function jslint_phase3_parse(state) {
                 if (!state.mode_json && token_nxt.id === "...") {
 
 // test_cause:
-// [";[...aa,aa]", "advance", "expected_a_b", ",", 8]
-// [";[...aa,aa]", "prefix_lbracket", "ellipsis", "...", 0]
+// ["aa=[...aa]", "prefix_lbracket", "ellipsis", "...", 0]
 
                     test_cause("ellipsis", token_nxt.id);
-                    element = prefix_ellipsis();
-                    the_token.expression.push(element);
-                    break;
+                    the_token.expression.push(prefix_ellipsis());
+
+// Issue #401 - Regression - Allow multiple-ellipsis in array-literal.
+
+                } else {
+                    the_token.expression.push(parse_expression(10));
                 }
-                element = parse_expression(10);
-                the_token.expression.push(element);
                 if (token_nxt.id !== ",") {
                     break;
                 }
@@ -6351,7 +6361,7 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id === "]") {
 
 // test_cause:
-// ["let aa=[0,]", "prefix_lbracket", "unexpected_a", ",", 10]
+// ["aa=[0,]", "prefix_lbracket", "unexpected_a", ",", 6]
 
                     warn("unexpected_a", token_now);
                     break;
@@ -7932,10 +7942,6 @@ function jslint_phase4_walk(state) {
                     the_variable = context[id];
                 }
             });
-
-// If it isn't in any of those either, perhaps it is a predefined global.
-// If so, add it to the global context.
-
             if (!the_variable && global_dict[id] === undefined) {
 
 // test_cause:
@@ -7951,8 +7957,15 @@ function jslint_phase4_walk(state) {
                 warn("undeclared_a", thing);
                 return;
             }
+
+// If it isn't in any of those either, perhaps it is a predefined global.
+// If so, add it to the global context.
+
             if (!the_variable) {
                 the_variable = {
+
+// 4a. Mark not dead, the global-variable, anywhere.
+
                     dead: false,
                     id,
                     init: true,
@@ -8365,7 +8378,7 @@ function jslint_phase4_walk(state) {
         }
     }
 
-    function post_s_export(the_thing) {
+    function post_s_export_toplevel(the_thing) {
 
 // Some features must be at the most outermost level.
 
@@ -8374,7 +8387,7 @@ function jslint_phase4_walk(state) {
 // test_cause:
 // ["
 // if(0){import aa from "aa";}
-// ", "post_s_export", "misplaced_a", "import", 7]
+// ", "post_s_export_toplevel", "misplaced_a", "import", 7]
 
             warn("misplaced_a", the_thing);
         }
@@ -8402,22 +8415,31 @@ function jslint_phase4_walk(state) {
 
             warn("unexpected_parens", thing);
         }
-        return post_s_lbrace();
+        return post_s_lbrace_pop_block();
     }
 
     function post_s_import(the_thing) {
         the_thing.name_list.forEach(function (name) {
+
+// 5a. Mark not dead, the import-name, after import-statement.
+
             name.dead = false;
-            blockage.live.push(name);
+
+// 5z. Mark as dead, the import-name, after module-scope.
+
+            blockage.live_list.push(name);
         });
-        return post_s_export(the_thing);
+        return post_s_export_toplevel(the_thing);
     }
 
-    function post_s_lbrace() {
-        blockage.live.forEach(function (name) {
+    function post_s_lbrace_pop_block() {
+        blockage.live_list.forEach(function (name) {
+
+// 1z. Mark as dead, the variable, after block-scope.
+
             name.dead = true;
         });
-        delete blockage.live;
+        delete blockage.live_list;
         blockage = block_stack.pop();
     }
 
@@ -8426,6 +8448,9 @@ function jslint_phase4_walk(state) {
             return;
         }
         if (thing.catch.name) {
+
+// 6a. Mark not dead, the exception-variable, before catch-block.
+
             catchage.context[thing.catch.name.id].dead = false;
         }
 
@@ -8440,7 +8465,12 @@ function jslint_phase4_walk(state) {
 
     function post_s_var(thing) {
         thing.name_list.forEach(function (name) {
-            name.dead = false; // t0d0 - move to end
+
+// t0d0 - Move to after walk_expression().
+
+// 1a. Mark not dead, the variable, after variable-initialization.
+
+            name.dead = false;
             if (name.expression) {
 
 // test_cause:
@@ -8455,7 +8485,15 @@ function jslint_phase4_walk(state) {
 
                 test_cause("let aa");
             }
-            blockage.live.push(name);
+            switch (thing.id) {
+            case "const":
+            case "let":
+
+// 1z. Mark as dead, the variable, after block-scope.
+
+                blockage.live_list.push(name);
+                break;
+            }
         });
     }
 
@@ -8700,33 +8738,99 @@ function jslint_phase4_walk(state) {
         warn("unexpected_a", thing);
     }
 
-    function pre_b_lparen(thing) {
-        const left = thing.expression[0];
-        let left_variable;
-        let parent;
-        if (
-            left.identifier
-            && functionage.context[left.id] === undefined
-            && typeof functionage.name === "object"
-        ) {
-            parent = functionage.name.parent;
-            if (parent) {
-                left_variable = parent.context[left.id];
-                if (
-                    left_variable !== undefined
+// PR-xxx - Probably deadcode.
 
-// Probably deadcode.
-// && left_variable.dead
-
-                    && left_variable.parent === parent
-                    && left_variable.calls !== undefined
-                    && left_variable.calls[functionage.name.id] !== undefined
-                ) {
-                    left_variable.dead = false;
-                }
-            }
-        }
-    }
+//     function pre_b_lparen(thing) {
+//
+// // This function runs right before the parser handles a "(" symbol
+// // (like in "myFunction()"). It is a safety valve to prevent
+// // incorrect "use before definition" warnings.
+// //
+// // Example code triggering this preaction:
+// // my_function();
+//
+// // Step 1: Find out what is being called.
+// // If the code is "foo()", "left" gets the "foo" part.
+// //
+// // Code representation:
+// // left === token_foo;
+//
+//         const left = thing.expression[0];
+//         let left_variable;
+//         let parent;
+//
+// // Step 2: Make sure we are calling a named thing (an identifier),
+// // and check that this thing is NOT defined locally inside the
+// // active function. We also make sure the active function
+// // actually has a name.
+// //
+// // Code structure matched here:
+// // function active_function() {
+// //     foo(); // "foo" is not defined inside active_function
+// // }
+//
+//         if (
+//             left.identifier
+//             && functionage.context[left.id] === undefined
+//             && typeof functionage.name === "object"
+//         ) {
+//
+// // Step 3: Find the outer function (the parent) that
+// // wraps our current function.
+// //
+// // Code structure matched here:
+// // function outer_parent() {
+// //     function active_function() { ... }
+// // }
+//
+//             parent = functionage.name.parent;
+//             if (parent) {
+//
+// // Step 4: Look up the variable we are calling ("foo")
+// // inside that parent function.
+// //
+// // Code structure matched here:
+// // function outer_parent() {
+// //     function foo() {} // Defined in the parent scope
+// //     function active_function() { foo(); }
+// // }
+//
+//                 left_variable = parent.context[left.id];
+//
+// // Step 5: Check if we need to temporarily "bring it
+// // back to life".
+// // We verify it was found in the parent scope, is currently marked
+// // as "dead", belongs to this parent, and has a registered call from
+// // our active function. If so, we revive it!
+// //
+// // Code structure matched here (Mutual Recursion):
+// // function outer_parent() {
+// //     function active_function() {
+// //         foo(); // "foo" is forward-referenced & currently dead
+// //     }
+// //     function foo() {
+// //         active_function();
+// //     }
+// // }
+//
+//                 if (
+//                     left_variable !== undefined
+// // Probably deadcode.
+// // && left_variable.dead
+//                     && left_variable.parent === parent
+//                     && left_variable.calls !== undefined
+//                     && left_variable.calls[functionage.name.id] !== undefined
+//                 ) {
+//
+// // If all those match, revive it! Mark "dead" as
+// // false so JSLint won't raise an error for
+// // calling it before its line is executed.
+//
+//                     left_variable.dead = false;
+//                 }
+//             }
+//         }
+//     }
 
     function pre_b_noteq(thing) {
 
@@ -8751,6 +8855,9 @@ function jslint_phase4_walk(state) {
     function pre_s_for(thing) {
         let the_variable;
         if (thing.name !== undefined) {
+
+// 7a. Mark not dead, the iterator variable, during for-loop-initialization.
+
             thing.name.dead = false;
             the_variable = name_lookup(thing.name, true);
             if (the_variable !== undefined) {
@@ -8788,8 +8895,11 @@ function jslint_phase4_walk(state) {
         block_stack.push(blockage);
         functionage = thing;
         blockage = thing;
-        thing.live = [];
+        thing.live_list = [];
         if (typeof thing.name === "object") {
+
+// 3a. Mark not dead, the function-name, in function-expression.
+
             thing.name.dead = false;
         }
         if (thing.extra === "get") {
@@ -8831,6 +8941,9 @@ function jslint_phase4_walk(state) {
                 test_cause("(aa)=>0");
             }
             walk_expression(name.expression);
+
+// 8a. Mark not dead, the function-parameter, after destructuring.
+
             name.dead = false;
         });
     }
@@ -8838,7 +8951,7 @@ function jslint_phase4_walk(state) {
     function pre_s_lbrace(thing) {
         block_stack.push(blockage);
         blockage = thing;
-        thing.live = [];
+        thing.live_list = [];
     }
 
     function pre_try(thing) {
@@ -8978,21 +9091,25 @@ function jslint_phase4_walk(state) {
     postaction("binary", "||", post_b_or);
     postaction("binary", post_b);
     postaction("statement", "const", post_s_var);
-    postaction("statement", "export", post_s_export);
+    postaction("statement", "export", post_s_export_toplevel);
     postaction("statement", "for", post_s_for);
     postaction("statement", "function", post_s_function);
     postaction("statement", "import", post_s_import);
     postaction("statement", "let", post_s_var);
     postaction("statement", "try", post_s_try);
     postaction("statement", "var", post_s_var);
-    postaction("statement", "{", post_s_lbrace);
+    postaction("statement", "{", post_s_lbrace_pop_block);
     postaction("ternary", post_t);
     postaction("unary", "+", post_u_plus);
     postaction("unary", "function", post_s_function);
     postaction("unary", post_u);
     preaction("assignment", pre_a_bitwise);
     preaction("binary", "!=", pre_b_noteq);
-    preaction("binary", "(", pre_b_lparen);
+
+// PR-xxx - Probably deadcode.
+
+//     preaction("binary", "(", pre_b_lparen);
+
     preaction("binary", "==", pre_b_eqeq);
     preaction("binary", "=>", pre_s_function);
     preaction("binary", "in", pre_b_in);

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -425,7 +425,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2026.6.1-beta";
+let jslint_edition = "v2026.7.1-beta";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -1420,6 +1420,15 @@ function jslint(
         case "use_double":
             mm = `Use double quotes, not single quotes.`;
             break;
+
+// PR-386 - Fix issue #382 - Make fart-related warnings more readable.
+
+        case "use_function_not_fart":
+            mm = (
+                `Use 'function (...)', not '(...) =>' when arrow functions`
+                + ` become too complex.`
+            );
+            break;
         case "use_open":
             mm = (
                 `Wrap a ternary expression in parens,`
@@ -4450,10 +4459,6 @@ function jslint_phase3_parse(state) {
         const id = left.id;
         if (
             !left.identifier
-
-// PR-xxx - Relax warning for ((...) => {...}());
-
-            && left.id !== "=>"
             && (
                 left.arity !== "ternary"
                 || (
@@ -5634,6 +5639,13 @@ function jslint_phase3_parse(state) {
             the_function = Object.assign(token_now.fart, {
                 async: 1
             });
+            if (!option_dict.fart) {
+
+// test_cause:
+// ["async()=>0", "prefix_async", "use_function_not_fart", "=>", 8]
+
+                warn("use_function_not_fart", the_function);
+            }
             prefix_lparen();
 
 // Parse async function.
@@ -5739,6 +5751,14 @@ function jslint_phase3_parse(state) {
                 return true;
             case "[":
             case "{":
+                if (the_function?.id === "=>" && !option_dict.fart) {
+
+// test_cause:
+// ["([aa])=>0", "name_parse", "use_function_not_fart", "=>", 7]
+// ["({aa})=>0", "name_parse", "use_function_not_fart", "=>", 7]
+
+                    warn("use_function_not_fart", the_function);
+                }
                 if (optional) {
 
 // test_cause:
@@ -6059,10 +6079,19 @@ function jslint_phase3_parse(state) {
                 );
             }
             the_function.expression = parse_expression(0);
-        } else {
+        } else if (mode_fart) {
 
 // The function's body is a block.
 
+            if (!option_dict.fart) {
+
+// test_cause:
+// ["()=>{}", "prefix_function", "use_function_not_fart", "=>", 3]
+
+                warn("use_function_not_fart", the_function);
+            }
+            the_function.block = block("body");
+        } else {
             the_function.block = block("body");
             if (
                 the_function.arity === "statement"

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -2590,11 +2590,11 @@ function jslint_phase2_lex(state) {
         ), function (ignore, ii) {
 
 // test_cause:
-// ["0x0_0_;", "check_numeric_separator", "illegal_num_separator", "", 6]
-// ["0x0_0__0;", "check_numeric_separator", "illegal_num_separator", "", 6]
-// ["aa=1_2_;", "check_numeric_separator", "illegal_num_separator", "", 7]
-// ["aa=1_2__3;", "check_numeric_separator", "illegal_num_separator", "", 7]
-// ["aa=1_2_n;", "check_numeric_separator", "illegal_num_separator", "", 7]
+// ["0x0_0_", "check_numeric_separator", "illegal_num_separator", "", 6]
+// ["0x0_0__0", "check_numeric_separator", "illegal_num_separator", "", 6]
+// ["aa=1_2_", "check_numeric_separator", "illegal_num_separator", "", 7]
+// ["aa=1_2__3", "check_numeric_separator", "illegal_num_separator", "", 7]
+// ["aa=1_2_n", "check_numeric_separator", "illegal_num_separator", "", 7]
 
             warn_at("illegal_num_separator", line, column + ii + 1);
             return "";
@@ -5104,7 +5104,7 @@ function jslint_phase3_parse(state) {
 // ["
 // function aa(){try{aa();}catch(aa){aa();}}
 // ", "name_enroll", "redefinition_a_b", "1", 31]
-// ["function aa(){var aa;}", "name_enroll", "redefinition_a_b", "1", 19]
+// ["function aa(){var aa}", "name_enroll", "redefinition_a_b", "1", 19]
 
             warn("redefinition_a_b", name, id, earlier.line);
         } else if (
@@ -5256,7 +5256,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["!", "parse_expression", "unexpected_a", "(end)", 1]
 // ["/./", "parse_expression", "unexpected_a", "/", 1]
-// ["let aa=`${}`;", "parse_expression", "unexpected_a", "}", 11]
+// ["let aa=`${}`", "parse_expression", "unexpected_a", "}", 11]
 
             return stop("unexpected_a", token_now);
         }
@@ -5560,7 +5560,7 @@ function jslint_phase3_parse(state) {
             if (disrupt) {
 
 // test_cause:
-// ["while(0){break;0;}", "parse_statements", "unreachable_a", "0", 16]
+// ["while(0){break;0}", "parse_statements", "unreachable_a", "0", 16]
 
                 warn("unreachable_a", a_statement);
             }
@@ -5665,8 +5665,8 @@ function jslint_phase3_parse(state) {
         if (functionage.async === 0 && functionage !== token_global) {
 
 // test_cause:
-// ["function aa(){aa=await 0;}", "prefix_await", "unexpected_a", "await", 18]
-// ["function aa(){await 0;}", "prefix_await", "unexpected_a", "await", 15]
+// ["function aa(){aa=await 0}", "prefix_await", "unexpected_a", "await", 18]
+// ["function aa(){await 0}", "prefix_await", "unexpected_a", "await", 15]
 
             warn("unexpected_a", the_await);
         } else {
@@ -6403,7 +6403,7 @@ function jslint_phase3_parse(state) {
                 advance("${");
 
 // test_cause:
-// ["let aa=`${}`;", "prefix_tick", "${", "", 0]
+// ["let aa=`${}`", "prefix_tick", "${", "", 0]
 
                 test_cause("${");
                 the_tick.expression.push(parse_expression(0));
@@ -6481,13 +6481,13 @@ function jslint_phase3_parse(state) {
                 if (the_label !== undefined && the_label.dead) {
 
 // test_cause:
-// ["aa:{function aa(aa){break aa;}}", "stmt_break", "out_of_scope_a", "aa", 27]
+// ["aa:{function aa(aa){break aa}}", "stmt_break", "out_of_scope_a", "aa", 27]
 
                     warn("out_of_scope_a");
                 } else {
 
 // test_cause:
-// ["aa:{break aa;}", "stmt_break", "not_label_a", "aa", 11]
+// ["aa:{break aa}", "stmt_break", "not_label_a", "aa", 11]
 
                     warn("not_label_a");
                 }
@@ -6562,7 +6562,7 @@ function jslint_phase3_parse(state) {
         if (the_do.block.disrupt === true) {
 
 // test_cause:
-// ["function aa(){do{break;}while(0)}", "stmt_do", "weird_loop", "do", 15]
+// ["function aa(){do{break}while(0)}", "stmt_do", "weird_loop", "do", 15]
 
             warn("weird_loop", the_do);
         }
@@ -6815,7 +6815,7 @@ function jslint_phase3_parse(state) {
                 if (the_if.else.disrupt === true) {
 
 // test_cause:
-// ["if(0){break;}else{break;}", "stmt_if", "disrupt", "", 0]
+// ["if(0){break}else{break}", "stmt_if", "disrupt", "", 0]
 
                     test_cause("disrupt");
                     the_if.disrupt = true;
@@ -7318,9 +7318,9 @@ function jslint_phase3_parse(state) {
         case "var":
 
 // test_cause:
-// ["const aa=0;const bb=0;", "stmt_var", "var_prv", "const", 0]
-// ["let aa=0;let bb=0;", "stmt_var", "var_prv", "let", 0]
-// ["var aa=0;var bb=0;", "stmt_var", "var_prv", "var", 0]
+// ["const aa=0;const bb=0", "stmt_var", "var_prv", "const", 0]
+// ["let aa=0;let bb=0", "stmt_var", "var_prv", "let", 0]
+// ["var aa=0;var bb=0", "stmt_var", "var_prv", "var", 0]
 
             test_cause("var_prv", functionage.statement_prv.id);
             variable_prv = functionage.statement_prv;
@@ -7341,10 +7341,10 @@ function jslint_phase3_parse(state) {
             ) {
 
 // test_cause:
-// ["console.log();let aa=0;", "stmt_var", "var_on_top", "let", 15]
-// ["console.log();var aa=0;", "stmt_var", "var_on_top", "var", 15]
-// ["try{aa();}catch(aa){var aa=0;}", "stmt_var", "var_on_top", "var", 21]
-// ["while(0){var aa;}", "stmt_var", "var_on_top", "var", 10]
+// ["console.log();let aa=0", "stmt_var", "var_on_top", "let", 15]
+// ["console.log();var aa=0", "stmt_var", "var_on_top", "var", 15]
+// ["try{}catch{var aa=0}", "stmt_var", "var_on_top", "var", 12]
+// ["while(0){var aa}", "stmt_var", "var_on_top", "var", 10]
 
                 warn("var_on_top", token_now);
             }
@@ -7409,7 +7409,7 @@ function jslint_phase3_parse(state) {
             }
 
 // test_cause:
-// ["let aa,bb;", "stmt_var", "expected_a_b", ",", 7]
+// ["let aa,bb", "stmt_var", "expected_a_b", ",", 7]
 
             warn("expected_a_b", token_nxt, ";", ",");
             advance(",");
@@ -7429,9 +7429,9 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["const bb=0;const aa=0;", "stmt_var", "expected_a_b_before_c_d", "aa", 12]
-// ["let bb;let aa;", "stmt_var", "expected_a_b_before_c_d", "aa", 8]
-// ["var bb;var aa;", "stmt_var", "expected_a_b_before_c_d", "aa", 8]
+// ["const bb=0;const aa=0", "stmt_var", "expected_a_b_before_c_d", "aa", 12]
+// ["let bb;let aa", "stmt_var", "expected_a_b_before_c_d", "aa", 8]
+// ["var bb;var aa", "stmt_var", "expected_a_b_before_c_d", "aa", 8]
 
             warn(
                 "expected_a_b_before_c_d",
@@ -7455,7 +7455,7 @@ function jslint_phase3_parse(state) {
         if (the_while.block.disrupt === true) {
 
 // test_cause:
-// ["function aa(){while(0){break;}}", "stmt_while", "weird_loop", "while", 15]
+// ["function aa(){while(0){break}}", "stmt_while", "weird_loop", "while", 15]
 
             warn("weird_loop", the_while);
         }
@@ -7900,7 +7900,7 @@ function jslint_phase4_walk(state) {
         if (the_variable && the_variable.role === "label") {
 
 // test_cause:
-// ["aa:while(0){aa;}", "name_lookup", "label_a", "aa", 13]
+// ["aa:while(0){aa}", "name_lookup", "label_a", "aa", 13]
 
             warn("label_a", thing);
             return the_variable;
@@ -7918,12 +7918,7 @@ function jslint_phase4_walk(state) {
 // test_cause:
 // ["aa", "name_lookup", "undeclared_a", "aa", 1]
 // ["class aa{}", "name_lookup", "undeclared_a", "aa", 7]
-// ["
-// let aa=0;try{aa();}catch(bb){bb();}bb();
-// ", "name_lookup", "undeclared_a", "bb", 36]
-// ["
-// let aa=0;try{aa();}catch(ignore){bb();}
-// ", "name_lookup", "undeclared_a", "bb", 34]
+// ["try{}catch(aa){}aa", "name_lookup", "undeclared_a", "aa", 17]
 
                 warn("undeclared_a", thing);
                 return;
@@ -7961,8 +7956,11 @@ function jslint_phase4_walk(state) {
 
 // test_cause:
 // ["(aa=aa)=>0", "name_lookup", "out_of_scope_a", "aa", 5]
-// ["let aa;if(aa){let bb;}bb;", "name_lookup", "out_of_scope_a", "bb", 23]
-// ["let aa=bb;let bb=0;", "name_lookup", "out_of_scope_a", "bb", 8]
+// ["if(0){let aa}aa", "name_lookup", "out_of_scope_a", "aa", 14]
+// ["let [aa]=aa", "name_lookup", "out_of_scope_a", "aa", 10]
+// ["let aa=()=>aa", "name_lookup", "out_of_scope_a", "aa", 12]
+// ["let aa=aa", "name_lookup", "out_of_scope_a", "aa", 8]
+// ["let aa=bb;let bb", "name_lookup", "out_of_scope_a", "bb", 8]
 
             warn("out_of_scope_a", thing);
         }
@@ -8436,15 +8434,6 @@ function jslint_phase4_walk(state) {
 
     function post_s_var(thing) {
         thing.name_list.forEach(function (name) {
-
-// t0d0 - Move to after walk_expression().
-
-// PR-xxx - Fix long-running regression where 'let x = x;'
-// doesn't warn about uninitialized variables.
-
-// 1a. Mark not dead, the variable, after variable-initialization.
-
-            name.dead = false;
             if (name.expression) {
 
 // test_cause:
@@ -8459,6 +8448,13 @@ function jslint_phase4_walk(state) {
 
                 test_cause("let aa");
             }
+
+// PR-xxx - Fix long-running regression where 'let x = x;'
+// doesn't warn about temporal-dead-zone.
+
+// 1a. Mark not dead, the variable, after variable-initialization.
+
+            name.dead = false;
             switch (thing.id) {
             case "const":
             case "let":
@@ -8479,8 +8475,8 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["let aa=(aa?`${0}`:`${0}`);", "post_t", "unexpected_a", "?", 11]
-// ["let aa=(aa?`0`:`0`);", "post_t", "unexpected_a", "?", 11]
+// ["let aa=(aa?`${0}`:`${0}`)", "post_t", "unexpected_a", "?", 11]
+// ["let aa=(aa?`0`:`0`)", "post_t", "unexpected_a", "?", 11]
 
             warn("unexpected_a", thing);
         } else if (is_equal(thing.expression[0], thing.expression[1])) {
@@ -9194,15 +9190,15 @@ function jslint_phase5_whitage(state) {
                 if (!name.used) {
 
 // test_cause:
-// ["/*jslint node*/\nlet aa;", "delve", "unused_a", "aa", 5]
 // ["function aa(bb){return;}", "delve", "unused_a", "bb", 13]
+// ["let aa;", "delve", "unused_a", "aa", 5]
 // ["let aa=0;try{aa();}catch(bb){aa();}", "delve", "unused_a", "bb", 26]
 
                     warn("unused_a", name);
                 } else if (!name.init) {
 
 // test_cause:
-// ["/*jslint node*/\nlet aa;aa();", "delve", "uninitialized_a", "aa", 5]
+// ["let aa;aa();", "delve", "uninitialized_a", "aa", 5]
 
                     warn("uninitialized_a", name);
                 }
@@ -9244,7 +9240,7 @@ function jslint_phase5_whitage(state) {
             if (left.thru !== right.from && nr_comments_skipped === 0) {
 
 // test_cause:
-// ["let aa = aa( );", "no_space", "unexpected_space_a_b", ")", 14]
+// ["String( );", "no_space", "unexpected_space_a_b", ")", 9]
 
                 warn(
                     "unexpected_space_a_b",
@@ -9253,7 +9249,8 @@ function jslint_phase5_whitage(state) {
                     artifact(right)
                 );
             }
-        } else {
+            return;
+        }
 
 // from:
 // } else if (
@@ -9280,15 +9277,15 @@ function jslint_phase5_whitage(state) {
 //     }
 // }
 
-            jslint_assert(open, `Expected open.`);
-            jslint_assert(free, `Expected free.`);
-            if (right.from < margin) {
+        jslint_assert(open, `Expected open.`);
+        jslint_assert(free, `Expected free.`);
+        if (right.from < margin) {
 
 // test_cause:
-// ["let aa = aa(\naa\n()\n);", "expected_at", "expected_a_at_b_c", "5", 1]
+// ["String(\nString\n()\n);", "no_space", "expected_at(margin)", "(", 0]
 
-                expected_at(margin);
-            }
+            test_cause("expected_at(margin)", right.id);
+            expected_at(margin);
         }
     }
 
@@ -9301,6 +9298,10 @@ function jslint_phase5_whitage(state) {
                 || left.thru !== right.from
             )
         ) {
+
+// test_cause:
+// ["String( 0);", "no_space_only", "unexpected_space_a_b", "0", 9]
+
             warn(
                 "unexpected_space_a_b",
                 right,
@@ -9313,6 +9314,10 @@ function jslint_phase5_whitage(state) {
     function one_space() {
         if (left.line === right.line || !open) {
             if (left.thru + 1 !== right.from && nr_comments_skipped === 0) {
+
+// test_cause:
+// ["String(0,0);", "one_space", "expected_space_a_b", "0", 10]
+
                 warn(
                     "expected_space_a_b",
                     right,
@@ -9320,10 +9325,15 @@ function jslint_phase5_whitage(state) {
                     artifact(right)
                 );
             }
-        } else {
-            if (right.from !== margin) {
-                expected_at(margin);
-            }
+            return;
+        }
+        if (right.from !== margin) {
+
+// test_cause:
+// ["let aa={\naa:\n0};", "one_space", "open", "0", 0]
+
+            test_cause("open", right.value);
+            expected_at(margin);
         }
     }
 
@@ -9336,21 +9346,20 @@ function jslint_phase5_whitage(state) {
     function whitage_case() {
 
 // test_cause:
-// ["let aa=[];", "whitage_case", "opener", "", 0]
-// ["let aa=`${0}`;", "whitage_case", "opener", "", 0]
-// ["let aa=aa();", "whitage_case", "opener", "", 0]
-// ["let aa={};", "whitage_case", "opener", "", 0]
+// ["String();", "whitage_case", "opener", "(", 0]
+// ["let aa=[];", "whitage_case", "opener", "[", 0]
+// ["let aa=`${0}`;", "whitage_case", "opener", "${", 0]
+// ["let aa={};", "whitage_case", "opener", "{", 0]
 
-        test_cause("opener");
+        test_cause("opener", left.id);
+        switch (left.id + right.id) {
 
 // Probably deadcode.
 // case "${}":
 
-        jslint_assert(
-            !(left.id + right.id === "${}"),
-            "Expected !(left.id + right.id === \"${}\")."
-        );
-        switch (left.id + right.id) {
+// test_cause:
+// ["let aa=`${}`;", "parse_expression", "unexpected_a", "}", 11]
+
         case "()":
         case "[]":
         case "{}":
@@ -9358,36 +9367,23 @@ function jslint_phase5_whitage(state) {
 // If left and right are opener and closer, then the placement of right depends
 // on the openness. Illegal pairs (like '{]') have already been detected.
 
-// test_cause:
-// ["let aa=[];", "whitage_case", "opener_closer", "", 0]
-// ["let aa=aa();", "whitage_case", "opener_closer", "", 0]
-// ["let aa={};", "whitage_case", "opener_closer", "", 0]
-
-            test_cause("opener_closer");
             if (left.line === right.line) {
 
 // test_cause:
-// ["let aa = aa( );", "no_space", "unexpected_space_a_b", ")", 14]
+// ["String();", "whitage_case", "()", "(", 0]
 
+                test_cause("()", left.id);
                 no_space();
             } else {
 
 // test_cause:
-// ["let aa = aa(\n );", "expected_at", "expected_a_at_b_c", "1", 2]
+// ["String(\n);", "whitage_case", "(\n)", "(", 0]
 
+                test_cause("(\n)", left.id);
                 at_margin(0);
             }
             break;
         default:
-
-// test_cause:
-// ["let aa=(0);", "whitage_case", "opener_operand", "", 0]
-// ["let aa=[0];", "whitage_case", "opener_operand", "", 0]
-// ["let aa=`${0}`;", "whitage_case", "opener_operand", "", 0]
-// ["let aa=aa(0);", "whitage_case", "opener_operand", "", 0]
-// ["let aa={aa:0};", "whitage_case", "opener_operand", "", 0]
-
-            test_cause("opener_operand");
             opening = left.open || (left.line !== right.line);
             indentage = {
                 closer,
@@ -9414,13 +9410,9 @@ function jslint_phase5_whitage(state) {
             if (opening) {
 
 // test_cause:
-// ["function aa(){\nreturn;\n}", "whitage_case", "opening", "", 0]
-// ["let aa=(\n0\n);", "whitage_case", "opening", "", 0]
-// ["let aa=[\n0\n];", "whitage_case", "opening", "", 0]
-// ["let aa=`${\n0\n}`;", "whitage_case", "opening", "", 0]
-// ["let aa={\naa:0\n};", "whitage_case", "opening", "", 0]
+// ["String(\n0);", "whitage_case", "(\n0)", "0", 0]
 
-                test_cause("opening");
+                test_cause("(\n0)", right.value);
                 free = closer === ")" && left.free;
                 open = true;
                 margin += mode_indent;
@@ -9436,16 +9428,11 @@ function jslint_phase5_whitage(state) {
 
 // test_cause:
 // ["
-// function aa() {
-//  bb:
-//     while (aa) {
-//         if (aa) {
-//             break bb;
-//         }
-//     }
-// }
-// ", "expected_at", "expected_a_at_b_c", "1", 2]
+// function aa(){
+//  bb:while(aa){aa();}}
+// ", "whitage_case", "{\n label", "bb", 0]
 
+                        test_cause("{\n label", right.id);
                         expected_at(0);
                     }
                 } else if (right.switch) {
@@ -9458,14 +9445,9 @@ function jslint_phase5_whitage(state) {
             if (right.statement || right.role === "label") {
 
 // test_cause:
-// ["
-// function aa() {bb:
-//     while (aa) {
-//         aa();
-//     }
-// }
-// ", "whitage_case", "expected_line_break_a_b", "bb", 16]
+// ["function aa(){bb:while(aa){aa();}}", "whitage_case", "{label", "bb", 0]
 
+                test_cause("{label", right.id);
                 warn(
                     "expected_line_break_a_b",
                     right,
@@ -9473,20 +9455,13 @@ function jslint_phase5_whitage(state) {
                     artifact(right)
                 );
             }
-
-// test_cause:
-// ["let aa=(0);", "whitage_case", "not_free", "", 0]
-// ["let aa=[0];", "whitage_case", "not_free", "", 0]
-// ["let aa=`${0}`;", "whitage_case", "not_free", "", 0]
-// ["let aa={aa:0};", "whitage_case", "not_free", "", 0]
-
-            test_cause("not_free");
             free = false;
             open = false;
 
 // test_cause:
-// ["let aa = ( 0 );", "no_space_only", "unexpected_space_a_b", "0", 12]
+// ["String(0);", "whitage_case", "(0)", "0", 0]
 
+            test_cause("(0)", right.value);
             no_space_only();
         }
     }
@@ -9497,23 +9472,20 @@ function jslint_phase5_whitage(state) {
 
 // test_cause:
 // ["
-// let aa = 0;
-// if (aa) {
-//     aa();
-// } else  if (aa) {
-//     aa();
-// }
-// ", "one_space_only", "expected_space_a_b", "if", 9]
+// let aa=0;if(aa){aa();}else if(aa){aa();}
+// ", "whitage_default", "stmt_else", "else", 0]
 
+                test_cause("stmt_else", left.id);
                 one_space_only();
-            } else {
+                return;
+            }
 
 // test_cause:
-// [" let aa = 0;", "expected_at", "expected_a_at_b_c", "1", 2]
+// ["let aa;", "whitage_default", "stmt", "let", 0]
 
-                at_margin(0);
-                open = false;
-            }
+            test_cause("stmt", right.id);
+            at_margin(0);
+            open = false;
             return;
         }
 
@@ -9527,6 +9499,11 @@ function jslint_phase5_whitage(state) {
             open = indentage.open;
             opening = indentage.opening;
             if (opening && right.id !== ";") {
+
+// test_cause:
+// ["String(\n0);", "whitage_default", "aa(\n0)", "0", 0]
+
+                test_cause("aa(\n0)", left.value);
                 at_margin(
                     indentage.indent_method
 
@@ -9535,9 +9512,9 @@ function jslint_phase5_whitage(state) {
                     ? mode_indent
                     : 0
                 );
-            } else {
-                no_space_only();
+                return;
             }
+            no_space_only();
             return;
         }
 
@@ -9556,43 +9533,36 @@ function jslint_phase5_whitage(state) {
 
 // test_cause:
 // ["
-// function aa() {
-//     aa();cc:
-//     while (aa) {
-//         if (aa) {
-//             break cc;
-//         }
-//     }
-// }
-// ", "expected_at", "expected_a_at_b_c", "1", 10]
+// function aa(){
+//     aa();bb:while(aa){aa();}}
+// ", "whitage_default", "{\n label", "bb", 0]
 
+                test_cause("{\n label", right.id);
                 expected_at(0);
             }
             return;
         }
         if (left.id === ",") {
-            if (!open || (
-                (free || closer === "]")
-                && left.line === right.line
-            )) {
+            if (
+                !open
+                || (
+                    (free || closer === "]")
+                    && left.line === right.line
+                )
+            ) {
 
 // test_cause:
-// ["let{aa,bb} = 0;", "one_space", "expected_space_a_b", "bb", 8]
+// ["String(0,0);", "whitage_default", "(0,", ",", 0]
 
+                test_cause("(0,", left.id);
                 one_space();
-            } else {
+                return;
+            }
 
 // test_cause:
-// ["
-// function aa() {
-//     aa(
-//         0,0
-//     );
-// }
-// ", "expected_at", "expected_a_at_b_c", "9", 11]
+// ["String(\n0,0);", "whitage_default", "(\n0,", ",", 0]
 
-                at_margin(0);
-            }
+            test_cause("(\n0,", left.id);
             return;
         }
 
@@ -9602,22 +9572,18 @@ function jslint_phase5_whitage(state) {
             if (open) {
 
 // test_cause:
-// ["
-// let aa = (
-//     aa
-//     ? 0
-// : 1
-// );
-// ", "expected_at", "expected_a_at_b_c", "5", 1]
+// ["String(\nString?0:1);", "whitage_default", "(\n0?0:0", "?", 0]
 
+                test_cause("(\n0?0:0", right.id);
                 at_margin(0);
-            } else {
+                return;
+            }
 
 // test_cause:
-// ["let aa = (aa ? 0 : 1);", "whitage_default", "use_open", "?", 14]
+// ["String(String?0:1);", "whitage_default", "(0?0:0", "?", 0]
 
-                warn("use_open", right);
-            }
+            test_cause("(0?0:0", right.id);
+            warn("use_open", right);
             return;
         }
         if (
@@ -9627,8 +9593,9 @@ function jslint_phase5_whitage(state) {
         ) {
 
 // test_cause:
-// ["let aa = aa(\naa ()\n);", "no_space", "unexpected_space_a_b", "(", 4]
+// ["String(\nString()\n);", "whitage_default", "aa(0", "(", 0]
 
+            test_cause("aa(0", right.id);
             no_space();
             return;
         }
@@ -9650,8 +9617,9 @@ function jslint_phase5_whitage(state) {
         ) {
 
 // test_cause:
-// ["let aa = 0 ;", "no_space_only", "unexpected_space_a_b", ";", 12]
+// ["String(...String);", "whitage_default", "...", "...", 0]
 
+            test_cause("...", left.id);
             no_space_only();
             return;
         }
@@ -9659,19 +9627,21 @@ function jslint_phase5_whitage(state) {
             if (left.line === right.line) {
 
 // test_cause:
-// ["let aa = aa ?.aa;", "no_space_only", "unexpected_space_a_b", "?.", 13]
+// ["String?.aa();", "whitage_default", "?.", "?.", 0]
 
+                test_cause("?.", right.id);
                 no_space_only();
-            } else {
+                return;
+            }
 
 // PR-498 - Relax warning on multiline-method-chaining.
 
-                indent_method_dict[right.line] = true;
-                at_margin(mode_indent);
-            }
+            indent_method_dict[right.line] = true;
+            at_margin(mode_indent);
             return;
         }
         if (left.id === ";") {
+            if (open) {
 
 // test_cause:
 // ["
@@ -9685,9 +9655,9 @@ function jslint_phase5_whitage(state) {
 //         aa();
 //     }
 // }
-// ", "expected_at", "expected_a_at_b_c", "9", 1]
+// ", "whitage_default", "for(;;)", ";", 0]
 
-            if (open) {
+                test_cause("for(;;)", left.id);
                 at_margin(0);
             }
             return;
@@ -9708,14 +9678,9 @@ function jslint_phase5_whitage(state) {
         ) {
 
 // test_cause:
-// ["
-// function aa() {
-//     do {
-//         aa();
-//     } while(aa());
-// }
-// ", "one_space_only", "expected_space_a_b", "(", 12]
+// ["if(String()){String();}", "whitage_default", "){", "){", 0]
 
+            test_cause("){", left.id + right.id);
             one_space_only();
             return;
         }
@@ -9752,9 +9717,9 @@ function jslint_phase5_whitage(state) {
         ) {
 
 // test_cause:
-// ["let aa=0;", "one_space", "expected_space_a_b", "0", 8]
-// ["let aa={\naa:\n0\n};", "expected_at", "expected_a_at_b_c", "5", 1]
+// ["let aa=0;", "whitage_default", "=", "=", 0]
 
+            test_cause("=", left.id);
             one_space();
             return;
         }

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -5143,7 +5143,7 @@ function jslint_phase3_parse(state) {
         name.parent.context[id] = name;
     }
 
-// PR-xxx - Unify name_list.push() logic with helper-function name_push().
+// PR-502 - Unify name_list.push() logic with helper-function name_push().
 
     function name_push(name_list, enroll, name, role, readonly, init) {
 
@@ -5898,7 +5898,7 @@ function jslint_phase3_parse(state) {
 // ", "check_ordered", "expected_a_b_before_c_d", "aa", 17]
 // ["let{bb,aa}=0", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
 
-// PR-xxx - Fix false-warning about ordering in nested-object-destructuring.
+// PR-501 - Fix false-warning about ordering in nested-object-destructuring.
 
             check_ordered(role, sub_list);
             advance_and_signature_push("}");
@@ -8478,7 +8478,7 @@ function jslint_phase4_walk(state) {
                 test_cause("let aa");
             }
 
-// PR-xxx - Fix long-running regression where 'let x = x;'
+// PR-502 - Fix long-running regression where 'let x = x;'
 // doesn't warn about temporal-dead-zone.
 
 // 1a. Mark not dead, the variable, after variable-initialization.
@@ -8737,7 +8737,7 @@ function jslint_phase4_walk(state) {
         warn("unexpected_a", thing);
     }
 
-// PR-xxx - Probably deadcode.
+// PR-502 - Probably deadcode.
 
 //     function pre_b_lparen(thing) {
 //
@@ -9105,7 +9105,7 @@ function jslint_phase4_walk(state) {
     preaction("assignment", pre_a_bitwise);
     preaction("binary", "!=", pre_b_noteq);
 
-// PR-xxx - Probably deadcode.
+// PR-502 - Probably deadcode.
 
 //     preaction("binary", "(", pre_b_lparen);
 
@@ -9763,7 +9763,7 @@ function jslint_phase5_whitage(state) {
 // or used. If the file imports or exports, then its global object is also
 // delved.
 
-// PR-xxx - tighten warning of unused variables to be always on.
+// PR-502 - tighten warning of unused variables to be always on.
 
     delve(token_global);
     catch_list.forEach(delve);

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -4365,7 +4365,15 @@ function jslint_phase3_parse(state) {
             the_token.arity = "assignment";
             right = parse_expression(20 - 1);
             if (id === "=" && left.arity === "variable") {
-                the_token.name_list = [left];
+                the_token.name_list = [];       // 1. name_list for "aa = ..."
+                name_list_push(
+                    the_token.name_list,        // name_list
+                    left,               // name
+                    undefined,          // enroll
+                    "variable",         // role
+                    false,              // readonly
+                    true                // init
+                );
                 the_token.expression = right;
             } else {
                 the_token.expression = [left, right];
@@ -5106,6 +5114,24 @@ function jslint_phase3_parse(state) {
         return the_symbol;
     }
 
+// PR-xxx - Unify name_list.push() logic with helper-function name_list_push().
+
+    function name_list_push(name_list, name, enroll, role, readonly, init) {
+
+// This function will:
+// 1. Push variable or function-parameter token <name> to <name_list>.
+// 2. Enroll <name> if its either a declared-variable or function-parameter.
+// 3. Set <name>.init = true, if its either an assigned-variable or
+//    function-parameter.
+
+        name_list.push(name);
+        if (enroll) {
+            enroll(name, role, readonly);
+        }
+        name.arity = role;
+        name.init = init;
+    }
+
     function parse_expression(rbp, initial) {
 
 // This is the heart of JSLINT, the Pratt parser. In addition to parsing, it
@@ -5226,7 +5252,7 @@ function jslint_phase3_parse(state) {
         return left;
     }
 
-    function parse_fart(the_fart, mode_infix) {
+    function parse_fart(the_fart, mode_infix_fart) {
 
 // Give the function properties storing its names and for observing the depth
 // of loops and switches.
@@ -5257,32 +5283,11 @@ function jslint_phase3_parse(state) {
         function_list.push(the_fart);
         function_stack.push(functionage);
         functionage = the_fart;
-        if (mode_infix) {
-            if (!token_prv.identifier) {
-
-// test_cause:
-// ["0=>0", "parse_fart", "expected_identifier_a", "0", 1]
-
-                return stop("expected_identifier_a", token_prv);
-            }
-
-// PR-499 - Update ES2015-feature arrow, to continue parsing unwrapped-form
-// with warning, instead of stopping.
-
-// test_cause:
-// ["aa=>0", "parse_fart", "wrap_fart_parameter", "=>", 3]
-
-            warn("wrap_fart_parameter", token_now);
-            the_fart.name = "anonymous";
-            the_fart.name_list = [token_prv];
-            the_fart.parameter_count = 1;
-            the_fart.signature = token_prv.id;
-            enroll(token_prv, "parameter", false);
-        } else {
 
 // Parse the parameter list.
 
-            prefix_function_parameter(the_fart);
+        prefix_function_parameter(the_fart, mode_infix_fart);
+        if (!mode_infix_fart) {
             advance("=>");
         }
 
@@ -5746,6 +5751,7 @@ function jslint_phase3_parse(state) {
         the_function_toplevel
     ) {
         const is_lbrace = token_now.id === "{";
+        const sub_list = [];
         const the_destructure = token_now;
         let optional;
         function advance_and_signature_push(id) {
@@ -5758,17 +5764,6 @@ function jslint_phase3_parse(state) {
                     the_function.signature.push(" ");
                     break;
                 }
-            }
-        }
-        function name_list_push(name) {
-            name_list.push(name);
-
-// PR-500 - Fix false-warning "uninitialized_a" in statement ";[aa]=0;".
-
-            name.arity = role;
-            if (enroll) {
-                enroll(name, role, readonly);
-                name.init = true;
             }
         }
         function name_parse() {
@@ -5876,11 +5871,11 @@ function jslint_phase3_parse(state) {
                 }
                 token_nxt.label = name;
                 name = token_nxt;
-                name_list_push(name);
+                name_list_push(sub_list, name, enroll, role, readonly, true);
                 advance_and_signature_push(token_nxt.id);
                 return;
             }
-            name_list_push(name);
+            name_list_push(sub_list, name, enroll, role, readonly, true);
 
 // test_cause:
 // ["const[aa]=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 11]
@@ -5937,9 +5932,11 @@ function jslint_phase3_parse(state) {
             }
             advance_and_signature_push(",");
         }
+        name_list.push(...sub_list);
         if (the_function_toplevel) {
-            advance_and_signature_push(")");
-        } else if (is_lbrace) {
+            return the_destructure;
+        }
+        if (is_lbrace) {
 
 // test_cause:
 // ["
@@ -5947,11 +5944,13 @@ function jslint_phase3_parse(state) {
 // ", "check_ordered", "expected_a_b_before_c_d", "aa", 17]
 // ["let{bb,aa}=0", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
 
-            check_ordered(role, name_list);
+// PR-xxx - Fix false-warning about ordering in nested-object-destructuring.
+
+            check_ordered(role, sub_list);
             advance_and_signature_push("}");
-        } else {
-            advance_and_signature_push("]");
+            return the_destructure;
         }
+        advance_and_signature_push("]");
         return the_destructure;
     }
 
@@ -6120,17 +6119,46 @@ function jslint_phase3_parse(state) {
         return the_function;
     }
 
-    function prefix_function_parameter(the_function) {
+    function prefix_function_parameter(the_function, mode_infix_fart) {
 
 // This function will parse input <parameters> at beginning of <the_function>
 
-        the_function.name_list = [];
+        the_function.name_list = [];    // 2. name_list for "function (aa)"
+        if (mode_infix_fart) {
+            if (!token_prv.identifier) {
+
+// test_cause:
+// ["0=>0", "prefix_function_parameter", "expected_identifier_a", "0", 1]
+
+                return stop("expected_identifier_a", token_prv);
+            }
+
+// PR-499 - Update ES2015-feature arrow, to continue parsing unwrapped-form
+// with warning, instead of stopping.
+
+// test_cause:
+// ["aa=>0", "prefix_function_parameter", "wrap_fart_parameter", "=>", 3]
+
+            warn("wrap_fart_parameter", token_now);
+            the_function.name = "anonymous";
+            the_function.parameter_count = 1;
+            the_function.signature = token_prv.id;
+            name_list_push(
+                the_function.name_list, // name_list
+                token_prv,              // name
+                enroll,                 // enroll
+                "parameter",            // role
+                false,                  // readonly
+                true                    // init
+            );
+            return;
+        }
         the_function.parameter_count = 0;
         the_function.signature = ["("];
         token_now.free = false;
         if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
 
-// PR-500 - Unify ES2015-destructure-logic. - function([aa]) {...}
+// PR-500 - Unify ES2015-destructure-logic. - function ([aa]) {...}
 
             prefix_destructure(
                 enroll,                 // enroll
@@ -6140,11 +6168,9 @@ function jslint_phase3_parse(state) {
                 the_function,           // the_function
                 true                    // the_function_toplevel
             );
-        } else {
-            advance(")");
-            the_function.signature.push(")");
         }
-        the_function.signature = the_function.signature.join("");
+        advance(")");
+        the_function.signature = the_function.signature.join("") + ")";
     }
 
     function prefix_lbrace() {
@@ -6330,7 +6356,7 @@ function jslint_phase3_parse(state) {
         the_token.expression = [];
         if (the_token.assignment) {
             the_token = token_now.assignment;
-            the_token.name_list = [];
+            the_token.name_list = [];   // 3. name_list for "[aa] = ..."
 
 // PR-500 - Unify ES2015-destructure-logic. - [aa] = ...;
 
@@ -6354,9 +6380,10 @@ function jslint_phase3_parse(state) {
                 if (!state.mode_json && token_nxt.id === "...") {
 
 // test_cause:
-// ["aa=[...aa]", "prefix_lbracket", "ellipsis", "", 0]
+// [";[...aa,aa]", "advance", "expected_a_b", ",", 8]
+// [";[...aa,aa]", "prefix_lbracket", "ellipsis", "...", 0]
 
-                    test_cause("ellipsis");
+                    test_cause("ellipsis", token_nxt.id);
                     element = prefix_ellipsis();
                     the_token.expression.push(element);
                     break;
@@ -6872,7 +6899,7 @@ function jslint_phase3_parse(state) {
     function stmt_import() {
         const the_import = token_now;
         let name;
-        the_import.name_list = [];
+        the_import.name_list = [];      // 4. name_list for "import ..."
         state.mode_module = true;
         while (true) {
 
@@ -6910,8 +6937,14 @@ function jslint_phase3_parse(state) {
 
                     warn("unexpected_a", name);
                 }
-                enroll(name, "variable", true);
-                the_import.name_list.push(name);
+                name_list_push(
+                    the_import.name_list,       // name_list
+                    name,               // name
+                    enroll,             // enroll
+                    "variable",         // role
+                    true,               // readonly
+                    true                // init
+                );
             } else {
                 advance("{");
                 if (token_nxt.id !== "}") {
@@ -6937,8 +6970,14 @@ function jslint_phase3_parse(state) {
 
                             warn("unexpected_a", name);
                         }
-                        enroll(name, "variable", true);
-                        the_import.name_list.push(name);
+                        name_list_push(
+                            the_import.name_list,       // name_list
+                            name,       // name
+                            enroll,     // enroll
+                            "variable", // role
+                            true,       // readonly
+                            true        // init
+                        );
                         if (token_nxt.id !== ",") {
                             break;
                         }
@@ -7301,9 +7340,10 @@ function jslint_phase3_parse(state) {
     function stmt_var() {
         const readonly = token_now.id === "const";
         let name;
+        let name_init;
         let the_variable = token_now;
         let variable_prv;
-        the_variable.name_list = [];
+        the_variable.name_list = [];    // 5. name_list for "let [aa] = ..."
 
 // A program may use var or let, but not both.
 
@@ -7404,22 +7444,19 @@ function jslint_phase3_parse(state) {
 
                     warn("unexpected_a", name);
                 }
-                enroll(name, "variable", readonly);
                 if (token_nxt.id === "=" || readonly) {
                     advance("=");
-
-// Issue #458 - Regression - Warn about variable usage before initialization.
-
-//                    name.dead = false;
-
-                    name.init = true;
-
-// test_cause:
-// ["const aa=bb;\nconst bb=0;", "lookup", "out_of_scope_a", "bb", 10]
-
                     name.expression = parse_expression(0);
+                    name_init = true;
                 }
-                the_variable.name_list.push(name);
+                name_list_push(
+                    the_variable.name_list,     // name_list
+                    name,               // name
+                    enroll,             // enroll
+                    "variable",         // role
+                    readonly,           // readonly
+                    name_init           // init
+                );
             } else {
 
 // test_cause:
@@ -8401,7 +8438,6 @@ function jslint_phase4_walk(state) {
     function post_s_import(the_thing) {
         the_thing.name_list.forEach(function (name) {
             name.dead = false;
-            name.init = true;
             blockage.live.push(name);
         });
         return post_s_export(the_thing);
@@ -8436,7 +8472,7 @@ function jslint_phase4_walk(state) {
 
     function post_s_var(thing) {
         thing.name_list.forEach(function (name) {
-            name.dead = false;
+            name.dead = false; // t0d0 - move to end
             if (name.expression) {
 
 // test_cause:
@@ -8444,22 +8480,6 @@ function jslint_phase4_walk(state) {
 
                 test_cause("let aa=0");
                 walk_expression(name.expression);
-
-// Probably deadcode.
-// if (name.id === "{" || name.id === "[") {
-//     name.name_list.forEach(subactivate);
-// } else {
-//     name.init = true;
-// }
-
-// PR-500 - Unify property the_function.parameters into the_function.name_list.
-
-// jslint_assert(
-// !(name.id === "{" || name.id === "["),
-// `Expected !(name.id === "{" || name.id === "[").`
-// );
-
-                name.init = true;
             } else {
 
 // test_cause:
@@ -8804,7 +8824,6 @@ function jslint_phase4_walk(state) {
         thing.live = [];
         if (typeof thing.name === "object") {
             thing.name.dead = false;
-            thing.name.init = true;
         }
         if (thing.extra === "get") {
             if (thing.parameter_count !== 0) {
@@ -8829,19 +8848,6 @@ function jslint_phase4_walk(state) {
                 warn("bad_set", thing);
             }
         }
-
-// PR-500 - Unify property the_function.parameters into the_function.name_list.
-
-// thing.parameters.forEach(function (name) {
-//     walk_expression(name.expression);
-//     if (name.id === "{" || name.id === "[") {
-//         name.name_list.forEach(subactivate);
-//     } else {
-//         name.dead = false;
-//         name.init = true;
-//     }
-// });
-
         thing.name_list.forEach(function (name) {
             if (name.expression) {
 
@@ -8859,7 +8865,6 @@ function jslint_phase4_walk(state) {
             }
             walk_expression(name.expression);
             name.dead = false;
-            name.init = true;
         });
     }
 
@@ -8886,14 +8891,6 @@ function jslint_phase4_walk(state) {
             the_variable.used += 1;
         }
     }
-
-// PR-500 - Unify property the_function.parameters into the_function.name_list.
-
-// function subactivate(name) {
-//     name.init = true;
-//     name.dead = false;
-//     blockage.live.push(name);
-// }
 
     function walk_expression(thing) {
         if (thing) {

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -982,8 +982,7 @@ shGitSquashPop() {(set -e
     git reset "$COMMIT"
     git add .
     # commit HEAD immediately after previous $COMMIT
-    git commit --allow-empty -am "$MESSAGE" || true
-    git log -n 4
+    git commit -am "$MESSAGE" || true
 )}
 
 shGithubCheckoutRemote() {(set -e
@@ -1158,13 +1157,13 @@ import moduleAssert from "assert";
 import moduleChildProcess from "child_process";
 import moduleFs from "fs";
 (async function () {
-    let branchCheckpoint = process.argv[1] || "HEAD";
-    let branchMerge = process.argv[2] || "beta";
+    let branchCheckpoint = process.argv[2] || "HEAD";
+    let branchMerge = process.argv[1] || "beta";
     let branchPull;
     let commitMessage;
     let data;
     let version = process.argv[3] || new Date().toISOString().slice(0, 10);
-    version = version.replace((/-0?/g), ".").replace((/^v/), "");
+    version = version.replace((/-0?/g), ".");
     // security - sanitize branchXxx
     [
         branchCheckpoint, branchMerge, version
@@ -1175,7 +1174,6 @@ import moduleFs from "fs";
     });
     data = await moduleFs.promises.readFile("CHANGELOG.md", "utf8");
     switch (branchMerge) {
-    case "main":
     case "master":
         version = `v${version}`;
         // update CHANGELOG.md
@@ -1227,7 +1225,6 @@ import moduleFs from "fs";
     git push origin alpha -f
     shDirHttplinkValidate
     git push . HEAD:__pr_${branchMerge} -f
-    git log -n 4
 )
             `)
         ],

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -982,7 +982,8 @@ shGitSquashPop() {(set -e
     git reset "$COMMIT"
     git add .
     # commit HEAD immediately after previous $COMMIT
-    git commit -am "$MESSAGE" || true
+    git commit --allow-empty -am "$MESSAGE" || true
+    git log -n 4
 )}
 
 shGithubCheckoutRemote() {(set -e
@@ -1157,13 +1158,13 @@ import moduleAssert from "assert";
 import moduleChildProcess from "child_process";
 import moduleFs from "fs";
 (async function () {
-    let branchCheckpoint = process.argv[2] || "HEAD";
-    let branchMerge = process.argv[1] || "beta";
+    let branchCheckpoint = process.argv[1] || "HEAD";
+    let branchMerge = process.argv[2] || "beta";
     let branchPull;
     let commitMessage;
     let data;
     let version = process.argv[3] || new Date().toISOString().slice(0, 10);
-    version = version.replace((/-0?/g), ".");
+    version = version.replace((/-0?/g), ".").replace((/^v/), "");
     // security - sanitize branchXxx
     [
         branchCheckpoint, branchMerge, version
@@ -1174,6 +1175,7 @@ import moduleFs from "fs";
     });
     data = await moduleFs.promises.readFile("CHANGELOG.md", "utf8");
     switch (branchMerge) {
+    case "main":
     case "master":
         version = `v${version}`;
         // update CHANGELOG.md
@@ -1225,6 +1227,7 @@ import moduleFs from "fs";
     git push origin alpha -f
     shDirHttplinkValidate
     git push . HEAD:__pr_${branchMerge} -f
+    git log -n 4
 )
             `)
         ],

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -1158,12 +1158,16 @@ import moduleAssert from "assert";
 import moduleChildProcess from "child_process";
 import moduleFs from "fs";
 (async function () {
-    let branchCheckpoint = process.argv[1] || "HEAD";
-    let branchMerge = process.argv[2] || "beta";
+    let [
+        ,
+        branchCheckpoint = "HEAD",
+        branchMerge = "beta",
+        version = new Date().toISOString().slice(0, 10),
+        branchSquash = "HEAD"
+    ] = process.argv;
     let branchPull;
     let commitMessage;
     let data;
-    let version = process.argv[3] || new Date().toISOString().slice(0, 10);
     version = version.replace((/-0?/g), ".").replace((/^v/), "");
     // security - sanitize branchXxx
     [
@@ -1193,6 +1197,7 @@ import moduleFs from "fs";
         commitMessage = (
             /\n\n# v\d\d\d\d\.\d\d?\.\d\d?(?:-.*?)?\n(- [\S\s]+?)(?:\n- |\n\n)/
         ).exec(data)[1];
+        commitMessage = `- shGithubPrCreate ${commitMessage}`;
     }
     branchPull = `branch-${version}`;
     // update README.md
@@ -1211,7 +1216,7 @@ import moduleFs from "fs";
     );
     await moduleFs.promises.writeFile("README.md", data);
     // security - sanitize commitMessage
-    commitMessage = commitMessage.trim().replace((/[$\u0027`]/g), "?");
+    commitMessage = commitMessage.trim().replace((/\u0027/g), "$&\"$&\"$&");
     moduleChildProcess.spawn(
         "sh",
         [
@@ -1220,13 +1225,14 @@ import moduleFs from "fs";
 (set -e
     . ./jslint_ci.sh
     npm run test2
-    git push . HEAD:__pr_${branchMerge}_pre -f
-    shGitSquashPop ${branchCheckpoint} \u0027${commitMessage}\u0027
-    git diff origin/${branchPull} || true
-    git push origin alpha:${branchPull} -f
+    git reset "${branchSquash}"
+    git push . HEAD:__pr_"${branchMerge}"_pre -f
+    shGitSquashPop "${branchCheckpoint}" \u0027${commitMessage}\u0027
+    git diff origin/"${branchPull}" || true
+    git push origin alpha:"${branchPull}" -f
     git push origin alpha -f
     shDirHttplinkValidate
-    git push . HEAD:__pr_${branchMerge} -f
+    git push . HEAD:__pr_"${branchMerge}" -f
     git log -n 4
 )
             `)
@@ -1235,7 +1241,7 @@ import moduleFs from "fs";
     ).on("exit", function (exitCode) {
         moduleAssert.ok(
             exitCode === 0,
-            `shGithubPrCreate - exitCode=${exitCode}`
+            `shGithubPrCreate - exitCode="${exitCode}"`
         );
     });
 }());

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "shCiArtifactUpload": 1,
     "shCiPublishNpm": 1,
     "type": "module",
-    "version": "2026.6.30"
+    "version": "2026.6.1-beta"
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "shCiArtifactUpload": 1,
     "shCiPublishNpm": 1,
     "type": "module",
-    "version": "2026.6.1-beta"
+    "version": "2026.6.30"
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "shCiArtifactUpload": 1,
     "shCiPublishNpm": 1,
     "type": "module",
-    "version": "2026.6.30"
+    "version": "2026.7.1-beta"
 }

--- a/test.mjs
+++ b/test.mjs
@@ -701,10 +701,10 @@ jstestDescribe((
                 ].map(function (source) {
                     source = source.replace("{expr}", (
                         `[{\n`
-                        + `    aa,\n`
-                        + `    bb = 0,\n`
-                        + `    bb: cc,\n`
-                        + `    dd: [{dd}],\n`
+                        + `    bb,\n`
+                        + `    cc = 0,\n`
+                        + `    cc: dd,\n`
+                        + `    dd: [{aa}],\n`
                         + `    ...zz\n`
                         + `}]`
                     ));

--- a/test.mjs
+++ b/test.mjs
@@ -600,7 +600,7 @@ jstestDescribe((
                 "aa.js"
             ],
             process_exit: processExit0,
-            source: "let aa = 0;"
+            source: "String();"
         });
         jslint.jslint_cli({
             // suppress error
@@ -646,64 +646,73 @@ jstestDescribe((
                 "new Array(0);"
             ],
             async_await: [
-                "async function aa() {\n    await aa();\n}",
+                "async function aa() {\n    await aa();\n}\nawait aa();",
 
 // PR-405 - Bugfix - fix expression after "await" mis-identified as statement.
 
-                "async function aa() {\n    await aa;\n}",
-                (
-                    "async function aa() {\n"
-                    + "    try {\n"
-                    + "        aa();\n"
-                    + "    } catch (err) {\n"
-                    + "        await err();\n"
-                    + "    }\n"
-                    + "}\n"
-                ),
-                (
-                    "async function aa() {\n"
-                    + "    try {\n"
-                    + "        await aa();\n"
-                    + "    } catch (err) {\n"
-                    + "        await err();\n"
-                    + "    }\n"
-                    + "}\n"
-                ),
-
-// PR-370 - Add top-level-await support.
-
-                "await String();\n"
+                "async function aa() {\n    await aa;\n}\nawait aa();",
+                (`
+async function aa() {
+    try {
+        return await aa();
+    } catch (err) {
+        await err();
+    }
+}
+await aa();
+                `),
+                (`
+let aa = async () => {
+    try {
+        return await aa();
+    } catch (err) {
+        await err();
+    }
+};
+await aa();
+                `)
             ],
 
 // PR-351 - Add BigInt support.
 
             bigint: [
-                "let aa = 0b0n;\n",
-                "let aa = 0o0n;\n",
-                "let aa = 0x0n;\n",
-                "let aa = BigInt(0n);\n",
-                "let aa = typeof aa === \"bigint\";\n"
+                (`
+const aa = 0;
+String(0b0n);
+String(0o0n);
+String(0x0n);
+String(BigInt(0n));
+aa(typeof aa === "bigint");
+                `)
             ],
             date: [
-                "Date.getTime();",
-                "let aa = aa().getTime();",
-                "let aa = aa.aa().getTime();"
+                (`
+const aa = 0;
+Date.getTime();
+aa().getTime();
+aa.aa().getTime();
+                `)
             ],
             destructure: [
 
 // PR-500 - Unify ES2015-destructure-logic.
 
                 [
-                    String(`
+                    (`
+(({expr}) => {
+    aa(bb, cc, dd, ee, ff, gg);
+}());
+                    `),
+                    (`
 (function ({expr}) {
     aa(bb, cc, dd, ee, ff, gg);
 }());
-                    `).trim(),
+                    `),
                     "const {expr}",
                     "let {expr}",
                     "let [aa, bb, cc, dd, ee, ff, gg] = 0;\n{expr}"
                 ].map(function (source) {
-                    source = source.replace("{expr}", String(`
+                    source = source.trim().replace("{expr}", String(`
 [
     {
         cc,
@@ -718,32 +727,38 @@ jstestDescribe((
     ]
 ]
                     `).trim());
-                    if (!(/function/).test(source)) {
-                        source = (
-                            `${source} = (function () {\n`
-                            + `    return;\n`
-                            + `}());\n`
-                            + `aa(bb, cc, dd, ee, ff, gg);\n`
-                        );
+                    if (!(/\=>|function/).test(source)) {
+                        source = (`
+${source} = (function () {
+    return;
+}());
+aa(bb, cc, dd, ee, ff, gg);
+                        `);
                     }
-                    source = `/*jslint node*/\n${source}`;
                     return source;
                 }),
 
 // PR-459 - Allow destructuring-assignment after function-definition.
 
-                (
-                    "let aa;\n"
-                    + "let bb;\n"
-                    + "function cc() {\n"
-                    + "    return;\n"
-                    + "}\n"
-                    + "[aa, bb] = cc();\n"
-                )
-            ].flat(),
+                (`
+let aa;
+let bb;
+function cc() {
+    return;
+}
+[aa, bb] = cc();
+aa(bb, cc);
+                `)
+            ],
             directive: [
-                "#!\n/*jslint browser:false, node*/\n\"use strict\";",
-                "/*property aa bb*/"
+                (`
+#!/usr/bin/env node
+/*global aa*/
+/*jslint browser:false, node*/
+/*property bb*/
+"use strict";
+aa.bb();
+                `)
             ],
             ellipsis: [
 
@@ -776,33 +791,51 @@ aa();
 
 // PR-483 - Allow parenthesis after ellipsis inside a function call.
 
-                (
-                    "let aa = 0;\n"
-                    + "aa(...(\n"
-                    + "    aa()\n"
-                    + "    ? [0]\n"
-                    + "    : [1]\n"
-                    + "));"
-                )
+                (`
+let aa = 0;
+aa(...(
+    aa()
+    ? 0
+    : 1
+));
+                `)
+            ],
+            fart: [
+                "let aa = () => 0;\naa();",
+                (`
+let aa = async (bb, {cc, dd}, [ee, ff], ...gg) => {
+    bb += 1;
+    return await (bb + cc + dd + ee + ff + gg);
+};
+aa();
+                `)
             ],
             for: [
-                (
-                    "/*jslint for*/\n"
-                    + "function aa(bb) {\n"
-                    + "    for (bb = 0; bb < 0; bb += 1) {\n"
-                    + "        bb();\n"
-                    + "    }\n"
-                    + "}\n"
-                )
+                (`
+/*jslint for*/
+function aa(bb) {
+    for (bb = 0; bb < 0; bb += 1) {
+        bb();
+    }
+}
+aa();
+                `)
             ],
             import: [
                 `let aa = 0;\nimport(aa).then(aa).catch(aa).finally(aa);`,
-                `let aa = await import("aa");`,
-                `let aa = await import("aa", {with: {type: "json"}});`,
-                `let {aa, bb} = await import("aa");`
+                `let aa = await import("aa");\naa();`,
+                `let aa = await import("aa", {with: {type: "json"}});\naa();`,
+                `let {aa, bb} = await import("aa");\naa(bb);`
             ],
             indent_method: [
-                "let aa = 0;\naa\n    .bb\n    .cc(\n        0\n    );"
+                (`
+let aa = 0;
+aa
+    .bb
+    .cc(
+        0
+    );
+                `)
             ],
             jslint_disable: [
                 "/*jslint-disable*/\n0\n/*jslint-enable*/"
@@ -814,16 +847,17 @@ aa();
                 "{\"aa\":[[],-0,null]}"
             ],
             label: [
-                (
-                    "function aa() {\n"
-                    + "bb:\n"
-                    + "    while (true) {\n"
-                    + "        if (true) {\n"
-                    + "            break bb;\n"
-                    + "        }\n"
-                    + "    }\n"
-                    + "}\n"
-                )
+                (`
+function aa() {
+bb:
+    while (true) {
+        if (true) {
+            break bb;
+        }
+    }
+}
+aa();
+                `)
             ],
             literal: [
                 "String(\"\".at());",
@@ -835,36 +869,38 @@ aa();
                 "let aa = 0;\naa ||= 0;"
             ],
             loop: [
-                (
-                    "function aa() {\n"
-                    + "    do {\n"
-                    + "        aa();\n"
-                    + "    } while (aa());\n"
-                    + "}\n"
-                ),
+                (`
+function aa() {
+    do {
+        aa();
+    } while (aa());
+}
+aa();
+                `),
 
 // PR-378 - Relax warning "function_in_loop".
 
-                (
-                    "function aa() {\n"
-                    + "    while (true) {\n"
-                    + "        (function () {\n"
-                    + "            return;\n"
-                    + "        }());\n"
-                    + "    }\n"
-                    + "}\n"
-                )
+                (`
+function aa() {
+    while (true) {
+        (function () {
+            return;
+        }());
+    }
+}
+aa();
+                `)
             ],
             module: [
                 "export default Object.freeze();",
 
 // PR-439 - Add grammar for "export async function ...".
 
-                (
-                    "export default Object.freeze(async function () {\n"
-                    + "    return await 0;\n"
-                    + "});\n"
-                ),
+                (`
+export default Object.freeze(async function () {
+    return await 0;
+});
+                `),
                 // `import "aa";`,
                 `import * as aa from "aa";\naa();`,
                 `import aa from "aa" with {type: "json"};\naa();`,
@@ -873,127 +909,124 @@ aa();
                 `import {} from "aa";`
             ],
             number: [
-                "let aa = 0.0e0;",
-                "let aa = 0b0;",
-                "let aa = 0o0;",
-                "let aa = 0x0;"
+                "String(0.0e0);",
+                "String(0b0);",
+                "String(0o0);",
+                "String(0x0);"
             ],
 
 // PR-390 - Add numeric-separator support.
 
             numeric_separator: [
-                "let aa = 0.0_0_0;",
-                "let aa = 0b0_1111_1111n;\n",
-                "let aa = 0o0_1234_1234n;\n",
-                "let aa = 0x0_1234_1234n;\n",
-                "let aa = 1_234_234.1_234_234E1_234_234;"
+                "String(0.0_0_0);",
+                "String(0b0_1111_1111n);",
+                "String(0o0_1234_1234n);",
+                "String(0x0_1234_1234n);",
+                "String(1_234_234.1_234_234E1_234_234);"
             ],
             optional_chaining: [
-                "let aa = aa?.bb?.cc;"
+                "String().aa?.bb?.cc();"
             ],
             param: [
-                "function aa({aa, bb}) {\n    return {aa, bb};\n}\n",
-                (
-                    "function aa({constructor}) {\n"
-                    + "    return {constructor};\n"
-                    + "}\n"
-                )
+                "function aa({aa, bb}) {\n    return {aa, bb};\n}\naa();",
+                (`
+function aa({constructor}) {
+    return {constructor};
+}
+aa();
+                `)
             ],
             property: [
-                "let aa = aa[`!`];"
+                "let aa = 0;\naa[`!`]();"
             ],
             regexp: [
                 `RegExp.escape("");`,
-                `function aa() {\n    return /./;\n}`,
-                `let aa = /(?!.)(?:.)(?=.)/;`,
-                `let aa = /(?ims-ims:.)/;`,
-                `let aa = /./dgimsuvy;`,
-                `let aa = /[\\--\\-]/;`
+                `String(/(?!.)(?:.)(?=.)/);`,
+                `String(/(?ims-ims:.)/);`,
+                `String(/./dgimsuvy);`,
+                `String(/[\\--\\-]/);`,
+                `function aa() {\n    return /./;\n}\naa();`
             ],
             ternary: [
-                (
-                    "let aa = (\n"
-                    + "    aa()\n"
-                    + "    ? 0\n"
-                    + "    : 1\n"
-                    + ") "
-                    + "&& (\n"
-                    + "    aa()\n"
-                    + "    ? 0\n"
-                    + "    : 1\n"
-                    + ");"
-                ),
-                (
-                    "let aa = (\n"
-                    + "    aa()\n"
-                    + "    ? `${0}`\n"
-                    + "    : `${1}`\n"
-                    + ");"
-                ),
+                (`
+let aa = (
+    aa()
+    ? 0
+    : 1
+) && (
+    aa()
+    ? 0
+    : 1
+);
+aa();
+                `),
+                (`
+let aa = (
+    aa()
+    ? \`$\{0}\`
+    : \`$\{1}\`
+);
+aa();
+                `),
 
 // PR-394 - Bugfix
 // Fix jslint falsely believing megastring literals `0` and `1` are similar.
 
-                (
-                    "let aa = (\n"
-                    + "    aa()\n"
-                    + "    ? `0`\n"
-                    + "    : `1`\n"
-                    + ");"
-                )
+                (`
+let aa = (
+    aa()
+    ? \`0\`
+    : \`1\`
+);
+                `)
             ],
             try_catch: [
-                (
-                    "let aa = 0;\n"
-                    + "try {\n"
-                    + "    aa();\n"
-                    + "} catch (err) {\n"
-                    + "    aa = err;\n"
-                    + "}\n"
-                    + "try {\n"
-                    + "    aa();\n"
-                    + "} catch (err) {\n"
-                    + "    aa = err;\n"
-                    + "}\n"
-                    + "aa();\n"
-                )
+                (`
+let aa = 0;
+try {
+    aa();
+} catch (err) {
+    aa = err;
+}
+try {
+    aa();
+} catch (err) {
+    aa = err;
+}
+aa();
+                `)
             ],
             try_finally: [
-                (
-                    "let aa = 0;\n"
-                    + "try {\n"
-                    + "    aa();\n"
-                    + "} finally {\n"
-                    + "    aa();\n"
-                    + "}\n"
-                )
+                (`
+let aa = 0;
+try {
+    aa();
+} finally {
+    aa();
+}
+                `)
             ],
             use_strict: [
-                (
-                    "\"use strict\";\n"
-                    + "let aa = 0;\n"
-                    + "function bb() {\n"
-                    + "    \"use strict\";\n"
-                    + "    return aa;\n"
-                    + "}\n"
-                )
+                (`
+"use strict";
+let aa = 0;
+function bb() {
+    "use strict";
+    return aa;
+}
+bb();
+                `)
             ],
             var: [
-                "/*jslint node*/\n",
-                ""
-            ].map(function (directive) {
-                return [
-                    "const aa = 0;\naa();\n",
-                    "let aa = 0;\naa();\n",
-                    "var aa = 0;\naa();\n"
-                ].map(function (source) {
-                    return directive + source;
-                });
-            }).flat()
+                "const aa = 0;\naa();\n",
+                "let aa = 0;\naa();\n",
+                "var aa = 0;\naa();\n"
+            ]
         }).forEach(function (codeList) {
             let elemPrv = "";
-            codeList.forEach(function (source) {
+            codeList.flat().flat().forEach(function (source) {
                 let warnings;
+                source = source.trim();
                 // Assert codeList is sorted.
                 assertOrThrow(elemPrv < source, JSON.stringify([
                     elemPrv, source
@@ -1008,7 +1041,11 @@ aa();
                     }).warnings;
                     assertOrThrow(
                         warnings.length === 0,
-                        `${source}\n${JSON.stringify(warnings, undefined, 4)}`
+                        `\n\n${source}\n\n${JSON.stringify(
+                            warnings,
+                            undefined,
+                            4
+                        )}`
                     );
                 });
             });
@@ -1026,7 +1063,7 @@ jstestDescribe((
         ], [
             ";\naa(new XMLHttpRequest());", {browser: true}, ["aa"]
         ], [
-            "let aa = \"aa\" + 0;", {convert: true}, []
+            "let aa = \"aa\" + 0;\naa();", {convert: true}, []
         ], [
             "registerType();", {couch: true}, []
         ], [
@@ -1037,69 +1074,70 @@ jstestDescribe((
 
             "new Function();\neval();", {eval: true, evil: true}, []
         ], [
-            "let aa = () => 0;", {fart: true}, []
+            (`
+function aa(aa) {
+    for (aa = 0; aa < 0; aa += 1) {
+        aa();
+    }
+}
+aa();
+            `), {for: true}, []
         ], [
-            (
-                "let aa = async (bb, {cc, dd}, [ee, ff], ...gg) => {\n"
-                + "    bb += 1;\n"
-                + "    return await (bb + cc + dd + ee + ff + gg);\n"
-                + "};\n"
-            ), {fart: true}, []
+            (`
+String({get aa() {
+    return;
+}});
+            `), {getset: true}, []
         ], [
-            (
-                "function aa(aa) {\n"
-                + "    for (aa = 0; aa < 0; aa += 1) {\n"
-                + "        aa();\n"
-                + "    }\n"
-                + "}\n"
-            ), {for: true}, []
-        ], [
-            "let aa = {get aa() {\n    return;\n}};", {getset: true}, []
-        ], [
-            "let aa = {set aa(aa) {\n    return aa;\n}};", {getset: true}, []
+            (`
+String({set aa(aa) {
+    return aa;
+}});
+            `), {getset: true}, []
         ], [
             sourceJslintMjs.replace((
                 /    /g
             ), "  "), {indent2: true}, []
         ], [
-            "function aa() {\n  return;\n}", {indent2: true}, []
+            "function aa() {\n  return;\n}\naa();", {indent2: true}, []
         ], [
             "/".repeat(100), {long: true}, []
         ], [
 
 // PR-404 - Alias "nomen" to jslint-directive "name" for backwards-compat.
 
-            "let aa = aa._;", {name: true, nomen: true}, []
+            "let aa = 0;\naa._();", {name: true, nomen: true}, []
         ], [
             "require();", {node: true}, []
         ], [
-            "let aa = 'aa';", {single: true}, []
+            "String('aa');", {single: true}, []
         ], [
 
 // PR-404 - Add new directive "subscript" to play nice with Google Closure.
 
-            "aa[\"aa\"] = 1;", {subscript: true}, ["aa"]
+            "aa[\"aa\"]();", {subscript: true}, ["aa"]
         ], [
             "", {test_internal_error: true}, []
         ], [
-            "let aa = this;", {this: true}, []
+            "String(this);", {this: true}, []
         ], [
             "", {trace: true}, []
         ], [
-            (
-                "function aa({bb, aa}) {\n"
-                + "    switch (aa) {\n"
-                + "    case 1:\n"
-                + "        break;\n"
-                + "    case 0:\n"
-                + "        break;\n"
-                + "    default:\n"
-                + "        return {bb, aa};\n"
-                + "    }\n"
-                + "}\n"
-            ), {unordered: true}, []
+            (`
+function aa({bb, aa}) {
+    switch (aa) {
+    case 1:
+        break;
+    case 0:
+        break;
+    default:
+        return {bb, aa};
+    }
+}
+aa();
+            `), {unordered: true}, []
         ], [
-            "let {bb, aa} = 0;", {unordered: true}, []
+            "let {bb, aa} = 0;\naa(bb);", {unordered: true}, []
         ], [
             (
                 "function aa() {\n"
@@ -1110,13 +1148,14 @@ jstestDescribe((
                 + "}\n"
             ), {variable: true}, []
         ], [
-            "let bb = 0;\nlet aa = 0;", {variable: true}, []
+            "let bb = 0;\nlet aa = 0;\naa(bb);", {variable: true}, []
         ], [
             "\t", {white: true}, []
         ]
     ].forEach(function ([
         source, option_dict, global_list
     ]) {
+        source = source.trim();
         jstestIt((
             `test option=${JSON.stringify(option_dict)} handling-behavior`
         ), function () {
@@ -1139,14 +1178,15 @@ jstestDescribe((
                 jslintCjs.jslint
             ].forEach(function (jslint) {
                 // test jslint's option handling-behavior
-                let warnings = jslint(
+                let warnings;
+                warnings = jslint(
                     source,
                     option_dict,
                     global_list
                 ).warnings;
                 assertOrThrow(
                     warnings.length === warningsLength,
-                    `${source}\n${JSON.stringify(warnings, undefined, 4)}`
+                    `\n\n${source}\n\n${JSON.stringify(warnings, undefined, 4)}`
                 );
                 // test jslint's directive handling-behavior
                 source = (
@@ -1164,9 +1204,10 @@ jstestDescribe((
                         /^#!/
                     ), "//")
                 );
+                warnings = jslint(source).warnings;
                 assertOrThrow(
-                    jslint(source).warnings.length === warningsLength,
-                    source
+                    warnings.length === warningsLength,
+                    `\n\n${source}\n\n${JSON.stringify(warnings, undefined, 4)}`
                 );
             });
         });

--- a/test.mjs
+++ b/test.mjs
@@ -662,7 +662,8 @@ async function aa() {
 await aa();
                 `),
                 (`
-let aa = async () => {
+let aa = 0;
+aa = async () => {
     try {
         return await aa();
     } catch (err) {
@@ -677,20 +678,18 @@ await aa();
 
             bigint: [
                 (`
-const aa = 0;
 String(0b0n);
 String(0o0n);
 String(0x0n);
 String(BigInt(0n));
-aa(typeof aa === "bigint");
+String(typeof String === "bigint");
                 `)
             ],
             date: [
                 (`
-const aa = 0;
 Date.getTime();
-aa().getTime();
-aa.aa().getTime();
+String().getTime();
+String.aa().getTime();
                 `)
             ],
             destructure: [
@@ -762,50 +761,46 @@ aa.bb();
             ],
             ellipsis: [
 
-// Issue #401 - Add ES2018-syntax for object-literal-spread-operator.
-
-                String(`
-let aa = 0;
-aa = [
-    [
-        0,
-        ...aa(),
-        0,
-        ...aa,
-        0,
-        ...aa.aa,
-        0
-    ],
-    {
-        aa: 0,
-        ...aa(),
-        bb: 0,
-        ...aa,
-        cc: 0,
-        ...aa.aa,
-        dd: 0
-    }
-];
-aa();
-                `).trim(),
-
 // PR-483 - Allow parenthesis after ellipsis inside a function call.
 
                 (`
-let aa = 0;
-aa(...(
-    aa()
+String(0, ...(
+    String()
     ? 0
     : 1
 ));
+                `),
+
+// Issue #401 - Add ES2018-syntax for object-literal-spread-operator.
+
+                (`
+let aa;
+aa = [
+    0,
+    ...aa(),
+    0,
+    ...aa,
+    0,
+    ...aa.aa,
+    0
+];
+aa = {
+    aa: 0,
+    ...aa(),
+    bb: 0,
+    ...aa,
+    cc: 0,
+    ...aa.aa,
+    dd: 0
+};
+aa();
                 `)
             ],
             fart: [
                 "let aa = () => 0;\naa();",
                 (`
-let aa = async (bb, {cc, dd}, [ee, ff], ...gg) => {
-    bb += 1;
-    return await (bb + cc + dd + ee + ff + gg);
+let aa = async (bb, [cc, dd], {ee, ff}, ...gg) => {
+    await bb(cc, dd, ee, ff, gg);
 };
 aa();
                 `)
@@ -829,10 +824,9 @@ aa();
             ],
             indent_method: [
                 (`
-let aa = 0;
-aa
-    .bb
-    .cc(
+String
+    .aa
+    .bb(
         0
     );
                 `)
@@ -920,8 +914,8 @@ export default Object.freeze(async function () {
             numeric_separator: [
                 "String(0.0_0_0);",
                 "String(0b0_1111_1111n);",
-                "String(0o0_1234_1234n);",
-                "String(0x0_1234_1234n);",
+                "String(0o0_1237_1237n);",
+                "String(0x0_123f_123fn);",
                 "String(1_234_234.1_234_234E1_234_234);"
             ],
             optional_chaining: [
@@ -937,7 +931,7 @@ aa();
                 `)
             ],
             property: [
-                "let aa = 0;\naa[`!`]();"
+                "String[`!`]();"
             ],
             regexp: [
                 `RegExp.escape("");`,
@@ -949,72 +943,46 @@ aa();
             ],
             ternary: [
                 (`
-let aa = (
-    aa()
-    ? 0
-    : 1
-) && (
-    aa()
+String(
+    String()
     ? 0
     : 1
 );
-aa();
-                `),
-                (`
-let aa = (
-    aa()
+String(
+    String()
     ? \`$\{0}\`
     : \`$\{1}\`
 );
-aa();
-                `),
 
 // PR-394 - Bugfix
-// Fix jslint falsely believing megastring literals `0` and `1` are similar.
+// Fix jslint falsely believing megastring literals \`0\` and \`1\` are similar.
 
-                (`
-let aa = (
-    aa()
+String(
+    String()
     ? \`0\`
     : \`1\`
 );
                 `)
             ],
-            try_catch: [
+            try_catch_finally: [
                 (`
-let aa = 0;
 try {
-    aa();
+    String();
 } catch (err) {
-    aa = err;
-}
-try {
-    aa();
-} catch (err) {
-    aa = err;
-}
-aa();
-                `)
-            ],
-            try_finally: [
-                (`
-let aa = 0;
-try {
-    aa();
+    err();
 } finally {
-    aa();
+    String();
 }
                 `)
             ],
             use_strict: [
                 (`
 "use strict";
-let aa = 0;
-function bb() {
+function aa() {
     "use strict";
-    return aa;
+    return;
 }
-bb();
+aa();
                 `)
             ],
             var: [
@@ -1058,22 +1026,17 @@ jstestDescribe((
 ), function testBehaviorJslintOption() {
     let elemPrv = "";
     [
-        [
-            "let aa = aa | 0;", {bitwise: true}, []
-        ], [
-            ";\naa(new XMLHttpRequest());", {browser: true}, ["aa"]
-        ], [
-            "let aa = \"aa\" + 0;\naa();", {convert: true}, []
-        ], [
-            "registerType();", {couch: true}, []
-        ], [
-            "debugger;", {devel: true}, []
-        ], [
+        [{bitwise: true}, "String(String | 0);"],
+        [{browser: true}, ";\nString(new XMLHttpRequest());"],
+        [{convert: true}, "String(\"aa\" + 0);"],
+        [{couch: true}, "registerType();"],
+        [{devel: true}, "debugger;"],
 
 // PR-404 - Alias "evil" to jslint-directive "eval" for backwards-compat.
 
-            "new Function();\neval();", {eval: true, evil: true}, []
-        ], [
+        [{eval: true, evil: true}, "new Function();\neval();"],
+        [
+            {for: true},
             (`
 function aa(aa) {
     for (aa = 0; aa < 0; aa += 1) {
@@ -1081,49 +1044,27 @@ function aa(aa) {
     }
 }
 aa();
-            `), {for: true}, []
-        ], [
-            (`
-String({get aa() {
-    return;
-}});
-            `), {getset: true}, []
-        ], [
-            (`
-String({set aa(aa) {
-    return aa;
-}});
-            `), {getset: true}, []
-        ], [
-            sourceJslintMjs.replace((
-                /    /g
-            ), "  "), {indent2: true}, []
-        ], [
-            "function aa() {\n  return;\n}\naa();", {indent2: true}, []
-        ], [
-            "/".repeat(100), {long: true}, []
-        ], [
+            `)
+        ],
+        [{getset: true}, "String({get aa() {\n    return;\n}});"],
+        [{getset: true}, "String({set aa(aa) {\n    return aa;\n}});"],
+        [{indent2: true}, sourceJslintMjs.replace((/    /g), "  ")],
+        [{indent2: true}, "function aa() {\n  return;\n}\naa();"],
+        [{long: true}, "/".repeat(100)],
 
 // PR-404 - Alias "nomen" to jslint-directive "name" for backwards-compat.
 
-            "let aa = 0;\naa._();", {name: true, nomen: true}, []
-        ], [
-            "require();", {node: true}, []
-        ], [
-            "String('aa');", {single: true}, []
-        ], [
+        [{name: true, nomen: true}, "let aa = 0;\naa._();"],
+        [{node: true}, "require();"],
+        [{single: true}, "String('aa');"],
 
 // PR-404 - Add new directive "subscript" to play nice with Google Closure.
 
-            "aa[\"aa\"]();", {subscript: true}, ["aa"]
-        ], [
-            "", {test_internal_error: true}, []
-        ], [
-            "String(this);", {this: true}, []
-        ], [
-            "", {trace: true}, []
-        ], [
-            (`
+        [{subscript: true}, "String[\"aa\"]();"],
+        [{test_internal_error: true}, ""],
+        [{this: true}, "String(this);"],
+        [{trace: true}, ""],
+        [{unordered: true}, (`
 function aa({bb, aa}) {
     switch (aa) {
     case 1:
@@ -1135,32 +1076,30 @@ function aa({bb, aa}) {
     }
 }
 aa();
-            `), {unordered: true}, []
-        ], [
-            "let {bb, aa} = 0;\naa(bb);", {unordered: true}, []
-        ], [
-            (
-                "function aa() {\n"
-                + "    if (aa) {\n"
-                + "        let bb = 0;\n"
-                + "        return bb;\n"
-                + "    }\n"
-                + "}\n"
-            ), {variable: true}, []
-        ], [
-            "let bb = 0;\nlet aa = 0;\naa(bb);", {variable: true}, []
-        ], [
-            "\t", {white: true}, []
-        ]
+            `)],
+        [{unordered: true}, "let {bb, aa} = 0;\naa(bb);"],
+        [
+            {variable: true},
+            (`
+function aa() {
+    if (aa) {
+        let bb = 0;
+        return bb;
+    }
+}
+            `)
+        ],
+        [{variable: true}, "let bb = 0;\nlet aa = 0;\naa(bb);"],
+        [{white: true}, "\t"]
     ].forEach(function ([
-        source, option_dict, global_list
+        option_dict, source
     ]) {
         source = source.trim();
         jstestIt((
             `test option=${JSON.stringify(option_dict)} handling-behavior`
         ), function () {
             let elemNow = JSON.stringify([
-                option_dict, source, global_list
+                option_dict, source
             ]);
             let warningsLength = (
                 option_dict.test_internal_error
@@ -1168,9 +1107,14 @@ aa();
                 : 0
             );
             // Assert list is sorted.
-            assertOrThrow(elemPrv < elemNow, JSON.stringify([
-                elemPrv, elemNow
-            ], undefined, 4));
+            assertOrThrow(
+                elemPrv < elemNow,
+                JSON.stringify(
+                    [elemPrv, elemNow],
+                    undefined,
+                    4
+                )
+            );
             elemPrv = elemNow;
             option_dict.beta = true;
             [
@@ -1181,8 +1125,7 @@ aa();
                 let warnings;
                 warnings = jslint(
                     source,
-                    option_dict,
-                    global_list
+                    option_dict
                 ).warnings;
                 assertOrThrow(
                     warnings.length === warningsLength,
@@ -1190,19 +1133,13 @@ aa();
                 );
                 // test jslint's directive handling-behavior
                 source = (
-                    "/*jslint " + JSON.stringify(
-                        option_dict
-                    ).slice(1, -1).replace((
-                        /"/g
-                    ), "") + "*/\n"
-                    + (
-                        global_list.length === 0
-                        ? ""
-                        : "/*global " + global_list.join(",") + "*/\n"
-                    )
-                    + source.replace((
-                        /^#!/
-                    ), "//")
+                    "/*jslint "
+                    + JSON
+                        .stringify(option_dict)
+                        .slice(1, -1)
+                        .replace((/"/g), "")
+                    + "*/\n"
+                    + source.replace((/^#!/), "//")
                 );
                 warnings = jslint(source).warnings;
                 assertOrThrow(
@@ -1240,7 +1177,6 @@ jstestDescribe((
                 /^\["\n([\S\s]*?)\n"(,.*?)$/gm
             ), function (ignore, source, param) {
                 source = "[" + JSON.stringify(source) + param;
-                assertOrThrow(source.length > (80 - 3), source);
                 return source;
             }).replace((
                 / \/\/jslint-ignore-line$/gm

--- a/test.mjs
+++ b/test.mjs
@@ -646,6 +646,18 @@ jstestDescribe((
                 "new Array(0);"
             ],
             async_await: [
+                (`
+/*jslint fart*/
+let aa = 0;
+aa = async () => {
+    try {
+        return await aa();
+    } catch (err) {
+        await err();
+    }
+};
+await aa();
+                `),
                 "async function aa() {\n    await aa();\n}\nawait aa();",
 
 // PR-405 - Bugfix - fix expression after "await" mis-identified as statement.
@@ -659,17 +671,6 @@ async function aa() {
         await err();
     }
 }
-await aa();
-                `),
-                (`
-let aa = 0;
-aa = async () => {
-    try {
-        return await aa();
-    } catch (err) {
-        await err();
-    }
-};
 await aa();
                 `)
             ],
@@ -697,11 +698,6 @@ String.aa().getTime();
 // PR-500 - Unify ES2015-destructure-logic.
 
                 [
-                    (`
-(({expr}) => {
-    aa(bb, cc, dd, ee, ff, gg);
-}());
-                    `),
                     (`
 (function ({expr}) {
     aa(bb, cc, dd, ee, ff, gg);
@@ -797,13 +793,14 @@ aa();
                 `)
             ],
             fart: [
-                "let aa = () => 0;\naa();",
                 (`
+/*jslint fart*/
 let aa = async (bb, [cc, dd], {ee, ff}, ...gg) => {
     await bb(cc, dd, ee, ff, gg);
 };
 aa();
-                `)
+                `),
+                "let aa = () => 0;\naa();"
             ],
             for: [
                 (`

--- a/test.mjs
+++ b/test.mjs
@@ -694,26 +694,36 @@ jstestDescribe((
 // PR-500 - Unify ES2015-destructure-logic.
 
                 [
-                    `(function ({expr}) {\n    aa(bb, cc, dd, zz);\n}());`,
-                    `const {expr}`,
-                    `let [aa, bb, cc, dd, zz] = 0;\n{expr}`,
-                    `let {expr}`
+                    String(`
+(function ({expr}) {
+    aa(bb, cc, dd, ee, ff, gg);
+}());
+                    `).trim(),
+                    "const {expr}",
+                    "let {expr}",
+                    "let [aa, bb, cc, dd, ee, ff, gg] = 0;\n{expr}"
                 ].map(function (source) {
-                    source = source.replace("{expr}", (
-                        `[{\n`
-                        + `    bb,\n`
-                        + `    cc = 0,\n`
-                        + `    cc: dd,\n`
-                        + `    dd: [{aa}],\n`
-                        + `    ...zz\n`
-                        + `}]`
-                    ));
+                    source = source.replace("{expr}", String(`
+[
+    {
+        cc,
+        dd = 0,
+        dd: ee,
+        ee: [{bb}],
+        ...aa
+    },
+    [
+        gg,
+        ...ff
+    ]
+]
+                    `).trim());
                     if (!(/function/).test(source)) {
                         source = (
                             `${source} = (function () {\n`
                             + `    return;\n`
                             + `}());\n`
-                            + `aa(bb, cc, dd, zz);\n`
+                            + `aa(bb, cc, dd, ee, ff, gg);\n`
                         );
                     }
                     source = `/*jslint node*/\n${source}`;
@@ -739,9 +749,30 @@ jstestDescribe((
 
 // Issue #401 - Add ES2018-syntax for object-literal-spread-operator.
 
-                "let aa = 0;\naa = {aa: 1, ...aa(), bb: 2};",
-                "let aa = 0;\naa = {aa: 1, ...aa, bb: 2};",
-                "let aa = 0;\naa = {aa: 1, ...aa.aa, bb: 2};",
+                String(`
+let aa = 0;
+aa = [
+    [
+        0,
+        ...aa(),
+        0,
+        ...aa,
+        0,
+        ...aa.aa,
+        0
+    ],
+    {
+        aa: 0,
+        ...aa(),
+        bb: 0,
+        ...aa,
+        cc: 0,
+        ...aa.aa,
+        dd: 0
+    }
+];
+aa();
+                `).trim(),
 
 // PR-483 - Allow parenthesis after ellipsis inside a function call.
 

--- a/test.mjs
+++ b/test.mjs
@@ -694,36 +694,26 @@ jstestDescribe((
 // PR-500 - Unify ES2015-destructure-logic.
 
                 [
-                    String(`
-(function ({expr}) {
-    aa(bb, cc, dd, ee, ff, gg);
-}());
-                    `).trim(),
-                    "const {expr}",
-                    "let {expr}",
-                    "let [aa, bb, cc, dd, ee, ff, gg] = 0;\n{expr}"
+                    `(function ({expr}) {\n    aa(bb, cc, dd, zz);\n}());`,
+                    `const {expr}`,
+                    `let [aa, bb, cc, dd, zz] = 0;\n{expr}`,
+                    `let {expr}`
                 ].map(function (source) {
-                    source = source.replace("{expr}", String(`
-[
-    {
-        cc,
-        dd = 0,
-        dd: ee,
-        ee: [{bb}],
-        ...aa
-    },
-    [
-        gg,
-        ...ff
-    ]
-]
-                    `).trim());
+                    source = source.replace("{expr}", (
+                        `[{\n`
+                        + `    aa,\n`
+                        + `    bb = 0,\n`
+                        + `    bb: cc,\n`
+                        + `    dd: [{dd}],\n`
+                        + `    ...zz\n`
+                        + `}]`
+                    ));
                     if (!(/function/).test(source)) {
                         source = (
                             `${source} = (function () {\n`
                             + `    return;\n`
                             + `}());\n`
-                            + `aa(bb, cc, dd, ee, ff, gg);\n`
+                            + `aa(bb, cc, dd, zz);\n`
                         );
                     }
                     source = `/*jslint node*/\n${source}`;
@@ -749,30 +739,9 @@ jstestDescribe((
 
 // Issue #401 - Add ES2018-syntax for object-literal-spread-operator.
 
-                String(`
-let aa = 0;
-aa = [
-    [
-        0,
-        ...aa(),
-        0,
-        ...aa,
-        0,
-        ...aa.aa,
-        0
-    ],
-    {
-        aa: 0,
-        ...aa(),
-        bb: 0,
-        ...aa,
-        cc: 0,
-        ...aa.aa,
-        dd: 0
-    }
-];
-aa();
-                `).trim(),
+                "let aa = 0;\naa = {aa: 1, ...aa(), bb: 2};",
+                "let aa = 0;\naa = {aa: 1, ...aa, bb: 2};",
+                "let aa = 0;\naa = {aa: 1, ...aa.aa, bb: 2};",
 
 // PR-483 - Allow parenthesis after ellipsis inside a function call.
 


### PR DESCRIPTION
This PR will:
- jslint-regression - Fix long-running regression where 'let x = x;' doesn't warn about temporal-dead-zone.

This PR will additionally:
- jslint-warning - Tighten warning of unused variables to be always on, regardless of module / nodejs mode.
- jslint - Wrap all property-updates 'name.init = true/false' with calls to:
    name_lookup() - 'aa=0'
    name_push()   - 'let aa=0'

Details
- Related to #458
- To resolve primary-issue, an audit of how jslint updates each lexical-token's '.dead' (tdz) property was conducted, reworked, and documented.
    - had to rewrite many tests that had this issue as well ^^;;;
- A compromise was made to allow the following:
    - jslint will raise a false-positive tdz for following legal-code:
        ```js
        function foo() {
            return bar; // bar is delared later below
        }

        let bar = 0;

        // warning:
        //  1. 'bar' is out of scope. // line 2, column 12
        //     return bar;
        ```
    - since its bad-form to use a variable above where its declared in code, this false-positive is deemed acceptable.

<img width="682" height="1033" alt="image" src="https://github.com/user-attachments/assets/00a7756b-478c-4800-af6a-918b8b58a35c" />
