### PR TITLE
- jslint-ecma - Add ES2015-feature for..of.

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -112,10 +112,11 @@ echo "\
                     "sh", file + ".sh"
                 ],
                 {
-                    env: Object.assign({
+                    env: {
                         // limit stdout to xxx lines
-                        SH_RUN_WITH_SCREENSHOT_TXT_MAX_LINES: 64
-                    }, process.env),
+                        SH_RUN_WITH_SCREENSHOT_TXT_MAX_LINES: 64,
+                        ...process.env
+                    },
                     stdio: ["ignore", 1, 2]
                 }
             ).on("exit", resolve);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 # Todo
+- jslint - Rename token-property for variables '.init' to '.assigned', to improve readability.
+- jslint - Rename internal variable 'blockage' to 'block_scope', 'functionage' to 'function_scope', to imporove readability.
+- jslint - Change warning 'uninitialized_a' to 'unassigned_variable_a'.
+- jslint - Change warning 'out_of_scope_a' to 'temporal_dead_zone_a'.
+- jslint - Add warning and tdz for function-declaration inside block-scope.
+- jslint - Add implicit block-scope for:
+    - if-else
+    - for-loop
+        - for-semicolon
+        - for-in
+        - for-of
+    - while-loop
+    - do-while
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
 - jslint - Relax warning expected_line_break_a_b for ternary-operator inside template-literal.
 - jslint - Add ability to auto-fix whitespace.
@@ -9,8 +22,15 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.7.1-beta
-- jslint - Move catch-variable from its special-scope into lexical-scope.
-- jslint - Add lexical-scope to internal-function jslint_phase3_parse().
+- jslint - Change scope from function-scope to block-scope:
+    - const-declaration
+    - let-declaration
+    - function-declaration
+- jslint - Restrict scope from function-scope to its own function-body:
+    - named-function-expression
+- jslint - Change scope from special-catch-scope to block-scope:
+    - catch-variable
+- jslint - Add block-scope to internal-function jslint_phase3_parse().
 - jslint-ecma - Add ES2015-feature for..of.
 - jslint - Expand built-in-globals for browser, ecma, and node - auto-generated from online-sources.
 - jslint-ci - Add automated ci for shellcheck to lint shell-scripts.
@@ -21,8 +41,8 @@
 - jslint-regression - Fix long-running regression where 'let x = x;' doesn't warn about temporal-dead-zone.
 - jslint-warning - Tighten warning of unused variables to be always on, regardless of module / nodejs mode.
 - jslint - Wrap all property-updates 'name.init = true/false' with calls to:
-    name_lookup() - 'aa=0'
-    name_push()   - 'let aa=0'
+    name_declare()      - 'let aa=0'
+    post_a_assignment() - 'aa=0'
 
 # v2026.6.30
 - jslint-ecma - Update README.md, documenting supported ES2015+ features.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,14 @@
 
 # Todo
 - jslint-ecma - Add ES2018-feature Asynchronous Iteration.
+- jslint-ecma - Add ES2015-feature iterators.
 - jslint - Audit token-property '.free'.
 - jslint - Rename token-property for variables '.init' to '.assigned', to improve readability.
 - jslint - Change warning 'uninitialized_a' to 'unassigned_variable_a'.
 - jslint - Change warning 'out_of_scope_a' to 'temporal_dead_zone_a'.
 - jslint - Add warning and tdz for function-declaration inside block-scope.
-- jslint - Add implicit scope_block for:
-    - if-else
-    - while-loop
-    - do-while
+- jslint - Add hidden scope_block for:
+    - label-statement
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
 - jslint - Relax warning expected_line_break_a_b for ternary-operator inside template-literal.
 - jslint - Add ability to auto-fix whitespace.
@@ -20,15 +19,19 @@
 
 # v2026.7.1-beta
 - jslint - Add implicit scope_block for:
+    - if-else
     - for-loop
+    - while-loop
+    - do-while
+- jslint - Add hidden scope_block for:
+    - catch-variable
+    - for-variable
 - jslint - Change scope from scope_function to scope_block:
     - const-declaration
     - let-declaration
     - function-declaration
 - jslint - Restrict scope from scope_function to its own function-body:
     - named-function-expression
-- jslint - Change scope from special-catch-scope to scope_block:
-    - catch-variable
 - jslint - Rename internal scope-variables to imporove readability of scope-logic:
     - 'blockage' to 'scope_block'
     - 'functionage' to 'scope_function'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
 - jslint - Change warning 'uninitialized_a' to 'unassigned_variable_a'.
 - jslint - Change warning 'out_of_scope_a' to 'temporal_dead_zone_a'.
 - jslint - Add warning and tdz for function-declaration inside block-scope.
-- jslint - Add hidden scope_block for:
-    - statement-label
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
 - jslint - Relax warning expected_line_break_a_b for ternary-operator inside template-literal.
 - jslint - Add ability to auto-fix whitespace.
@@ -18,19 +16,20 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.7.1-beta
-- jslint - Add implicit scope_block for:
-    - if-else
-    - for-loop
-    - while-loop
-    - do-while
-- jslint - Add hidden scope_block for:
-    - catch-variable
-    - for-variable
-    - function-parameter
 - jslint - Change scope from scope_function to scope_block:
     - const-declaration
     - let-declaration
     - function-declaration
+- jslint - Add implicit scope_block for:
+    - do-while
+    - for-loop
+    - if-else
+    - while-loop
+- jslint - Add hidden scope_block for:
+    - catch-variable
+    - for-variable
+    - function-parameter
+    - label-name
 - jslint - Restrict scope from scope_function to its own function-body:
     - named-function-expression
 - jslint - Rename internal scope-variables to imporove readability of scope-logic:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.7.1-beta
+- jslint - Move catch-variable from its special-scope into lexical-scope.
 - jslint - Add lexical-scope to internal-function jslint_phase3_parse().
 - jslint-ecma - Add ES2015-feature for..of.
 - jslint - Expand built-in-globals for browser, ecma, and node - auto-generated from online-sources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,14 @@
 # Changelog
 
 # Todo
+- jslint-ecma - Add ES2018-feature Asynchronous Iteration.
+- jslint - Audit token-property '.free'.
 - jslint - Rename token-property for variables '.init' to '.assigned', to improve readability.
 - jslint - Change warning 'uninitialized_a' to 'unassigned_variable_a'.
 - jslint - Change warning 'out_of_scope_a' to 'temporal_dead_zone_a'.
 - jslint - Add warning and tdz for function-declaration inside block-scope.
 - jslint - Add implicit scope_block for:
     - if-else
-    - for-loop
-        - for-semicolon
-        - for-in
-        - for-of
     - while-loop
     - do-while
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
@@ -21,6 +19,8 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.7.1-beta
+- jslint - Add implicit scope_block for:
+    - for-loop
 - jslint - Change scope from scope_function to scope_block:
     - const-declaration
     - let-declaration
@@ -33,6 +33,7 @@
     - 'blockage' to 'scope_block'
     - 'functionage' to 'scope_function'
 - jslint - Add block-scope to internal-function jslint_phase3_parse().
+- jslint - Disable directive-option /*jslint for*/, replacing it with for-loop specific warnings.
 - jslint-ecma - Add ES2015-feature for..of.
 - jslint - Expand built-in-globals for browser, ecma, and node - auto-generated from online-sources.
 - jslint-ci - Add automated ci for shellcheck to lint shell-scripts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.7.1-beta
+- jslint-ecma - Add ES2015-feature for..of.
+- jslint - Disable directive-option /*jslint for*/, replacing it with for-loop specific warnings.
+- jslint - Update scope-related warnings for variables, depending on whether they are let/const (scope_block) or var (scope_function).
 - jslint - Change scope from scope_function to scope_block:
     - const-declaration
     - let-declaration
@@ -36,8 +39,6 @@
     - 'blockage' to 'scope_block'
     - 'functionage' to 'scope_function'
 - jslint - Add block-scope to internal-function jslint_phase3_parse().
-- jslint - Disable directive-option /*jslint for*/, replacing it with for-loop specific warnings.
-- jslint-ecma - Add ES2015-feature for..of.
 - jslint - Expand built-in-globals for browser, ecma, and node - auto-generated from online-sources.
 - jslint-ci - Add automated ci for shellcheck to lint shell-scripts.
 - jslint-regression - Cleanup indent for multiline-method-chaining.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.7.1-beta
+- jslint-ecma - Add ES2015-feature for..of.
 - jslint - Expand built-in-globals for browser, ecma, and node - auto-generated from online-sources.
 - jslint-ci - Add automated ci for shellcheck to lint shell-scripts.
 - jslint-regression - Cleanup indent for multiline-method-chaining.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 # Todo
 - jslint - Rename token-property for variables '.init' to '.assigned', to improve readability.
-- jslint - Rename internal variable 'blockage' to 'block_scope', 'functionage' to 'function_scope', to imporove readability.
 - jslint - Change warning 'uninitialized_a' to 'unassigned_variable_a'.
 - jslint - Change warning 'out_of_scope_a' to 'temporal_dead_zone_a'.
 - jslint - Add warning and tdz for function-declaration inside block-scope.
-- jslint - Add implicit block-scope for:
+- jslint - Add implicit scope_block for:
     - if-else
     - for-loop
         - for-semicolon
@@ -22,14 +21,17 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.7.1-beta
-- jslint - Change scope from function-scope to block-scope:
+- jslint - Change scope from scope_function to scope_block:
     - const-declaration
     - let-declaration
     - function-declaration
-- jslint - Restrict scope from function-scope to its own function-body:
+- jslint - Restrict scope from scope_function to its own function-body:
     - named-function-expression
-- jslint - Change scope from special-catch-scope to block-scope:
+- jslint - Change scope from special-catch-scope to scope_block:
     - catch-variable
+- jslint - Rename internal scope-variables to imporove readability of scope-logic:
+    - 'blockage' to 'scope_block'
+    - 'functionage' to 'scope_function'
 - jslint - Add block-scope to internal-function jslint_phase3_parse().
 - jslint-ecma - Add ES2015-feature for..of.
 - jslint - Expand built-in-globals for browser, ecma, and node - auto-generated from online-sources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
 # v2026.7.1-beta
+- jslint - Add lexical-scope to internal-function jslint_phase3_parse().
 - jslint-ecma - Add ES2015-feature for..of.
 - jslint - Expand built-in-globals for browser, ecma, and node - auto-generated from online-sources.
 - jslint-ci - Add automated ci for shellcheck to lint shell-scripts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - jslint - Change warning 'out_of_scope_a' to 'temporal_dead_zone_a'.
 - jslint - Add warning and tdz for function-declaration inside block-scope.
 - jslint - Add hidden scope_block for:
-    - label-statement
+    - statement-label
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
 - jslint - Relax warning expected_line_break_a_b for ternary-operator inside template-literal.
 - jslint - Add ability to auto-fix whitespace.
@@ -26,6 +26,7 @@
 - jslint - Add hidden scope_block for:
     - catch-variable
     - for-variable
+    - function-parameter
 - jslint - Change scope from scope_function to scope_block:
     - const-declaration
     - let-declaration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 - jslint-ecma - Add ES2018-feature Asynchronous Iteration.
 - jslint-ecma - Add ES2015-feature iterators.
 - jslint - Audit token-property '.free'.
-- jslint - Change warning 'uninitialized_a' to 'unassigned_variable_a'.
-- jslint - Change warning 'out_of_scope_a' to 'temporal_dead_zone_a'.
 - jslint - Add warning and tdz for function-declaration inside block-scope.
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
 - jslint - Relax warning expected_line_break_a_b for ternary-operator inside template-literal.
@@ -18,6 +16,8 @@
 - jslint-ecma - Add ES2015-feature for..of.
 - jslint - Disable directive-option /*jslint for*/, replacing it with for-loop specific warnings.
 - jslint - Update scope-related warnings for variables, depending on whether they are let/const (scope_block) or var (scope_function).
+- jslint - Change warning 'out_of_scope_a' to 'temporal_dead_zone_a'.
+- jslint - Change warning 'uninitialized_a' to 'unassigned_var_a'.
 - jslint - Change scope from scope_function to scope_block:
     - const-declaration
     - let-declaration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - jslint-ecma - Add ES2018-feature Asynchronous Iteration.
 - jslint-ecma - Add ES2015-feature iterators.
 - jslint - Audit token-property '.free'.
-- jslint - Rename token-property for variables '.init' to '.assigned', to improve readability.
 - jslint - Change warning 'uninitialized_a' to 'unassigned_variable_a'.
 - jslint - Change warning 'out_of_scope_a' to 'temporal_dead_zone_a'.
 - jslint - Add warning and tdz for function-declaration inside block-scope.

--- a/README.md
+++ b/README.md
@@ -1010,7 +1010,7 @@ if (false) {
         - verify ci-success @ https://github.com/kaizhu256/jslint/actions
         - verify ci-success @ https://github.com/jslint-org/jslint/actions
 
-1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.7.3
+1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-p2026.7.20
     - click `Create pull request`
     - input `Add a title *` with: `<CHANGELOG.md entry #1>`
     - input `Add a description` with:

--- a/README.md
+++ b/README.md
@@ -949,7 +949,7 @@ if (false) {
 |  17. | ✅ | ES2015 | [`destructuring`](https://github.com/lukehoban/es6features#destructuring) |
 |  16. | ✅ | ES2015 | [`default + rest + spread`](https://github.com/lukehoban/es6features#default--rest--spread) |
 |  15. | ✅ | ES2015 | [`let + const`](https://github.com/lukehoban/es6features#let--const) |
-|  14. | ❌ | ES2015 | [`iterators + for..of`](https://github.com/lukehoban/es6features#iterators--forof) |
+|  14. | ⚠️ | ES2015 | [`iterators + for..of`](https://github.com/lukehoban/es6features#iterators--forof) |
 |  13. | ❌ | ES2015 | [`generators`](https://github.com/lukehoban/es6features#generators) |
 |  12. | ✅ | ES2015 | [`unicode`](https://github.com/lukehoban/es6features#unicode) |
 |  11. | ⚠️ | ES2015 | [`modules`](https://github.com/lukehoban/es6features#modules) |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Douglas Crockford <douglas@crockford.com>
         - [`/*jslint devel*/`](#jslint-devel)
         - [`/*jslint eval*/`](#jslint-eval)
         - [`/*jslint fart*/`](#jslint-fart)
-        - [`/*jslint for*/`](#jslint-for)
         - [`/*jslint getset*/`](#jslint-getset)
         - [`/*jslint indent2*/`](#jslint-indent2)
         - [`/*jslint long*/`](#jslint-long)
@@ -629,21 +628,6 @@ eval("1");
 let foo = async ({bar, baz}) => {
     return await bar(baz);
 };
-```
-
-<br>
-
-##### `/*jslint for*/`
-```js
-/*jslint for*/
-// Allow for-loop.
-
-function foo() {
-    let ii;
-    for (ii = 0; ii < 10; ii += 1) {
-        foo();
-    }
-}
 ```
 
 <br>

--- a/index.html
+++ b/index.html
@@ -1584,8 +1584,7 @@ if (!mode_debug) {
     editor.setValue(String(`
 #!/usr/bin/env node
 /*jslint browser, node*/
-/*global caches, indexedDb*/
-import https from "https";
+/*global indexedDb, localStorage*/
 import jslint from \u0022./jslint.mjs\u0022;
 
 /*jslint-disable*/
@@ -1597,6 +1596,15 @@ eval("console.log(\\"hello world\\");"); //jslint-ignore-line
 
 eval("console.log(\\"hello world\\");");
 
+await (async function () {
+    let result = await fetch("https://www.jslint.com/jslint.mjs");
+    result = await result.text();
+    result = jslint.jslint(result);
+    for (const {formatted_message} of result.warnings) {
+        console.error(formatted_message);
+    }
+}());
+
 // Optional directives.
 // .... /*jslint beta*/ .......... Enable experimental warnings.
 // .... /*jslint bitwise*/ ....... Allow bitwise operator.
@@ -1606,7 +1614,6 @@ eval("console.log(\\"hello world\\");");
 // .... /*jslint devel*/ ......... Allow console.log() and friends.
 // .... /*jslint eval*/ .......... Allow eval().
 // .... /*jslint fart*/ .......... Allow complex fat-arrow.
-// .... /*jslint for*/ ........... Allow for-statement.
 // .... /*jslint getset*/ ........ Allow get() and set().
 // .... /*jslint indent2*/ ....... Use 2-space indent.
 // .... /*jslint long*/ .......... Allow long lines.
@@ -1619,25 +1626,6 @@ eval("console.log(\\"hello world\\");");
 // .... /*jslint unordered*/ ..... Allow unordered cases, params, properties,
 // ................................... variables, and exports.
 // .... /*jslint white*/ ......... Allow messy whitespace.
-
-await (async function () {
-    let result = await new Promise(function (resolve) {
-        https.request("https://www.jslint.com/jslint.mjs", function (res) {
-            result = "";
-            res.on("data", function (chunk) {
-                result += chunk;
-            }).on("end", function () {
-                resolve(result);
-            }).setEncoding("utf8");
-        }).end();
-    });
-    result = jslint.jslint(result);
-    result.warnings.forEach(function ({
-        formatted_message
-    }) {
-        console.error(formatted_message);
-    });
-}());
     `).trim() + "\n");
 }
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -96,7 +96,6 @@
     NODE_V8_COVERAGE,
     a,
     alive,
-    alive_list,
     all,
     argv,
     arity,
@@ -1112,7 +1111,6 @@ function jslint(
     const syntax_dict = empty();        // The object containing the parser.
     const tenure = empty();     // The predefined property registry.
     const token_global = {      // The global object; the outermost context.
-        alive_list: [],
         async: 0,
         body: true,
         context: empty(),
@@ -1725,6 +1723,8 @@ function jslint(
         case "wrap_unary":
             mm = `Wrap the unary expression in parens.`;
             break;
+        //!! default:
+            //!! jslint_assert(undefined, `warning_code=${code}`);
         }
 
 // Validate mm.
@@ -5064,7 +5064,6 @@ function jslint_phase3_parse(state) {
 // 2.fun.1 - Mark 'declared', the function-name, during function-declaration.
 // 2.fun.2 - Mark 'alive', the function-name, during function-declaration.
 // 2.fun.3 - Mark 'init', the function-name, during function-declaration.
-// 2.fun.4 - Mark 'out-of-scope', the function-name, after function-body.
 //
 // 3.cat.1 - Mark 'declared', the catch-variable, before catch-block.
 // 3.cat.2 - Mark 'alive', the catch-variable, before catch-block.
@@ -5073,7 +5072,6 @@ function jslint_phase3_parse(state) {
 // 3.for.1 - Mark 'declared', the for-variable, ???.
 // 3.for.2 - Mark 'alive', the for-variable, before for-block.
 // 3.for.3 - Mark 'init', the for-variable, before for-block.
-// 3.for.4 - Mark 'out-of-scope', the for-variable, ???.
 //
 // 3.glo.1 - Mark 'declared', the global-variable, immediately.
 // 3.glo.2 - Mark 'alive', the global-variable, immediately.
@@ -5083,7 +5081,6 @@ function jslint_phase3_parse(state) {
 // 3.var.2 - Mark 'alive', the variable, after variable-declaration.
 // 3.var.3 - Mark 'init', the variable, after assignment.
 // 3.var.3 - Mark 'init', the variable, during variable-declaration.
-// 3.var.4 - Mark 'out-of-scope', the variable, after block-scope.
 //
 // 4.par.1 - Mark 'declared', the function-parameter, during destructuring.
 // 4.par.1 - Mark 'declared', the function-parameter, if unwrapped.
@@ -5093,6 +5090,7 @@ function jslint_phase3_parse(state) {
 // 5.lab.1 - Mark 'declared', the label-statement, before control-flow-block.
 // 5.lab.2 - Mark 'alive', the label-statement, before control-flow-block.
 // 5.lab.3 - Mark 'init', the label-statement, before control-flow-block.
+// 5.lab.4 - Mark 'out-of-scope', the label-statement, after control-flow-block.
 
         let earlier;
         let id = name.id;
@@ -5121,23 +5119,20 @@ function jslint_phase3_parse(state) {
             warn("reserved_a", name);
             return;
         }
+        block_stack.some(function (blockage, ii) {
+            earlier = blockage.context[id];
+            if (earlier && ii === 0) {
 
 // Has the name been declared in this context?
 
-        earlier = declared_scope.context[id];
-        if (earlier) {
-
 // test_cause:
-// ["let aa;let aa", "name_declare", "redefinition_a_b", "1", 12]
+// ["let aa;(function aa(){})", "name_declare", "scope_current", "aa", 0]
+// ["let aa;function aa(){}", "name_declare", "scope_current", "aa", 0]
+// ["let aa;let aa", "name_declare", "scope_current", "aa", 0]
 
-            warn("redefinition_a_b", name, id, earlier.line);
-            return;
-        }
-
-// Has the name been declared in an outer context?
-
-        block_stack.some(function (blockage) {
-            earlier = blockage.context[id];
+                test_cause("scope_current", id);
+                warn("redefinition_a_b", name, id, earlier.line);
+            }
             return earlier;
         });
 
@@ -5152,8 +5147,9 @@ function jslint_phase3_parse(state) {
             if (earlier.role === "variable") {
 
 // test_cause:
-// ["let ignore;(ignore)=>0", "name_declare", "redefinition_a_b", "1", 13]
+// ["let ignore;(ignore)=>0", "name_declare", "ignore", "ignore", 0]
 
+                test_cause("ignore", id);
                 warn("redefinition_a_b", name, id, earlier.line);
             }
             return;
@@ -5167,9 +5163,10 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // function aa(){try{aa();}catch(aa){aa();}}
-// ", "name_declare", "redefinition_a_b", "1", 31]
-// ["function aa(){var aa}", "name_declare", "redefinition_a_b", "1", 19]
+// ", "name_declare", "scope_outer", "aa", 0]
+// ["function aa(){var aa}", "name_declare", "scope_outer", "aa", 0]
 
+            test_cause("scope_outer", id);
             warn("redefinition_a_b", name, id, earlier.line);
             return;
         }
@@ -5511,6 +5508,10 @@ function jslint_phase3_parse(state) {
 
                 the_label.alive = true;
                 the_statement = parse_statement();
+
+// 5.lab.4 - Mark 'out-of-scope', the label-statement, after control-flow-block.
+
+                the_label.alive = false;
                 functionage.statement_prv = the_statement;
                 the_statement.label = the_label;
                 the_statement.statement = true;
@@ -5968,8 +5969,13 @@ function jslint_phase3_parse(state) {
 
     function prefix_function(the_function, mode_fart, mode_fart_unwrapped) {
         const name = !mode_fart && token_nxt.identifier && token_nxt;
+
+// PR-xxx - Change scope from function-scope to block-scope:
+// - function-declaration
+
+        let declared_scope = blockage;
+        let role = "variable";
         the_function = the_function || token_now;
-        the_function.alive_list = [];
         if (mode_fart) {
             the_function.arity = "binary";
         }
@@ -5985,6 +5991,16 @@ function jslint_phase3_parse(state) {
                 return stop("expected_identifier_a", token_nxt);
             }
             name.calls = empty();
+        } else if (name) {
+
+// A function expression may have an optional name.
+
+// PR-xxx - Restrict scope from function-scope to its own function-body:
+// - named-function-expression
+
+            declared_scope = the_function;
+            name.used = true;
+            the_function.context = empty();
         }
         if (name) {
             advance();
@@ -5992,17 +6008,8 @@ function jslint_phase3_parse(state) {
 
 // 2.fun.1 - Mark 'declared', the function-name, during function-declaration.
 
-                functionage,            // declared_scope
-                //!! (                       // declared_scope
-                    //!! the_function.arity === "statement"
-                    //!! ? functionage
-                    //!! : the_function
-                //!! ),
-                (                       // role
-                    the_function.arity === "statement"
-                    ? "variable"
-                    : "function"
-                ),
+                declared_scope,         // declared_scope
+                role,                   // role
                 false,                  // readonly
                 [],                     // name_list
                 name,                   // name
@@ -6015,13 +6022,6 @@ function jslint_phase3_parse(state) {
 // 2.fun.2 - Mark 'alive', the function-name, during function-declaration.
 
             name.alive = true;
-            if (the_function.arity !== "statement") {
-
-// 2.fun.4 - Mark 'out-of-scope', the function-name, after function-body.
-
-                the_function.alive_list.push(name);
-                name.used = true;
-            }
         }
 
 // Give the function properties for storing its names and for observing the
@@ -7362,6 +7362,9 @@ function jslint_phase3_parse(state) {
 
 // 3.cat.1 - Mark 'declared', the catch-variable, before catch-block.
 
+// PR-xxx - Change scope from special-catch-scope to block-scope:
+// - catch-variable
+
                         blockage,       // declared_scope
                         "exception",    // role
                         true,           // readonly
@@ -7412,9 +7415,18 @@ function jslint_phase3_parse(state) {
     }
 
     function stmt_var() {
+        const declared_scope = (
+            token_now.id === "var"
+            ? functionage
+
+// PR-xxx - Change scope from function-scope to block-scope:
+// - const-declaration
+// - let-declaration
+
+            : blockage
+        );
         const readonly = token_now.id === "const";
         const the_variable = token_now;
-        let declared_scope = functionage;
         let name;
         let variable_prv;
         the_variable.name_list = [];    // 5. name_list for "let [aa] = ..."
@@ -7457,11 +7469,6 @@ function jslint_phase3_parse(state) {
 
             test_cause("var_prv", functionage.statement_prv.id);
             variable_prv = functionage.statement_prv;
-            //!! declared_scope = (
-                //!! variable_prv === "var"
-                //!! ? functionage
-                //!! : blockage
-            //!! );
             break;
         case "import":
 
@@ -7531,7 +7538,7 @@ function jslint_phase3_parse(state) {
 
 // 3.var.1 - Mark 'declared', the variable, during variable-declaration.
 
-                    functionage,        // declared_scope
+                    declared_scope,     // declared_scope
                     "variable",         // role
                     readonly,           // readonly
                     the_variable.name_list,     // name_list
@@ -8054,64 +8061,67 @@ function jslint_phase4_walk(state) {
             return;
         }
 
-// Look up the variable in the current context.
+// Look up the variable, from current-scope, moving up the scope-chain.
 
-        the_variable = blockage.context[id];
+        block_stack.some(function (blockage, ii) {
+            the_variable = blockage.context[id];
+            if (the_variable && ii > 0) {
 
-// If it isn't local, search all the other contexts. If there are name
-// collisions, take the most recent.
+// If found outside current-scope, mark as closure.
 
-        if (!the_variable) {
-            block_stack.some(function (blockage) {
-                the_variable = blockage.context[id];
-                return the_variable;
-            });
-            if (!the_variable && !global_dict[id]) {
+                the_variable.closure = true;
+            }
+            return the_variable;
+        });
+        if (!the_variable && !global_dict[id]) {
 
 // test_cause:
+// ["(function aa(){})aa", "name_lookup", "undeclared_a", "aa", 18]
 // ["aa", "name_lookup", "undeclared_a", "aa", 1]
 // ["class aa{}", "name_lookup", "undeclared_a", "aa", 7]
+// ["function aa(){function bb(){}}bb", "name_lookup", "undeclared_a", "bb", 31]
+// ["function aa(){var bb}bb", "name_lookup", "undeclared_a", "bb", 22]
+// ["if(0){const aa=0}aa", "name_lookup", "undeclared_a", "aa", 18]
+// ["if(0){function aa(){}}aa", "name_lookup", "undeclared_a", "aa", 23]
+// ["if(0){let aa}aa", "name_lookup", "undeclared_a", "aa", 14]
 // ["try{}catch(aa){}aa", "name_lookup", "undeclared_a", "aa", 17]
 
-                warn("undeclared_a", thing);
-                return;
-            }
+//!! // ["aa:while(0){}aa", "name_lookup", "undeclared_a", "aa", 14]
+
+            warn("undeclared_a", thing);
+            return;
+        }
 
 // If it isn't in any of those either, perhaps it is a predefined global.
 // If so, add it to the global context.
 
-            if (!the_variable) {
-                the_variable = {
+        if (!the_variable) {
+            the_variable = {
 
 // 3.glo.2 - Mark 'alive', the global-variable, immediately.
 
-                    alive: true,
-                    declared_scope: token_global,
-                    id,
+                alive: true,
+                declared_scope: token_global,
+                id,
 
 // 3.glo.3 - Mark 'init', the global-variable, immediately.
 
-                    init: true,
-                    readonly: true,
-                    role: "variable"
-                };
-                token_global.context[id] = the_variable;
-            }
-            the_variable.closure = true;
+                init: true,
+                readonly: true,
+                role: "variable"
+            };
 
 // 3.glo.1 - Mark 'declared', the global-variable, immediately.
 
             token_global.context[id] = the_variable;
         }
-        if (the_variable?.role === "label") {
+        if (the_variable.role === "label") {
 
 // test_cause:
 // ["aa:while(0){aa}", "name_lookup", "label_a", "aa", 13]
 
             warn("label_a", thing);
-            return the_variable;
-        }
-        if (
+        } else if (
             (
                 !the_variable.calls
                 || !functionage.name
@@ -8124,8 +8134,6 @@ function jslint_phase4_walk(state) {
 
 // test_cause:
 // ["(aa=aa)=>0", "name_lookup", "out_of_scope_a", "aa", 5]
-// ["(function aa(){})aa", "name_lookup", "out_of_scope_a", "aa", 18]
-// ["if(0){let aa}aa", "name_lookup", "out_of_scope_a", "aa", 14]
 // ["let [aa]=aa", "name_lookup", "out_of_scope_a", "aa", 10]
 // ["let aa=()=>aa", "name_lookup", "out_of_scope_a", "aa", 12]
 // ["let aa=aa", "name_lookup", "out_of_scope_a", "aa", 8]
@@ -8565,10 +8573,6 @@ function jslint_phase4_walk(state) {
     }
 
     function post_s_lbrace_pop_block() {
-        blockage?.alive_list?.forEach(function (name) {
-            name.alive = false;
-        });
-        delete blockage.alive_list;
         blockage = block_stack_pop(block_stack);
     }
 
@@ -8577,7 +8581,7 @@ function jslint_phase4_walk(state) {
 
 // Recurse walk_statement().
 
-            walk_statement(thing?.catch?.block);
+            walk_statement(thing.catch.block);
 
 // Restore previous catch-scope after catch-block.
 
@@ -8608,15 +8612,6 @@ function jslint_phase4_walk(state) {
 // 3.var.2 - Mark 'alive', the variable, after variable-declaration.
 
             name.alive = true;
-            switch (thing.id) {
-            case "const":
-            case "let":
-
-// 3.var.4 - Mark 'out-of-scope', the variable, after block-scope.
-
-                blockage.alive_list.push(name);
-                break;
-            }
         });
     }
 
@@ -8861,100 +8856,6 @@ function jslint_phase4_walk(state) {
         warn("unexpected_a", thing);
     }
 
-// PR-502 - Probably deadcode.
-
-//     function pre_b_lparen(thing) {
-//
-// // This function runs right before the parser handles a "(" symbol
-// // (like in "myFunction()"). It is a safety valve to prevent
-// // incorrect "use before definition" warnings.
-// //
-// // Example code triggering this preaction:
-// // my_function();
-//
-// // Step 1: Find out what is being called.
-// // If the code is "foo()", "left" gets the "foo" part.
-// //
-// // Code representation:
-// // left === token_foo;
-//
-//         const left = thing.expression[0];
-//         let left_variable;
-//         let parent;
-//
-// // Step 2: Make sure we are calling a named thing (an identifier),
-// // and check that this thing is NOT defined locally inside the
-// // active function. We also make sure the active function
-// // actually has a name.
-// //
-// // Code structure matched here:
-// // function active_function() {
-// //     foo(); // "foo" is not defined inside active_function
-// // }
-//
-//         if (
-//             left.identifier
-//             && functionage.context[left.id] === undefined
-//             && typeof functionage.name === "object"
-//         ) {
-//
-// // Step 3: Find the outer function (the parent) that
-// // wraps our current function.
-// //
-// // Code structure matched here:
-// // function outer_parent() {
-// //     function active_function() { ... }
-// // }
-//
-//             parent = functionage.name.declared_scope;
-//             if (parent) {
-//
-// // Step 4: Look up the variable we are calling ("foo")
-// // inside that parent function.
-// //
-// // Code structure matched here:
-// // function outer_parent() {
-// //     function foo() {} // Defined in the parent scope
-// //     function active_function() { foo(); }
-// // }
-//
-//                 left_variable = parent.context[left.id];
-//
-// // Step 5: Check if we need to temporarily "bring it
-// // back to life".
-// // We verify it was found in the parent scope, is currently marked
-// // as "dead", belongs to this parent, and has a registered call from
-// // our active function. If so, we revive it!
-// //
-// // Code structure matched here (Mutual Recursion):
-// // function outer_parent() {
-// //     function active_function() {
-// //         foo(); // "foo" is forward-referenced & currently dead
-// //     }
-// //     function foo() {
-// //         active_function();
-// //     }
-// // }
-//
-//                 if (
-//                     left_variable !== undefined
-// // Probably deadcode.
-// // && !left_variable.alive
-//                     && left_variable.declared_scope === parent
-//                     && left_variable.calls !== undefined
-//                     && left_variable.calls[functionage.name.id] !== undefined
-//                 ) {
-//
-// // If all those match, revive it! Mark "dead" as
-// // false so JSLint won't raise an error for
-// // calling it before its line is executed.
-//
-//                     left_variable.alive = true;
-//                 }
-//             }
-//         }
-//     }
-
     function pre_b_noteq(thing) {
 
 // test_cause:
@@ -8981,7 +8882,6 @@ function jslint_phase4_walk(state) {
 
 // 3.for.1 - Mark 'declared', the for-variable, ???.
 // 3.for.2 - Mark 'alive', the for-variable, before for-block.
-// 3.for.4 - Mark 'out-of-scope', the for-variable, ???.
 
             thing.name.alive = true;
             the_variable = name_lookup(thing.name);
@@ -9072,7 +8972,6 @@ function jslint_phase4_walk(state) {
 
     function pre_s_lbrace(thing) {
         blockage = block_stack_push(block_stack, thing, undefined);
-        thing.alive_list = [];
     }
 
     function pre_s_try(thing) {
@@ -9225,11 +9124,6 @@ function jslint_phase4_walk(state) {
     postaction("unary", post_u);
     preaction("assignment", pre_a_bitwise);
     preaction("binary", "!=", pre_b_noteq);
-
-// PR-502 - Probably deadcode.
-
-//     preaction("binary", "(", pre_b_lparen);
-
     preaction("binary", "==", pre_b_eqeq);
     preaction("binary", "=>", pre_s_function);
     preaction("binary", "in", pre_b_in);
@@ -10474,10 +10368,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
         }).sort());
         list.sort();
         html += detail("variable", list.filter(function (id) {
-            return (
-                context[id].role === "variable"
-                && context[id].declared_scope === the_function
-            );
+            return context[id].role === "variable";
         }));
         html += detail("exception", list.filter(function (id) {
             return context[id].role === "exception";

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -1565,6 +1565,9 @@ function jslint(
         case "nested_comment":
             mm = `Nested comment.`;
             break;
+        case "not_label_a":
+            mm = `'${a}' is not a label.`;
+            break;
         case "number_isNaN":
             mm = `Use Number.isNaN function to compare with NaN.`;
             break;
@@ -1612,9 +1615,6 @@ function jslint(
             break;
         case "undeclared_a":
             mm = `Undeclared '${a}'.`;
-            break;
-        case "undeclared_label_a":
-            mm = `Undeclared label '${a}'.`;
             break;
         case "unexpected_a":
             mm = `Unexpected '${a}'.`;
@@ -5192,7 +5192,6 @@ function jslint_phase3_parse(state) {
         if (earlier) {
 
 // test_cause:
-// ["aa:let aa", "name_declare", "scope_current", "aa", 0]
 // ["let aa;(function aa(){})", "name_declare", "scope_current", "aa", 0]
 // ["let aa;function aa(){}", "name_declare", "scope_current", "aa", 0]
 // ["let aa;let aa", "name_declare", "scope_current", "aa", 0]
@@ -5211,7 +5210,7 @@ function jslint_phase3_parse(state) {
                 if (earlier.role !== "label") {
 
 // test_cause:
-// ["let aa;aa:0", "name_declare", "label_vs_not_label", "aa", 0]
+// ["let aa;aa:while(0){}", "name_declare", "label_vs_not_label", "aa", 0]
 
                     test_cause("label_vs_not_label", id);
                     warn("redefinition_a_b", name, id, earlier.line);
@@ -5224,7 +5223,7 @@ function jslint_phase3_parse(state) {
                 if (earlier.role === "label") {
 
 // test_cause:
-// ["aa:{let aa}", "name_declare", "default_vs_label", "aa", 0]
+// ["aa:while(0){let aa}", "name_declare", "default_vs_label", "aa", 0]
 
                     test_cause("default_vs_label", id);
                     warn("redefinition_a_b", name, id, earlier.line);
@@ -5618,11 +5617,10 @@ function jslint_phase3_parse(state) {
         }
         advance();
         if (token_now.identifier && token_nxt.id === ":") {
-            //!! the_statement = stmt_label();
-            //!! if (the_statement) {
-                //!! return the_statement;
-            //!! }
-            return stmt_label();
+            the_statement = stmt_label();
+            if (the_statement) {
+                return the_statement;
+            }
         }
 
 // Parse the statement.
@@ -6644,10 +6642,10 @@ function jslint_phase3_parse(state) {
             if (!the_label) {
 
 // test_cause:
-// ["aa:while(0){}break aa", "stmt_break", "undeclared_label_a", "aa", 20]
-// ["break aa", "stmt_break", "undeclared_label_a", "aa", 7]
+// ["aa:while(0){}break aa", "stmt_break", "not_label_a", "aa", 20]
+// ["break aa", "stmt_break", "not_label_a", "aa", 7]
 
-                warn("undeclared_label_a", token_nxt);
+                warn("not_label_a", token_nxt);
             }
             the_break.label_break = token_nxt;
             advance();
@@ -7234,11 +7232,6 @@ function jslint_phase3_parse(state) {
     function stmt_label() {
         const the_label = token_now;
         let the_statement;
-
-// PR-xxx - Add hidden scope_block for:
-// - label-name
-
-        scope_block = scope_block_push(the_label, true);
         if (the_label.id === "ignore") {
 
 // test_cause:
@@ -7272,9 +7265,14 @@ function jslint_phase3_parse(state) {
 // ["aa:bb:0", "stmt_label", "unexpected_label_a", "aa", 1]
 
             warn("unexpected_label_a", the_label);
-            //!! advance();
-            //!! return;
+            advance();
+            return;
         }
+
+// PR-xxx - Add hidden scope_block for:
+// - label-name
+
+        scope_block = scope_block_push(the_label, true);
         name_declare(
 
 // 5.lab.1 - Mark 'declared', the label-name, before control-flow-block.
@@ -7635,7 +7633,47 @@ function jslint_phase3_parse(state) {
         );
         const the_variable = token_now;
         let name;
+        let the_operator;
         let variable_prv;
+        function advance_operator() {
+            switch (the_operator.id) {
+            case "=":
+                the_variable.operator = the_operator;
+                advance("=");
+                break;
+            case "in":
+            case "of":
+                if (for_init) {
+
+// test_cause:
+// ["for(let aa in 0){}", "advance_operator", "for_init", "in", 0]
+// ["for(let aa of 0){}", "advance_operator", "for_init", "of", 0]
+// ["for(let {aa} in 0){}", "advance_operator", "for_init", "in", 0]
+// ["for(let {aa} of 0){}", "advance_operator", "for_init", "of", 0]
+
+                    test_cause("for_init", the_operator.id);
+                    the_variable.operator = the_operator;
+                    advance();
+                    break;
+                }
+
+// test_cause:
+// ["let aa in 0", "advance_operator", "not_for_init", "in", 0]
+// ["let aa of 0", "advance_operator", "not_for_init", "of", 0]
+// ["let {aa} in 0", "advance_operator", "not_for_init", "in", 0]
+// ["let {aa} of 0", "advance_operator", "not_for_init", "of", 0]
+
+                test_cause("not_for_init", the_operator.id);
+                the_variable.operator = the_operator;
+                advance("=");
+                break;
+            default:
+                if (readonly) {
+                    the_variable.operator = the_operator;
+                    advance("=");
+                }
+            }
+        }
         the_variable.name_list = [];    // 5. name_list for "let [aa] = ..."
 
 // A program may use var or let, but not both.
@@ -7723,7 +7761,8 @@ function jslint_phase3_parse(state) {
                     undefined,          // the_function
                     false               // the_function_toplevel
                 );
-                advance("=");
+                the_operator = token_nxt;
+                advance_operator();
                 the_variable.expression = parse_expression(0);
             } else if (token_nxt.identifier) {
                 name = token_nxt;
@@ -7737,41 +7776,14 @@ function jslint_phase3_parse(state) {
 
                     warn("unexpected_a", name);
                 }
-                switch (token_nxt.id) {
+                the_operator = token_nxt;
+                advance_operator();
+                switch (the_operator.id) {
                 case "=":
-                    the_variable.operator = token_nxt;
-                    advance("=");
-                    name.expression = parse_expression(0);
-                    break;
                 case "in":
                 case "of":
-                    if (for_init) {
-
-// test_cause:
-// ["for(let aa in 0){}", "stmt_var", "for_init", "in", 0]
-// ["for(let aa of 0){}", "stmt_var", "for_init", "of", 0]
-
-                        test_cause("for_init", token_nxt.id);
-                        the_variable.operator = token_nxt;
-                        advance();
-                        name.expression = parse_expression(0);
-                        break;
-                    }
-
-// test_cause:
-// ["let aa in 0", "stmt_var", "not_for_init", "in", 0]
-// ["let aa of 0", "stmt_var", "not_for_init", "of", 0]
-
-                    test_cause("not_for_init", token_nxt.id);
-                    the_variable.operator = token_nxt;
-                    advance("=");
+                    name.expression = parse_expression(0);
                     break;
-                default:
-                    if (readonly) {
-                        the_variable.operator = token_nxt;
-                        advance("=");
-                        name.expression = parse_expression(0);
-                    }
                 }
                 name_declare(
 
@@ -8316,7 +8328,7 @@ function jslint_phase4_walk(state) {
             }
             return the_variable;
         });
-        if (!the_variable && !global_dict[id]) {
+        if (!the_variable && global_dict[id] === undefined) {
 
 // test_cause:
 // ["(function aa(){})aa", "name_lookup", "undeclared_a", "aa", 18]
@@ -8815,7 +8827,7 @@ function jslint_phase4_walk(state) {
     }
 
     function post_s_try(thing) {
-        if (thing.catch) {
+        if (thing.catch !== undefined) {
 
 // PR-xxx - Add hidden scope_block for:
 // - catch-variable

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -8628,7 +8628,7 @@ function jslint_phase4_walk(state) {
         });
     }
 
-    function post_ternary(thing) {
+    function post_t_ternary(thing) {
         if (
             is_weird(thing.expression[0])
             || thing.expression[0].constant === true
@@ -8636,20 +8636,20 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["let aa=(aa?`${0}`:`${0}`)", "post_ternary", "unexpected_a", "?", 11]
-// ["let aa=(aa?`0`:`0`)", "post_ternary", "unexpected_a", "?", 11]
+// ["let aa=(aa?`${0}`:`${0}`)", "post_t_ternary", "unexpected_a", "?", 11]
+// ["let aa=(aa?`0`:`0`)", "post_t_ternary", "unexpected_a", "?", 11]
 
             warn("unexpected_a", thing);
         } else if (is_equal(thing.expression[0], thing.expression[1])) {
 
 // test_cause:
-// ["aa?aa:0", "post_ternary", "expected_a_b", "?", 3]
+// ["aa?aa:0", "post_t_ternary", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "||", "?");
         } else if (is_equal(thing.expression[0], thing.expression[2])) {
 
 // test_cause:
-// ["aa?0:aa", "post_ternary", "expected_a_b", "?", 3]
+// ["aa?0:aa", "post_t_ternary", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "&&", "?");
         } else if (
@@ -8658,7 +8658,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa?true:false", "post_ternary", "expected_a_b", "?", 3]
+// ["aa?true:false", "post_t_ternary", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "Boolean(...)", "?");
         } else if (
@@ -8667,7 +8667,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa?false:true", "post_ternary", "expected_a_b", "?", 3]
+// ["aa?false:true", "post_t_ternary", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "!", "?");
         } else if (
@@ -8679,40 +8679,9 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["(aa&&!aa?0:1)", "post_ternary", "wrap_condition", "&&", 4]
+// ["(aa&&!aa?0:1)", "post_t_ternary", "wrap_condition", "&&", 4]
 
             warn("wrap_condition", thing.expression[0]);
-        }
-    }
-
-    function post_u(thing) {
-        if (thing.id === "`") {
-            if (thing.expression.every(function (thing) {
-                return thing.constant;
-            })) {
-                thing.constant = true;
-            }
-        } else if (thing.id === "!") {
-            if (thing.expression.constant === true) {
-                warn("unexpected_a", thing);
-            }
-        } else if (thing.id === "!!") {
-            if (!option_dict.convert) {
-
-// test_cause:
-// ["!!0", "post_u", "expected_a_b", "!!", 1]
-
-                warn("expected_a_b", thing, "Boolean(...)", "!!");
-            }
-        } else if (
-            thing.id !== "["
-            && thing.id !== "{"
-            && thing.id !== "function"
-            && thing.id !== "new"
-        ) {
-            if (thing.expression.constant === true) {
-                thing.constant = true;
-            }
         }
     }
 
@@ -8733,6 +8702,37 @@ function jslint_phase4_walk(state) {
             || (right.id === "[" && right.arity !== "binary")
         ) {
             warn("unexpected_a", thing, "+");
+        }
+    }
+
+    function post_u_unary(thing) {
+        if (thing.id === "`") {
+            if (thing.expression.every(function (thing) {
+                return thing.constant;
+            })) {
+                thing.constant = true;
+            }
+        } else if (thing.id === "!") {
+            if (thing.expression.constant === true) {
+                warn("unexpected_a", thing);
+            }
+        } else if (thing.id === "!!") {
+            if (!option_dict.convert) {
+
+// test_cause:
+// ["!!0", "post_u_unary", "expected_a_b", "!!", 1]
+
+                warn("expected_a_b", thing, "Boolean(...)", "!!");
+            }
+        } else if (
+            thing.id !== "["
+            && thing.id !== "{"
+            && thing.id !== "function"
+            && thing.id !== "new"
+        ) {
+            if (thing.expression.constant === true) {
+                thing.constant = true;
+            }
         }
     }
 
@@ -9131,8 +9131,8 @@ function jslint_phase4_walk(state) {
     postaction("statement", "try", post_s_try);
     postaction("statement", "var", post_s_var);
     postaction("statement", "{", post_s_lbrace_pop_block);
-    postaction("ternary", "(all)", post_ternary);
-    postaction("unary", "(all)", post_u);
+    postaction("ternary", "(all)", post_t_ternary);
+    postaction("unary", "(all)", post_u_unary);
     postaction("unary", "+", post_u_plus);
     postaction("unary", "function", post_s_function);
     preaction("assignment", "(all)", pre_a_bitwise);

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -112,8 +112,6 @@
     block,
     block_list,
     block_stack,
-    block_stack_pop,
-    block_stack_push,
     body,
     browser,
     c,
@@ -140,7 +138,6 @@
     cwd,
     d,
     debugInline,
-    declared_scope,
     default,
     delta,
     devel,
@@ -329,6 +326,9 @@
     reverse,
     role,
     round,
+    scope_declared,
+    scope_stack_pop,
+    scope_stack_push,
     scriptId,
     search,
     set,
@@ -1143,28 +1143,6 @@ function jslint(
         );
     }
 
-    function block_stack_pop(stack) {
-        jslint_assert(stack.length > 1, `block_stack.length=${stack.length}`);
-        stack.shift();
-        return stack[0];
-    }
-
-    function block_stack_push(stack, stack_pushed, list_pushed) {
-        stack.unshift(stack_pushed);
-        if (stack === block_stack && !stack_pushed.context) {
-            stack_pushed.context = empty();
-        }
-        switch (list_pushed && stack) {
-        case block_stack:
-            block_list.push(list_pushed);
-            break;
-        case function_stack:
-            function_list.push(list_pushed);
-            break;
-        }
-        return stack_pushed;
-    }
-
     function is_equal(aa, bb) {
 
 // test_cause:
@@ -1307,6 +1285,28 @@ function jslint(
         default:
             return false;
         }
+    }
+
+    function scope_stack_pop(stack) {
+        jslint_assert(stack.length > 1, `block_stack.length=${stack.length}`);
+        stack.shift();
+        return stack[0];
+    }
+
+    function scope_stack_push(stack, stack_pushed, list_pushed) {
+        stack.unshift(stack_pushed);
+        if (stack === block_stack && !stack_pushed.context) {
+            stack_pushed.context = empty();
+        }
+        switch (list_pushed && stack) {
+        case block_stack:
+            block_list.push(list_pushed);
+            break;
+        case function_stack:
+            function_list.push(list_pushed);
+            break;
+        }
+        return stack_pushed;
     }
 
     function stop(code, the_token, a, b, c, d) {
@@ -1768,8 +1768,6 @@ function jslint(
                 artifact,
                 block_list,
                 block_stack,
-                block_stack_pop,
-                block_stack_push,
                 directive_list,
                 export_dict,
                 function_list,
@@ -1787,6 +1785,8 @@ function jslint(
                 mode_shebang: false,    // true if #! is seen on the first line.
                 option_dict,
                 property_dict,
+                scope_stack_pop,
+                scope_stack_push,
                 source,
                 stop,
                 stop_at,
@@ -3884,7 +3884,7 @@ function jslint_phase2_lex(state) {
         case "unordered":       // Allow unordered cases, params, properties,
                                 // ... variables, and exports.
         case "variable":        // Allow unordered const and let declarations
-                                // ... that are not at top of function-scope.
+                                // ... that are not at top of scope_function.
         case "white":           // Allow messy whitespace.
             option_dict[key] = val;
             break;
@@ -4254,8 +4254,6 @@ function jslint_phase3_parse(state) {
     const {
         artifact,
         block_stack,
-        block_stack_pop,
-        block_stack_push,
         export_dict,
         function_list,
         function_stack,
@@ -4264,6 +4262,8 @@ function jslint_phase3_parse(state) {
         is_equal,
         option_dict,
         property_dict,
+        scope_stack_pop,
+        scope_stack_push,
         stop,
         syntax_dict,
         tenure,
@@ -4274,9 +4274,9 @@ function jslint_phase3_parse(state) {
         warn_at
     } = state;
     let anon = "anonymous";     // The guessed name for anonymous functions.
-    let blockage = token_global;        // The current block.
-    let functionage = token_global;     // The current function.
     let mode_var;               // "var" if using var; "let" if using let.
+    let scope_block;            // The current block-scope.
+    let scope_function;         // The current function-scope.
     let token_ii = 0;           // The index of the next token in <token_list>.
     let token_now = token_global;       // The current token being examined in
                                         // ... the parse.
@@ -4369,7 +4369,7 @@ function jslint_phase3_parse(state) {
                 the_token.expression = right;
                 the_token.name_list = [];       // 1. name_list for "aa = ..."
                 name_declare(
-                    undefined,          // declared_scope
+                    undefined,          // scope_declared
                     "variable",         // role
                     false,              // readonly
                     the_token.name_list,        // name_list
@@ -4406,9 +4406,9 @@ function jslint_phase3_parse(state) {
             advance("{");
         }
         the_block = token_now;
-        blockage = block_stack_push(block_stack, token_now, token_now);
+        scope_block = scope_stack_push(block_stack, token_now, token_now);
         if (special !== "body") {
-            functionage.statement_prv = the_block;
+            scope_function.statement_prv = the_block;
         }
         the_block.arity = "statement";
         the_block.body = special === "body";
@@ -4438,7 +4438,7 @@ function jslint_phase3_parse(state) {
         } else {
             the_block.disrupt = parsed_block[parsed_block.length - 1].disrupt;
         }
-        blockage = block_stack_pop(block_stack);
+        scope_block = scope_stack_pop(block_stack);
         advance("}");
         return the_block;
     }
@@ -4503,7 +4503,7 @@ function jslint_phase3_parse(state) {
 
 // Some features should not be at the outermost level.
 
-        if (functionage === token_global) {
+        if (scope_function === token_global) {
 
 // test_cause:
 // ["
@@ -4964,8 +4964,8 @@ function jslint_phase3_parse(state) {
 
             check_left(left, the_paren);
         }
-        if (functionage.arity === "statement" && left.identifier) {
-            functionage.name.calls[left.id] = left;
+        if (scope_function.arity === "statement" && left.identifier) {
+            scope_function.name.calls[left.id] = left;
         }
         the_paren.expression = [left];
         if (token_nxt.id !== ")") {
@@ -5048,7 +5048,7 @@ function jslint_phase3_parse(state) {
 // PR-502 - Unify name_list.push() logic with helper-function name_declare().
 
     function name_declare(
-        declared_scope,
+        scope_declared,
         role,
         readonly,
         name_list,
@@ -5060,7 +5060,7 @@ function jslint_phase3_parse(state) {
 // 1. Push variable or function-parameter <name> to <name_list>.
 // 2. Set <name>.init = true, if its an assigned-variable,
 //    a function-parameter, or existing variable assigned new value.
-// 3. Declare <name> in <declared_scope>.context, if its a declared-variable,
+// 3. Declare <name> in <scope_declared>.context, if its a declared-variable,
 //    or function-parameter.
 //
 // Most calls to name_declare() are commented regarding thing being declared,
@@ -5110,11 +5110,11 @@ function jslint_phase3_parse(state) {
         if (role === "variable") {
             name.arity = "variable";
         }
-        if (!declared_scope) {
+        if (!scope_declared) {
             return;
         }
 
-// Declare a name into the current declared_scope's context. The role can be
+// Declare a name into the current scope_declared's context. The role can be
 // exception, function, label, parameter, or variable. We look for variable
 // redefinition because it causes confusion.
 
@@ -5128,8 +5128,8 @@ function jslint_phase3_parse(state) {
             warn("reserved_a", name);
             return;
         }
-        block_stack.some(function (blockage, ii) {
-            earlier = blockage.context[id];
+        block_stack.some(function (scope_block, ii) {
+            earlier = scope_block.context[id];
             if (earlier && ii === 0) {
 
 // Has the name been declared in this context?
@@ -5147,8 +5147,8 @@ function jslint_phase3_parse(state) {
 
 // Declare it.
 
-        declared_scope.context[id] = name;
-        name.declared_scope = declared_scope;
+        scope_declared.context[id] = name;
+        name.scope_declared = scope_declared;
 
 // Warn about variable redefinition.
 
@@ -5544,7 +5544,7 @@ function jslint_phase3_parse(state) {
 
 // 5.lab.1 - Mark 'declared', the label-statement, before control-flow-block.
 
-                    functionage,        // declared_scope
+                    scope_function,     // scope_declared
                     "label",            // role
                     true,               // readonly
                     [],                 // name_list
@@ -5565,7 +5565,7 @@ function jslint_phase3_parse(state) {
                 the_label.alive = false;
                 the_statement.label = the_label;
                 the_statement.statement = true;
-                functionage.statement_prv = the_statement;
+                scope_function.statement_prv = the_statement;
                 return the_statement;
             default:
 
@@ -5613,7 +5613,7 @@ function jslint_phase3_parse(state) {
             }
             semicolon();
         }
-        functionage.statement_prv = the_statement;
+        scope_function.statement_prv = the_statement;
         return the_statement;
     }
 
@@ -5718,7 +5718,7 @@ function jslint_phase3_parse(state) {
 
 // PR-370 - Add top-level-await support.
 
-        if (functionage.async === 0 && functionage !== token_global) {
+        if (scope_function.async === 0 && scope_function !== token_global) {
 
 // test_cause:
 // ["function aa(){aa=await 0}", "prefix_await", "unexpected_a", "await", 18]
@@ -5726,8 +5726,8 @@ function jslint_phase3_parse(state) {
 
             warn("unexpected_a", the_await);
         }
-        if (functionage.async === 1) {
-            functionage.async = 2;
+        if (scope_function.async === 1) {
+            scope_function.async = 2;
         }
         the_await.expression = parse_expression(150);
         if (the_await.arity === "statement") {
@@ -5740,7 +5740,7 @@ function jslint_phase3_parse(state) {
     }
 
     function prefix_destructure(
-        declared_scope,
+        scope_declared,
         role,
         readonly,
         name_list,
@@ -5818,7 +5818,7 @@ function jslint_phase3_parse(state) {
                 test_cause("recurse_element");
                 advance_and_signature_push(token_nxt.id);
                 prefix_destructure(
-                    declared_scope,     // declared_scope
+                    scope_declared,     // scope_declared
                     role,               // role
                     readonly,           // readonly
                     name_list,          // name_list
@@ -5870,7 +5870,7 @@ function jslint_phase3_parse(state) {
                 token_nxt.label = name;
                 name = token_nxt;
                 name_declare(
-                    declared_scope,     // declared_scope
+                    scope_declared,     // scope_declared
                     role,               // role
                     readonly,           // readonly
                     sub_list,           // name_list
@@ -5881,7 +5881,7 @@ function jslint_phase3_parse(state) {
                 return;
             }
             name_declare(
-                declared_scope,         // declared_scope
+                scope_declared,         // scope_declared
                 role,                   // role
                 readonly,               // readonly
                 sub_list,               // name_list
@@ -5983,12 +5983,12 @@ function jslint_phase3_parse(state) {
 
     function prefix_function(the_function, mode_fart, mode_fart_unwrapped) {
         const name = !mode_fart && token_nxt.identifier && token_nxt;
+        let role = "variable";
 
-// PR-xxx - Change scope from function-scope to block-scope:
+// PR-xxx - Change scope from scope_function to scope_block:
 // - function-declaration
 
-        let declared_scope = blockage;
-        let role = "variable";
+        let scope_declared = scope_block;
         the_function = the_function || token_now;
         if (mode_fart) {
             the_function.arity = "binary";
@@ -6009,10 +6009,10 @@ function jslint_phase3_parse(state) {
 
 // A function expression may have an optional name.
 
-// PR-xxx - Restrict scope from function-scope to its own function-body:
+// PR-xxx - Restrict scope from scope_function to its own function-body:
 // - named-function-expression
 
-            declared_scope = the_function;
+            scope_declared = the_function;
             name.used = true;
             the_function.context = empty();
         }
@@ -6022,7 +6022,7 @@ function jslint_phase3_parse(state) {
 
 // 2.fun.1 - Mark 'declared', the function-name, during function-declaration.
 
-                declared_scope,         // declared_scope
+                scope_declared,         // scope_declared
                 role,                   // role
                 false,                  // readonly
                 [],                     // name_list
@@ -6043,7 +6043,7 @@ function jslint_phase3_parse(state) {
 
         the_function.async = the_function.async || 0;
         the_function.finally = 0;
-        the_function.level = functionage.level + 1;
+        the_function.level = scope_function.level + 1;
         the_function.loop = 0;
         the_function.name = (
             name
@@ -6064,7 +6064,7 @@ function jslint_phase3_parse(state) {
 
 // PR-384 - Relax warning "function_in_loop".
 //
-//         if (functionage.loop > 0) {
+//         if (scope_function.loop > 0) {
 
 // // test_cause:
 // // ["while(0){aa.map(()=>0);}", "parse_fart", "function_in_loop", "=>", 19]
@@ -6074,8 +6074,8 @@ function jslint_phase3_parse(state) {
 
 // Push the current function context and establish a new one.
 
-        blockage = block_stack_push(block_stack, the_function, the_function);
-        functionage = block_stack_push(
+        scope_block = scope_stack_push(block_stack, the_function, the_function);
+        scope_function = scope_stack_push(
             function_stack,
             the_function,
             the_function
@@ -6098,7 +6098,7 @@ function jslint_phase3_parse(state) {
 
 // 4.par.1 - Mark 'declared', the function-parameter, if unwrapped.
 
-                functionage,            // declared_scope
+                scope_function,         // scope_declared
                 "parameter",            // role
                 false,                  // readonly
                 the_function.name_list, // name_list
@@ -6118,7 +6118,7 @@ function jslint_phase3_parse(state) {
 
 // 4.par.1 - Mark 'declared', the function-parameter, during destructuring.
 
-                    functionage,        // declared_scope
+                    scope_function,     // scope_declared
                     "parameter",        // role
                     false,              // readonly
                     the_function.name_list,     // name_list
@@ -6221,8 +6221,8 @@ function jslint_phase3_parse(state) {
 
 // Restore the previous context.
 
-        blockage = block_stack_pop(block_stack);
-        functionage = block_stack_pop(function_stack);
+        scope_block = scope_stack_pop(block_stack);
+        scope_function = scope_stack_pop(function_stack);
         return the_function;
     }
 
@@ -6413,7 +6413,7 @@ function jslint_phase3_parse(state) {
 // PR-500 - Unify ES2015-destructure-logic. - [aa] = ...;
 
             element = prefix_destructure(
-                undefined,              // declared_scope
+                undefined,              // scope_declared
                 "variable",             // role
                 false,                  // readonly
                 the_token.name_list,    // name_list
@@ -6578,8 +6578,8 @@ function jslint_phase3_parse(state) {
         const the_break = token_now;
         let the_label;
         if (
-            (functionage.loop < 1 && functionage.switch < 1)
-            || functionage.finally > 0
+            (scope_function.loop < 1 && scope_function.switch < 1)
+            || scope_function.finally > 0
         ) {
 
 // test_cause:
@@ -6589,7 +6589,7 @@ function jslint_phase3_parse(state) {
         }
         the_break.disrupt = true;
         if (token_nxt.identifier && token_now.line === token_nxt.line) {
-            the_label = functionage.context[token_nxt.id];
+            the_label = scope_function.context[token_nxt.id];
             if (
                 !the_label
                 || the_label.role !== "label"
@@ -6622,7 +6622,7 @@ function jslint_phase3_parse(state) {
 
     function stmt_continue() {
         const the_continue = token_now;
-        if (functionage.loop < 1 || functionage.finally > 0) {
+        if (scope_function.loop < 1 || scope_function.finally > 0) {
 
 // test_cause:
 // ["continue", "stmt_continue", "unexpected_a", "continue", 1]
@@ -6673,7 +6673,7 @@ function jslint_phase3_parse(state) {
     function stmt_do() {
         const the_do = token_now;
         check_not_top_level(the_do);
-        functionage.loop += 1;
+        scope_function.loop += 1;
         the_do.block = block();
         advance("while");
         the_do.expression = condition();
@@ -6685,7 +6685,7 @@ function jslint_phase3_parse(state) {
 
             warn("weird_loop", the_do);
         }
-        functionage.loop -= 1;
+        scope_function.loop -= 1;
         return the_do;
     }
 
@@ -6849,7 +6849,7 @@ function jslint_phase3_parse(state) {
             warn("unexpected_a", the_for);
         }
         check_not_top_level(the_for);
-        functionage.loop += 1;
+        scope_function.loop += 1;
         advance("(");
         token_now.free = true;
         if (token_nxt.id === ";") {
@@ -6915,7 +6915,7 @@ function jslint_phase3_parse(state) {
 
             warn("weird_loop", the_for);
         }
-        functionage.loop -= 1;
+        scope_function.loop -= 1;
         return the_for;
     }
 
@@ -7003,7 +7003,7 @@ function jslint_phase3_parse(state) {
 
 // 1.imp.1 - Mark 'declared', the import-name, during import-statement.
 
-                    functionage,        // declared_scope
+                    scope_function,     // scope_declared
                     "variable",         // role
                     true,               // readonly
                     the_import.name_list,       // name_list
@@ -7042,7 +7042,7 @@ function jslint_phase3_parse(state) {
 
 // 1.imp.1 - Mark 'declared', the import-name, during import-statement.
 
-                            functionage,        // declared_scope
+                            scope_function,     // scope_declared
                             "variable", // role
                             true,       // readonly
                             the_import.name_list,       // name_list
@@ -7119,7 +7119,7 @@ function jslint_phase3_parse(state) {
     function stmt_return() {
         const the_return = token_now;
         check_not_top_level(the_return);
-        if (functionage.finally > 0) {
+        if (scope_function.finally > 0) {
 
 // test_cause:
 // ["
@@ -7160,7 +7160,7 @@ function jslint_phase3_parse(state) {
             return is_equal(thing, exp);
         }
         check_not_top_level(the_switch);
-        if (functionage.finally > 0) {
+        if (scope_function.finally > 0) {
 
 // test_cause:
 // ["
@@ -7169,7 +7169,7 @@ function jslint_phase3_parse(state) {
 
             warn("unexpected_a", the_switch);
         }
-        functionage.switch += 1;
+        scope_function.switch += 1;
         advance("(");
         token_now.free = true;
         the_switch.expression = parse_expression(0);
@@ -7316,7 +7316,7 @@ function jslint_phase3_parse(state) {
             the_disrupt = false;
         }
         advance("}", the_switch);
-        functionage.switch -= 1;
+        scope_function.switch -= 1;
         the_switch.disrupt = the_disrupt;
         return the_switch;
     }
@@ -7326,7 +7326,7 @@ function jslint_phase3_parse(state) {
         the_throw.disrupt = true;
         the_throw.expression = parse_expression(10);
         semicolon();
-        if (functionage.try > 0) {
+        if (scope_function.try > 0) {
 
 // test_cause:
 // ["try{throw 0}catch(){}", "stmt_throw", "unexpected_a", "throw", 5]
@@ -7341,14 +7341,14 @@ function jslint_phase3_parse(state) {
         let ignored;
         let the_catch;
         let the_disrupt;
-        if (functionage.try > 0) {
+        if (scope_function.try > 0) {
 
 // test_cause:
 // ["try{try{}catch(){}}catch(){}", "stmt_try", "unexpected_a", "try", 5]
 
             warn("unexpected_a", the_try);
         }
-        functionage.try += 1;
+        scope_function.try += 1;
         the_try.block = block();
         the_disrupt = the_try.block.disrupt;
         if (token_nxt.id === "catch") {
@@ -7359,7 +7359,7 @@ function jslint_phase3_parse(state) {
 
 // Create new catch-scope for catch-parameter.
 
-            blockage = block_stack_push(block_stack, the_catch, the_catch);
+            scope_block = scope_stack_push(block_stack, the_catch, the_catch);
             if (token_nxt.id === "(") {
                 advance("(");
                 if (!token_nxt.identifier) {
@@ -7376,10 +7376,10 @@ function jslint_phase3_parse(state) {
 
 // 3.cat.1 - Mark 'declared', the catch-variable, before catch-block.
 
-// PR-xxx - Change scope from special-catch-scope to block-scope:
+// PR-xxx - Change scope from special-catch-scope to scope_block:
 // - catch-variable
 
-                        blockage,       // declared_scope
+                        scope_block,    // scope_declared
                         "exception",    // role
                         true,           // readonly
                         [],             // name_list
@@ -7404,7 +7404,7 @@ function jslint_phase3_parse(state) {
 
 // Restore previous catch-scope after catch-block.
 
-            blockage = block_stack_pop(block_stack);
+            scope_block = scope_stack_pop(block_stack);
 
 // PR-404 - Relax warning about missing `catch` in `try...finally` statement.
 //
@@ -7417,29 +7417,29 @@ function jslint_phase3_parse(state) {
 
         }
         if (token_nxt.id === "finally") {
-            functionage.finally += 1;
+            scope_function.finally += 1;
             advance("finally");
             the_try.else = block();
             the_disrupt = the_try.else.disrupt;
-            functionage.finally -= 1;
+            scope_function.finally -= 1;
         }
         the_try.disrupt = the_disrupt;
-        functionage.try -= 1;
+        scope_function.try -= 1;
         return the_try;
     }
 
     function stmt_var() {
-        const declared_scope = (
+        const readonly = token_now.id === "const";
+        const scope_declared = (
             token_now.id === "var"
-            ? functionage
+            ? scope_function
 
-// PR-xxx - Change scope from function-scope to block-scope:
+// PR-xxx - Change scope from scope_function to scope_block:
 // - const-declaration
 // - let-declaration
 
-            : blockage
+            : scope_block
         );
-        const readonly = token_now.id === "const";
         const the_variable = token_now;
         let name;
         let variable_prv;
@@ -7461,7 +7461,7 @@ function jslint_phase3_parse(state) {
 
 // We don't expect to see variables created in switch statements.
 
-        if (functionage.switch > 0) {
+        if (scope_function.switch > 0) {
 
 // test_cause:
 // ["switch(0){case 0:var aa}", "stmt_var", "var_switch", "var", 18]
@@ -7469,8 +7469,8 @@ function jslint_phase3_parse(state) {
             warn("var_switch", the_variable);
         }
         switch (
-            Boolean(functionage.statement_prv)
-            && functionage.statement_prv.id
+            Boolean(scope_function.statement_prv)
+            && scope_function.statement_prv.id
         ) {
         case "const":
         case "let":
@@ -7481,8 +7481,8 @@ function jslint_phase3_parse(state) {
 // ["let aa=0;let bb=0", "stmt_var", "var_prv", "let", 0]
 // ["var aa=0;var bb=0", "stmt_var", "var_prv", "var", 0]
 
-            test_cause("var_prv", functionage.statement_prv.id);
-            variable_prv = functionage.statement_prv;
+            test_cause("var_prv", scope_function.statement_prv.id);
+            variable_prv = scope_function.statement_prv;
             break;
         case "import":
 
@@ -7523,7 +7523,7 @@ function jslint_phase3_parse(state) {
 // PR-500 - Unify ES2015-destructure-logic. - let [aa] = ...;
 
                 prefix_destructure(
-                    declared_scope,     // declared_scope
+                    scope_declared,     // scope_declared
                     "variable",         // role
                     readonly,           // readonly
                     the_variable.name_list,     // name_list
@@ -7552,7 +7552,7 @@ function jslint_phase3_parse(state) {
 
 // 3.var.1 - Mark 'declared', the variable, during variable-declaration.
 
-                    declared_scope,     // declared_scope
+                    scope_declared,     // scope_declared
                     "variable",         // role
                     readonly,           // readonly
                     the_variable.name_list,     // name_list
@@ -7614,7 +7614,7 @@ function jslint_phase3_parse(state) {
     function stmt_while() {
         const the_while = token_now;
         check_not_top_level(the_while);
-        functionage.loop += 1;
+        scope_function.loop += 1;
         the_while.expression = condition();
         the_while.block = block();
         if (the_while.block.disrupt === true) {
@@ -7624,7 +7624,7 @@ function jslint_phase3_parse(state) {
 
             warn("weird_loop", the_while);
         }
-        functionage.loop -= 1;
+        scope_function.loop -= 1;
         return the_while;
     }
 
@@ -7889,8 +7889,8 @@ function jslint_phase3_parse(state) {
 
     block_stack.length = 0;
     function_stack.length = 0;
-    block_stack_push(block_stack, token_global, token_global);
-    block_stack_push(function_stack, token_global, undefined);
+    scope_block = scope_stack_push(block_stack, token_global, token_global);
+    scope_function = scope_stack_push(function_stack, token_global, undefined);
 
 // Init token_nxt.
 
@@ -7958,20 +7958,18 @@ function jslint_phase4_walk(state) {
     const {
         artifact,
         block_stack,
-        block_stack_pop,
-        block_stack_push,
         function_stack,
         global_dict,
         is_equal,
         is_weird,
         option_dict,
+        scope_stack_pop,
+        scope_stack_push,
         syntax_dict,
         test_cause,
         token_global,
         warn
     } = state;
-    let blockage = token_global;        // The current block.
-    let functionage = token_global;     // The current function.
     let postaction;
     let postamble;
     let posts = empty();
@@ -7984,6 +7982,8 @@ function jslint_phase4_walk(state) {
     let relationop = object_assign_from_list(empty(), [
         "!=", "!==", "<", "<=", "==", "===", ">", ">="
     ], true);
+    let scope_block;            // The current block-scope.
+    let scope_function;         // The current function-scope.
 
 // Ambulation of the parse tree.
 
@@ -8076,8 +8076,8 @@ function jslint_phase4_walk(state) {
 
 // Look up the variable, from current-scope, moving up the scope-chain.
 
-        block_stack.some(function (blockage, ii) {
-            the_variable = blockage.context[id];
+        block_stack.some(function (scope_block, ii) {
+            the_variable = scope_block.context[id];
             if (the_variable && ii > 0) {
 
 // If found outside current-scope, mark as closure.
@@ -8114,14 +8114,14 @@ function jslint_phase4_walk(state) {
 // 3.glo.2 - Mark 'alive', the global-variable, immediately.
 
                 alive: true,
-                declared_scope: token_global,
                 id,
 
 // 3.glo.3 - Mark 'init', the global-variable, immediately.
 
                 init: true,
                 readonly: true,
-                role: "variable"
+                role: "variable",
+                scope_declared: token_global
             };
 
 // 3.glo.1 - Mark 'declared', the global-variable, immediately.
@@ -8137,8 +8137,8 @@ function jslint_phase4_walk(state) {
         } else if (
             (
                 !the_variable.calls
-                || !functionage.name
-                || !the_variable.calls[functionage.name.id]
+                || !scope_function.name
+                || !the_variable.calls[scope_function.name.id]
             )
             && !the_variable.alive
         ) {
@@ -8539,7 +8539,7 @@ function jslint_phase4_walk(state) {
 
 // Some features must be at the most outermost level.
 
-        if (blockage !== token_global) {
+        if (scope_block !== token_global) {
 
 // test_cause:
 // ["
@@ -8558,13 +8558,13 @@ function jslint_phase4_walk(state) {
     }
 
     function post_s_function(thing) {
-        delete functionage.async;
-        delete functionage.finally;
-        delete functionage.loop;
-        delete functionage.statement_prv;
-        delete functionage.switch;
-        delete functionage.try;
-        functionage = block_stack_pop(function_stack);
+        delete scope_function.async;
+        delete scope_function.finally;
+        delete scope_function.loop;
+        delete scope_function.statement_prv;
+        delete scope_function.switch;
+        delete scope_function.try;
+        scope_function = scope_stack_pop(function_stack);
         if (thing.wrapped) {
 
 // test_cause:
@@ -8572,7 +8572,7 @@ function jslint_phase4_walk(state) {
 
             warn("unexpected_parens", thing);
         }
-        blockage = block_stack_pop(block_stack);
+        scope_block = scope_stack_pop(block_stack);
     }
 
     function post_s_import(the_thing) {
@@ -8586,7 +8586,7 @@ function jslint_phase4_walk(state) {
     }
 
     function post_s_lbrace_pop_block() {
-        blockage = block_stack_pop(block_stack);
+        scope_block = scope_stack_pop(block_stack);
     }
 
     function post_s_try(thing) {
@@ -8598,7 +8598,7 @@ function jslint_phase4_walk(state) {
 
 // Restore previous catch-scope after catch-block.
 
-            blockage = block_stack_pop(block_stack);
+            scope_block = scope_stack_pop(block_stack);
         }
     }
 
@@ -8928,15 +8928,15 @@ function jslint_phase4_walk(state) {
 // ["function aa(){}", "pre_s_function", "", "", 0]
 
         test_cause("");
-        if (thing.arity === "statement" && blockage.body !== true) {
+        if (thing.arity === "statement" && scope_block.body !== true) {
 
 // test_cause:
 // ["if(0){function aa(){}\n}", "pre_s_function", "unexpected_a", "function", 7]
 
             warn("unexpected_a", thing);
         }
-        blockage = block_stack_push(block_stack, thing, undefined);
-        functionage = block_stack_push(function_stack, thing, undefined);
+        scope_block = scope_stack_push(block_stack, thing, undefined);
+        scope_function = scope_stack_push(function_stack, thing, undefined);
         if (thing.extra === "get") {
             if (thing.parameter_count !== 0) {
 
@@ -8984,7 +8984,7 @@ function jslint_phase4_walk(state) {
     }
 
     function pre_s_lbrace(thing) {
-        blockage = block_stack_push(block_stack, thing, undefined);
+        scope_block = scope_stack_push(block_stack, thing, undefined);
     }
 
     function pre_s_try(thing) {
@@ -8992,7 +8992,7 @@ function jslint_phase4_walk(state) {
 
 // Create new catch-scope for catch-parameter.
 
-            blockage = block_stack_push(block_stack, thing.catch, undefined);
+            scope_block = scope_stack_push(block_stack, thing.catch, undefined);
         }
     }
 
@@ -9156,8 +9156,8 @@ function jslint_phase4_walk(state) {
 
     block_stack.length = 0;
     function_stack.length = 0;
-    block_stack_push(block_stack, token_global, undefined);
-    block_stack_push(function_stack, token_global, undefined);
+    scope_block = scope_stack_push(block_stack, token_global, undefined);
+    scope_function = scope_stack_push(function_stack, token_global, undefined);
 
 // Walk the token_tree.
 
@@ -9259,7 +9259,7 @@ function jslint_phase5_whitage(state) {
     function delve(the_function) {
         Object.keys(the_function.context).forEach(function (id) {
             const name = the_function.context[id];
-            if (id !== "ignore" && name.declared_scope === the_function) {
+            if (id !== "ignore" && name.scope_declared === the_function) {
 
 // test_cause:
 // ["function aa(aa) {return aa;}", "delve", "id", "", 0]
@@ -10389,17 +10389,17 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
         html += detail("closure", list.filter(function (id) {
             return (
                 context[id].closure === true
-                && context[id].declared_scope === the_function
+                && context[id].scope_declared === the_function
             );
         }));
         html += detail("outer", list.filter(function (id) {
             return (
-                context[id].declared_scope.id !== "(global)"
-                && context[id].declared_scope !== the_function
+                context[id].scope_declared.id !== "(global)"
+                && context[id].scope_declared !== the_function
             );
         }));
         html += detail(module, list.filter(function (id) {
-            return context[id].declared_scope.id === "(global)";
+            return context[id].scope_declared.id === "(global)";
         }));
         html += detail("label", list.filter(function (id) {
             return context[id].role === "label";

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -330,9 +330,11 @@
     role,
     round,
     scope_block,
+    scope_block_pop,
+    scope_block_push,
     scope_declared,
-    scope_stack_pop,
-    scope_stack_push,
+    scope_function_pop,
+    scope_function_push,
     scriptId,
     search,
     set,
@@ -1291,26 +1293,41 @@ function jslint(
         }
     }
 
-    function scope_stack_pop(stack) {
-        jslint_assert(stack.length > 1, `block_stack.length=${stack.length}`);
-        stack.shift();
-        return stack[0];
+    function scope_block_pop() {
+        jslint_assert(
+            block_stack.length > 1,
+            `block_stack.length=${block_stack.length}`
+        );
+        block_stack.shift();
+        return block_stack[0];
     }
 
-    function scope_stack_push(stack, stack_pushed, list_pushed) {
-        stack.unshift(stack_pushed);
-        if (stack === block_stack && !stack_pushed.context) {
-            stack_pushed.context = empty();
+    function scope_block_push(value, list_push) {
+        if (!value.context) {
+            value.context = empty();
         }
-        switch (list_pushed && stack) {
-        case block_stack:
-            block_list.push(list_pushed);
-            break;
-        case function_stack:
-            function_list.push(list_pushed);
-            break;
+        block_stack.unshift(value);
+        if (list_push) {
+            block_list.push(value);
         }
-        return stack_pushed;
+        return value;
+    }
+
+    function scope_function_pop() {
+        jslint_assert(
+            function_stack.length > 1,
+            `function_stack.length=${function_stack.length}`
+        );
+        function_stack.shift();
+        return function_stack[0];
+    }
+
+    function scope_function_push(value, list_push) {
+        function_stack.unshift(value);
+        if (list_push) {
+            function_list.push(value);
+        }
+        return value;
     }
 
     function stop(code, the_token, a, b, c, d) {
@@ -1789,8 +1806,10 @@ function jslint(
                 mode_shebang: false,    // true if #! is seen on the first line.
                 option_dict,
                 property_dict,
-                scope_stack_pop,
-                scope_stack_push,
+                scope_block_pop,
+                scope_block_push,
+                scope_function_pop,
+                scope_function_push,
                 source,
                 stop,
                 stop_at,
@@ -4278,8 +4297,10 @@ function jslint_phase3_parse(state) {
         is_equal,
         option_dict,
         property_dict,
-        scope_stack_pop,
-        scope_stack_push,
+        scope_block_pop,
+        scope_block_push,
+        scope_function_pop,
+        scope_function_push,
         stop,
         syntax_dict,
         tenure,
@@ -4445,7 +4466,7 @@ function jslint_phase3_parse(state) {
         }
         the_block = token_now;
         the_block.scope_block = true;
-        scope_block = scope_stack_push(block_stack, the_block, the_block);
+        scope_block = scope_block_push(the_block, true);
         if (special !== "body") {
             scope_function.statement_prv = the_block;
         }
@@ -4477,7 +4498,7 @@ function jslint_phase3_parse(state) {
         } else {
             the_block.disrupt = parsed_block[parsed_block.length - 1].disrupt;
         }
-        scope_block = scope_stack_pop(block_stack);
+        scope_block = scope_block_pop();
         if (!implicit) {
             advance("}");
         }
@@ -6073,12 +6094,8 @@ function jslint_phase3_parse(state) {
 
 // Push the current function context and establish a new one.
 
-        scope_block = scope_stack_push(block_stack, the_function, the_function);
-        scope_function = scope_stack_push(
-            function_stack,
-            the_function,
-            the_function
-        );
+        scope_block = scope_block_push(the_function, true);
+        scope_function = scope_function_push(the_function, true);
 
 // Parse the parameter list.
 
@@ -6220,8 +6237,8 @@ function jslint_phase3_parse(state) {
 
 // Restore the previous context.
 
-        scope_block = scope_stack_pop(block_stack);
-        scope_function = scope_stack_pop(function_stack);
+        scope_block = scope_block_pop();
+        scope_function = scope_function_pop();
         return the_function;
     }
 
@@ -6847,7 +6864,7 @@ function jslint_phase3_parse(state) {
 // PR-xxx - Add hidden scope_block for:
 // - for-variable
 
-        scope_block = scope_stack_push(block_stack, the_for, the_for);
+        scope_block = scope_block_push(the_for, true);
         advance("(");
         the_for.free = true;
         if (the_for.for_semicolon) {
@@ -7002,7 +7019,7 @@ function jslint_phase3_parse(state) {
 
             warn("weird_loop", the_for);
         }
-        scope_block = scope_stack_pop(block_stack);
+        scope_block = scope_block_pop();
         scope_function.loop -= 1;
         return the_for;
     }
@@ -7516,7 +7533,7 @@ function jslint_phase3_parse(state) {
 // PR-xxx - Add hidden scope_block for:
 // - catch-variable
 
-            scope_block = scope_stack_push(block_stack, the_catch, the_catch);
+            scope_block = scope_block_push(the_catch, true);
             if (token_nxt.id === "(") {
                 advance("(");
                 if (!token_nxt.identifier) {
@@ -7558,7 +7575,7 @@ function jslint_phase3_parse(state) {
 
 // Restore previous catch-scope after catch-block.
 
-            scope_block = scope_stack_pop(block_stack);
+            scope_block = scope_block_pop();
 
 // PR-404 - Relax warning about missing `catch` in `try...finally` statement.
 //
@@ -8078,8 +8095,8 @@ function jslint_phase3_parse(state) {
 
     block_stack.length = 0;
     function_stack.length = 0;
-    scope_block = scope_stack_push(block_stack, token_global, token_global);
-    scope_function = scope_stack_push(function_stack, token_global, undefined);
+    scope_block = scope_block_push(token_global, true);
+    scope_function = scope_function_push(token_global, false);
 
 // Init token_nxt.
 
@@ -8152,8 +8169,10 @@ function jslint_phase4_walk(state) {
         is_equal,
         is_weird,
         option_dict,
-        scope_stack_pop,
-        scope_stack_push,
+        scope_block_pop,
+        scope_block_push,
+        scope_function_pop,
+        scope_function_push,
         stop,
         syntax_dict,
         test_cause,
@@ -8747,7 +8766,7 @@ function jslint_phase4_walk(state) {
         if (thing.for_semicolon) {
             walk_statement(thing.for_semicolon[2]);
         }
-        scope_block = scope_stack_pop(block_stack);
+        scope_block = scope_block_pop();
     }
 
     function post_s_function(thing) {
@@ -8764,8 +8783,8 @@ function jslint_phase4_walk(state) {
 
             warn("unexpected_parens", thing);
         }
-        scope_block = scope_stack_pop(block_stack);
-        scope_function = scope_stack_pop(function_stack);
+        scope_block = scope_block_pop();
+        scope_function = scope_function_pop();
     }
 
     function post_s_import(the_thing) {
@@ -8782,7 +8801,7 @@ function jslint_phase4_walk(state) {
 // PR-xxx - Add hidden scope_block for:
 // - catch-variable
 
-            scope_block = scope_stack_push(block_stack, thing.catch, undefined);
+            scope_block = scope_block_push(thing.catch, false);
 
 // Recurse walk_statement().
 
@@ -8790,7 +8809,7 @@ function jslint_phase4_walk(state) {
 
 // Restore previous catch-scope after catch-block.
 
-            scope_block = scope_stack_pop(block_stack);
+            scope_block = scope_block_pop();
         }
     }
 
@@ -9098,7 +9117,7 @@ function jslint_phase4_walk(state) {
 // PR-xxx - Add hidden scope_block for:
 // - for-variable
 
-        scope_block = scope_stack_push(block_stack, thing, undefined);
+        scope_block = scope_block_push(thing, false);
         if (thing.for_semicolon) {
             walk_statement(thing.for_semicolon[0]);
             walk_expression(thing.for_semicolon[1]);
@@ -9135,8 +9154,8 @@ function jslint_phase4_walk(state) {
 // PR-xxx - Add hidden scope_block for:
 // - function-parameter
 
-        scope_block = scope_stack_push(block_stack, thing, undefined);
-        scope_function = scope_stack_push(function_stack, thing, undefined);
+        scope_block = scope_block_push(thing, false);
+        scope_function = scope_function_push(thing, false);
         if (thing.extra === "get") {
             if (thing.parameter_count !== 0) {
 
@@ -9250,7 +9269,7 @@ function jslint_phase4_walk(state) {
             return;
         }
         if (thing.scope_block) {
-            scope_block = scope_stack_push(block_stack, thing, undefined);
+            scope_block = scope_block_push(thing, false);
         }
         preamble(thing);
         walk_expression(thing.expression);
@@ -9284,7 +9303,7 @@ function jslint_phase4_walk(state) {
         walk_statement(thing.else);
         postamble(thing);
         if (thing.scope_block) {
-            scope_block = scope_stack_pop(block_stack);
+            scope_block = scope_block_pop();
         }
     }
 
@@ -9332,8 +9351,8 @@ function jslint_phase4_walk(state) {
 
     block_stack.length = 0;
     function_stack.length = 0;
-    scope_block = scope_stack_push(block_stack, token_global, undefined);
-    scope_function = scope_stack_push(function_stack, token_global, undefined);
+    scope_block = scope_block_push(token_global, false);
+    scope_function = scope_function_push(token_global, false);
 
 // Walk the token_tree.
 
@@ -9360,13 +9379,13 @@ function jslint_phase5_whitage(state) {
     const {
         artifact,
         block_list,
-        block_stack,
         option_dict,
         test_cause,
         token_global,
         token_list,
         warn
     } = state;
+    const indent_stack = [];
     let closer = "(end)";
     let dot_depth = 0;
 
@@ -9549,7 +9568,7 @@ function jslint_phase5_whitage(state) {
 
 // If right is a closer, then pop the previous state.
 
-        indentage = block_stack.pop();
+        indentage = indent_stack.pop();
         closer = indentage.closer;
         free = indentage.free;
         margin = indentage.margin;
@@ -9861,7 +9880,7 @@ function jslint_phase5_whitage(state) {
             open,
             opening
         };
-        block_stack.push(indentage);
+        indent_stack.push(indentage);
 
 // Commit 3903449a - Cleanup indent for multiline-method-chaining.
 
@@ -9943,10 +9962,6 @@ function jslint_phase5_whitage(state) {
         no_space_only();
     }
 
-// Init block_stack.
-
-    block_stack.length = 0;
-
 // uninitialized_and_unused();
 // Delve into the functions looking for variables that were not initialized
 // or used. If the file imports or exports, then its global object is also
@@ -9998,14 +10013,10 @@ function jslint_phase5_whitage(state) {
         delete left.used;
         left = right;
     });
-
-// Cleanup block_stack.
-
     jslint_assert(
-        block_stack.length === 0,
-        `block_stack.length=${block_stack.length}.`
+        indent_stack.length === 0,
+        `indent_stack.length=${indent_stack.length}.`
     );
-    block_stack.length = 0;
 }
 
 function jslint_report({

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -4383,7 +4383,7 @@ function jslint_phase3_parse(state) {
                     false,              // readonly
                     the_token.name_list,        // name_list
                     left,               // name
-                    true                // init
+                    false               // init
                 );
             } else {
                 the_token.expression = [left, right];
@@ -5068,44 +5068,53 @@ function jslint_phase3_parse(state) {
 //
 // 1.imp.1 - Mark 'enrolled', the import-name, during import-statement.
 // 1.imp.2 - Mark 'alive', the import-name, after import-statement.
+// 1.imp.3 - Mark 'init', the import-name, during import-statement.
 // 1.imp.4 - Mark 'out-of-scope', the import-name, after module-scope.
 //
 // 2.fun.1 - Mark 'enrolled', the function-name, immediately.
 // 2.fun.2 - Mark 'alive', the function-name, immediately.
+// 2.fun.3 - Mark 'init', the function-name, immediately.
 // 2.fun.4 - Mark 'out-of-scope', the function-name, after expression-scope.
 // 2.fun.4 - Mark 'out-of-scope', the function-name, after function-scope.
 //
 // 3.exc.1 - Mark 'enrolled', the exception-variable, before catch-block.
 // 3.exc.2 - Mark 'alive', the exception-variable, before catch-block.
+// 3.exc.3 - Mark 'init', the exception-variable, before catch-block.
 // 3.exc.4 - Mark 'out-of-scope', the exception-variable, after catch-block.
 //
 // 3.for.1 - Mark 'enrolled', the for-variable, ???.
 // 3.for.2 - Mark 'alive', the for-variable, before for-block.
+// 3.for.3 - Mark 'init', the for-variable, before for-block.
 // 3.for.4 - Mark 'out-of-scope', the for-variable, ???.
 //
 // 3.glo.1 - Mark 'enrolled', the global-variable, immediately.
 // 3.glo.2 - Mark 'alive', the global-variable, immediately.
+// 3.glo.3 - Mark 'init', the global-variable, immediately.
 // 3.glo.4 - Mark 'out-of-scope', the global-variable, never.
 //
 // 3.var.1 - Mark 'enrolled', the variable, during variable-initialization.
 // 3.var.2 - Mark 'alive', the variable, after variable-initialization.
+// 3.var.3 - Mark 'init', the variable, after assignment.
+// 3.var.3 - Mark 'init', the variable, during variable-initialization.
 // 3.var.4 - Mark 'out-of-scope', the variable, after block-scope.
 // 3.var.4 - Mark 'out-of-scope', the variable, after function-scope.
 //
 // 4.par.1 - Mark 'enrolled', the function-parameter, during destructuring.
 // 4.par.1 - Mark 'enrolled', the function-parameter, if unwrapped.
 // 4.par.2 - Mark 'alive', the function-parameter, after destructuring.
+// 4.par.3 - Mark 'init', the function-parameter, if unwrapped.
 // 4.par.4 - Mark 'out-of-scope', the function-parameter, after function-scope.
 //
 // 5.lab.1 - Mark 'enrolled', the label-statement, before control-flow-block.
 // 5.lab.2 - Mark 'alive', the label-statement, before control-flow-block.
+// 5.lab.3 - Mark 'init', the label-statement, before control-flow-block.
 // 5.lab.4 - Mark 'out-of-scope', the label-statement, after control-flow-block.
 
         let earlier;
         let id = name.id;
         name_list.push(name);
         if (init) {
-            name.init = init;
+            name.init = true;
         }
         if (role === "variable") {
             name.arity = "variable";
@@ -5507,6 +5516,9 @@ function jslint_phase3_parse(state) {
                     true,               // readonly
                     [],                 // name_list
                     the_label,          // name
+
+// 5.lab.3 - Mark 'init', the label-statement, before control-flow-block.
+
                     true                // init
                 );
 
@@ -5994,6 +6006,9 @@ function jslint_phase3_parse(state) {
                 false,                  // readonly
                 [],                     // name_list
                 name,                   // name
+
+// 2.fun.3 - Mark 'init', the function-name, immediately.
+
                 true                    // init
             );
 
@@ -6079,6 +6094,9 @@ function jslint_phase3_parse(state) {
                 false,                  // readonly
                 the_function.name_list, // name_list
                 token_prv,              // name
+
+// 4.par.3 - Mark 'init', the function-parameter, if unwrapped.
+
                 true                    // init
             );
         } else {
@@ -6979,6 +6997,9 @@ function jslint_phase3_parse(state) {
                     true,               // readonly
                     the_import.name_list,       // name_list
                     name,               // name
+
+// 1.imp.3 - Mark 'init', the import-name, during import-statement.
+
                     true                // init
                 );
             } else {
@@ -7015,6 +7036,9 @@ function jslint_phase3_parse(state) {
                             true,       // readonly
                             the_import.name_list,       // name_list
                             name,       // name
+
+// 1.imp.3 - Mark 'init', the import-name, during import-statement.
+
                             true        // init
                         );
                         if (token_nxt.id !== ",") {
@@ -7349,6 +7373,9 @@ function jslint_phase3_parse(state) {
                         true,           // readonly
                         [],             // name_list
                         token_nxt,      // name
+
+// 3.exc.3 - Mark 'init', the exception-variable, before catch-block.
+
                         true            // init
                     );
                 }
@@ -7505,6 +7532,9 @@ function jslint_phase3_parse(state) {
                     readonly,           // readonly
                     the_variable.name_list,     // name_list
                     name,               // name
+
+// 3.var.3 - Mark 'init', the variable, during variable-initialization.
+
                     Boolean(name.expression)    // init
                 );
             } else {
@@ -7991,12 +8021,10 @@ function jslint_phase4_walk(state) {
         };
     }
 
-    function name_lookup(thing, init) {
+    function name_lookup(thing) {
 
-// This function will:
-// 1. Lookup and return variable or function-parameter <the_variable> in current
-//    context from given <thing>.id.
-// 2. Set <the_variable>.init = true, if lookup was from an assignment.
+// This function will lookup and return variable or function-parameter
+// <the_variable> in current context from given <thing>.id.
 
         let id = thing.id;
         let the_variable;
@@ -8048,6 +8076,9 @@ function jslint_phase4_walk(state) {
 
                     alive: true,
                     id,
+
+// 3.glo.3 - Mark 'init', the global-variable, immediately.
+
                     init: true,
                     parent: token_global,
                     readonly: true,
@@ -8086,16 +8117,10 @@ function jslint_phase4_walk(state) {
 
             warn("out_of_scope_a", thing);
         }
-
-// Set variable as initialized, if lookup was from an assignment.
-
-        if (init && the_variable && !the_variable.readonly) {
-            the_variable.init = true;
-        }
         return the_variable;
     }
 
-    function post_a(thing) {
+    function post_a_assignment(thing) {
 
 // Assignment using = sets the init property of a variable. No other assignment
 // operator can do this. A = token keeps that variable (or array of variables
@@ -8110,10 +8135,10 @@ function jslint_phase4_walk(state) {
             ) {
 
 // test_cause:
-// ["aa+=0", "post_a", "+=", "aa", 0]
-// ["aa+=0", "post_a", "bad_assignment_a", "aa", 1]
-// ["const aa=0;aa+=0", "post_a", "+=", "aa", 0]
-// ["const aa=0;aa+=0", "post_a", "bad_assignment_a", "aa", 12]
+// ["aa+=0", "post_a_assignment", "+=", "aa", 0]
+// ["aa+=0", "post_a_assignment", "bad_assignment_a", "aa", 1]
+// ["const aa=0;aa+=0", "post_a_assignment", "+=", "aa", 0]
+// ["const aa=0;aa+=0", "post_a_assignment", "bad_assignment_a", "aa", 12]
 
                 test_cause("+=", lvalue.id);
                 warn("bad_assignment_a", lvalue);
@@ -8133,7 +8158,7 @@ function jslint_phase4_walk(state) {
             ) {
 
 // test_cause:
-// ["aa+=undefined", "post_a", "unexpected_a", "undefined", 5]
+// ["aa+=undefined", "post_a_assignment", "unexpected_a", "undefined", 5]
 
                 warn("unexpected_a", thing.expression[1]);
             }
@@ -8141,26 +8166,30 @@ function jslint_phase4_walk(state) {
         }
         if (thing.name_list) {
             thing.name_list.forEach(function (name) {
-                const the_variable = name_lookup(name, true);
-                if (!the_variable || the_variable.readonly) {
+                const the_variable = name_lookup(name);
+                if (the_variable && !the_variable.readonly) {
 
-// test_cause:
-// ["aa=0", "post_a", "=", "aa", 0]
-// ["aa=0", "post_a", "bad_assignment_a", "aa", 1]
-// ["const aa=0;aa=0", "post_a", "=", "aa", 0]
-// ["const aa=0;aa=0", "post_a", "bad_assignment_a", "aa", 12]
+// 3.var.3 - Mark 'init', the variable, after assignment.
 
-                    test_cause("=", name.id);
-                    warn("bad_assignment_a", name);
+                    the_variable.init = true;
                     return;
                 }
+
+// test_cause:
+// ["aa=0", "post_a_assignment", "=", "aa", 0]
+// ["aa=0", "post_a_assignment", "bad_assignment_a", "aa", 1]
+// ["const aa=0;aa=0", "post_a_assignment", "=", "aa", 0]
+// ["const aa=0;aa=0", "post_a_assignment", "bad_assignment_a", "aa", 12]
+
+                test_cause("=", name.id);
+                warn("bad_assignment_a", name);
             });
             return;
         }
         if (lvalue.id === "." && thing.expression[1].id === "undefined") {
 
 // test_cause:
-// ["aa.aa=undefined", "post_a", "expected_a_b", "undefined", 1]
+// ["aa.aa=undefined", "post_a_assignment", "expected_a_b", "undefined", 1]
 
             warn("expected_a_b", lvalue.expression, "delete", "undefined");
             return;
@@ -8179,92 +8208,6 @@ function jslint_phase4_walk(state) {
                 || Number.isNaN(right.value)
             ) {
                 warn("unexpected_a", right);
-            }
-        }
-    }
-
-    function post_b(thing) {
-        let right;
-        if (relationop[thing.id]) {
-            if (
-                is_weird(thing.expression[0])
-                || is_weird(thing.expression[1])
-                || is_equal(thing.expression[0], thing.expression[1])
-                || (
-                    thing.expression[0].constant === true
-                    && thing.expression[1].constant === true
-                )
-            ) {
-
-// test_cause:
-// ["if(0===0){0}", "post_b", "weird_relation_a", "===", 5]
-
-                warn("weird_relation_a", thing);
-            }
-        }
-        if (thing.id === "+") {
-            if (!option_dict.convert) {
-                if (thing.expression[0].value === "") {
-
-// test_cause:
-// ["\"\"+0", "post_b", "expected_a_b", "\"\" +", 3]
-
-                    warn("expected_a_b", thing, "String(...)", "\"\" +");
-                } else if (thing.expression[1].value === "") {
-
-// test_cause:
-// ["0+\"\"", "post_b", "expected_a_b", "+ \"\"", 2]
-
-                    warn("expected_a_b", thing, "String(...)", "+ \"\"");
-                }
-            }
-        } else if (thing.id === "[") {
-            if (thing.expression[0].id === "window") {
-
-// test_cause:
-// ["aa=window[0]", "post_b", "weird_expression_a", "window[...]", 10]
-
-                warn("weird_expression_a", thing, "window[...]");
-            }
-            if (thing.expression[0].id === "self") {
-
-// test_cause:
-// ["aa=self[0]", "post_b", "weird_expression_a", "self[...]", 8]
-
-                warn("weird_expression_a", thing, "self[...]");
-            }
-        } else if (thing.id === "." || thing.id === "?.") {
-            if (thing.expression.id === "RegExp") {
-
-// PR-499 - Relax warning for ES2025-feature RegExp.escape().
-
-                if (!thing.name || thing.name.id !== "escape") {
-
-// test_cause:
-// ["aa=RegExp.aa", "post_b", "weird_expression_a", ".", 10]
-
-                    warn("weird_expression_a", thing);
-                }
-            }
-        } else if (thing.id !== "=>" && thing.id !== "(") {
-            right = thing.expression[1];
-            if (
-                (thing.id === "+" || thing.id === "-")
-                && right.id === thing.id
-                && right.arity === "unary"
-                && !right.wrapped
-            ) {
-
-// test_cause:
-// ["0- -0", "post_b", "wrap_unary", "-", 4]
-
-                warn("wrap_unary", right);
-            }
-            if (
-                thing.expression[0].constant === true
-                && right.constant === true
-            ) {
-                thing.constant = true;
             }
         }
     }
@@ -8290,6 +8233,92 @@ function jslint_phase4_walk(state) {
 // ["aa={}&&{}", "post_b_and", "weird_condition_a", "&&", 6]
 
             warn("weird_condition_a", thing);
+        }
+    }
+
+    function post_b_binary(thing) {
+        let right;
+        if (relationop[thing.id]) {
+            if (
+                is_weird(thing.expression[0])
+                || is_weird(thing.expression[1])
+                || is_equal(thing.expression[0], thing.expression[1])
+                || (
+                    thing.expression[0].constant === true
+                    && thing.expression[1].constant === true
+                )
+            ) {
+
+// test_cause:
+// ["if(0===0){0}", "post_b_binary", "weird_relation_a", "===", 5]
+
+                warn("weird_relation_a", thing);
+            }
+        }
+        if (thing.id === "+") {
+            if (!option_dict.convert) {
+                if (thing.expression[0].value === "") {
+
+// test_cause:
+// ["\"\"+0", "post_b_binary", "expected_a_b", "\"\" +", 3]
+
+                    warn("expected_a_b", thing, "String(...)", "\"\" +");
+                } else if (thing.expression[1].value === "") {
+
+// test_cause:
+// ["0+\"\"", "post_b_binary", "expected_a_b", "+ \"\"", 2]
+
+                    warn("expected_a_b", thing, "String(...)", "+ \"\"");
+                }
+            }
+        } else if (thing.id === "[") {
+            if (thing.expression[0].id === "window") {
+
+// test_cause:
+// ["aa=window[0]", "post_b_binary", "weird_expression_a", "window[...]", 10]
+
+                warn("weird_expression_a", thing, "window[...]");
+            }
+            if (thing.expression[0].id === "self") {
+
+// test_cause:
+// ["aa=self[0]", "post_b_binary", "weird_expression_a", "self[...]", 8]
+
+                warn("weird_expression_a", thing, "self[...]");
+            }
+        } else if (thing.id === "." || thing.id === "?.") {
+            if (thing.expression.id === "RegExp") {
+
+// PR-499 - Relax warning for ES2025-feature RegExp.escape().
+
+                if (!thing.name || thing.name.id !== "escape") {
+
+// test_cause:
+// ["aa=RegExp.aa", "post_b_binary", "weird_expression_a", ".", 10]
+
+                    warn("weird_expression_a", thing);
+                }
+            }
+        } else if (thing.id !== "=>" && thing.id !== "(") {
+            right = thing.expression[1];
+            if (
+                (thing.id === "+" || thing.id === "-")
+                && right.id === thing.id
+                && right.arity === "unary"
+                && !right.wrapped
+            ) {
+
+// test_cause:
+// ["0- -0", "post_b_binary", "wrap_unary", "-", 4]
+
+                warn("wrap_unary", right);
+            }
+            if (
+                thing.expression[0].constant === true
+                && right.constant === true
+            ) {
+                thing.constant = true;
+            }
         }
     }
 
@@ -8763,7 +8792,7 @@ function jslint_phase4_walk(state) {
         }
     }
 
-    function pre_b(thing) {
+    function pre_b_binary(thing) {
         let left;
         let right;
         let value;
@@ -8773,7 +8802,7 @@ function jslint_phase4_walk(state) {
             if (left.id === "NaN" || right.id === "NaN") {
 
 // test_cause:
-// ["NaN===NaN", "pre_b", "number_isNaN", "===", 4]
+// ["NaN===NaN", "pre_b_binary", "number_isNaN", "===", 4]
 
                 warn("number_isNaN", thing);
             } else if (left.id === "typeof") {
@@ -8781,7 +8810,7 @@ function jslint_phase4_walk(state) {
                     if (right.id !== "typeof") {
 
 // test_cause:
-// ["typeof 0===0", "pre_b", "expected_string_a", "0", 12]
+// ["typeof 0===0", "pre_b_binary", "expected_string_a", "0", 12]
 
                         warn("expected_string_a", right);
                     }
@@ -8792,7 +8821,7 @@ function jslint_phase4_walk(state) {
 // test_cause:
 // ["
 // typeof aa==="undefined"
-// ", "pre_b", "unexpected_typeof_a", "undefined", 13]
+// ", "pre_b_binary", "unexpected_typeof_a", "undefined", 13]
 
                         warn("unexpected_typeof_a", right, value);
                     } else if (
@@ -8806,7 +8835,7 @@ function jslint_phase4_walk(state) {
                     ) {
 
 // test_cause:
-// ["typeof 0===\"aa\"", "pre_b", "expected_type_string_a", "aa", 12]
+// ["typeof 0===\"aa\"", "pre_b_binary", "expected_type_string_a", "aa", 12]
 
                         warn("expected_type_string_a", right, value);
                     }
@@ -8962,7 +8991,13 @@ function jslint_phase4_walk(state) {
 // 3.for.4 - Mark 'out-of-scope', the for-variable, ???.
 
             thing.name.alive = true;
-            the_variable = name_lookup(thing.name, true);
+            the_variable = name_lookup(thing.name);
+            if (the_variable && !the_variable.readonly) {
+
+// 3.for.3 - Mark 'init', the for-variable, before for-block.
+
+                the_variable.init = true;
+            }
             if (the_variable !== undefined) {
                 if (the_variable.init && the_variable.readonly) {
 
@@ -9064,8 +9099,8 @@ function jslint_phase4_walk(state) {
         }
     }
 
-    function pre_s_var(thing) {
-        const the_variable = name_lookup(thing, false);
+    function pre_v_var(thing) {
+        const the_variable = name_lookup(thing);
         if (the_variable !== undefined) {
             thing.variable = the_variable;
             the_variable.used += 1;
@@ -9183,13 +9218,13 @@ function jslint_phase4_walk(state) {
     preaction = action(pres);
     preamble = amble(pres);
     postaction("assignment", "+=", post_a_pluseq);
-    postaction("assignment", post_a);
+    postaction("assignment", post_a_assignment);
     postaction("binary", "&&", post_b_and);
     postaction("binary", "(", post_b_lparen);
     postaction("binary", "=>", post_s_function);
     postaction("binary", "[", post_b_lbracket);
     postaction("binary", "||", post_b_or);
-    postaction("binary", post_b);
+    postaction("binary", post_b_binary);
     postaction("statement", "const", post_s_var);
     postaction("statement", "export", post_s_export_toplevel);
     postaction("statement", "for", post_s_for);
@@ -9215,7 +9250,7 @@ function jslint_phase4_walk(state) {
     preaction("binary", "in", pre_b_in);
     preaction("binary", "instanceof", pre_b_instanceof);
     preaction("binary", "||", pre_b_or);
-    preaction("binary", pre_b);
+    preaction("binary", pre_b_binary);
     preaction("binary", pre_a_bitwise);
     preaction("statement", "for", pre_s_for);
     preaction("statement", "function", pre_s_function);
@@ -9223,7 +9258,7 @@ function jslint_phase4_walk(state) {
     preaction("statement", "{", pre_s_lbrace);
     preaction("unary", "function", pre_s_function);
     preaction("unary", "~", pre_a_bitwise);
-    preaction("variable", pre_s_var);
+    preaction("variable", pre_v_var);
 
     walk_statement(state.token_tree);
 }

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -181,7 +181,9 @@
     floor,
     for,
     forEach,
-    for_inc,
+    for_init,
+    for_of,
+    for_semicolon,
     formatted_message,
     free,
     freeze,
@@ -214,7 +216,6 @@
     index,
     indexOf,
     init,
-    initial,
     isArray,
     isBlockCoverage,
     isHole,
@@ -291,6 +292,7 @@
     on,
     open,
     opening,
+    operator,
     option,
     option_dict,
     order,
@@ -2642,7 +2644,6 @@ function jslint_phase2_lex(state) {
 
     const {
         artifact,
-        block_stack,
         directive_list,
         global_dict,
         global_list,
@@ -2657,6 +2658,7 @@ function jslint_phase2_lex(state) {
         warn,
         warn_at
     } = state;
+    const opener_stack = [];    // Stack of opener tokens: (, [.
     let char;                   // The current character being lexed.
     let column = 0;             // The column number of the next character.
     let from;                   // The starting column number of the token.
@@ -2673,7 +2675,7 @@ function jslint_phase2_lex(state) {
                                 // ... literal.
     let mode_regexp;            // true if regular expression literal seen on
                                 // ... this line.
-    let opener_popped = empty();        // Last token popped from block_stack.
+    let opener_popped = empty();        // Last token popped from opener_stack.
     let snippet = "";           // A piece of string.
     let token_1;                // The first token.
     let token_prv = token_global;       // The previous token including
@@ -4094,7 +4096,7 @@ function jslint_phase2_lex(state) {
 
 // Create the token object and append it to token_list.
 
-        let the_token = {
+        const the_token = {
             from,
             id,
             identifier: Boolean(identifier),
@@ -4152,14 +4154,14 @@ function jslint_phase2_lex(state) {
         switch (id) {
         case "(":
         case "[":
-            block_stack.push(the_token);
+            opener_stack.unshift(the_token);
             break;
         case ")":
         case "]":
 
 // PR-503 - Fix jslint crashing before warning about dangling ')' or ']'.
 
-            opener_popped = block_stack.pop() || empty();
+            opener_popped = opener_stack.shift() || empty();
             if (
                 (id === ")" && opener_popped.id !== "(")
                 || (id === "]" && opener_popped.id !== "[")
@@ -4172,6 +4174,11 @@ function jslint_phase2_lex(state) {
 // ["]", "token_create", "unexpected_a", "]", 1]
 
                 return stop("unexpected_a", the_token);
+            }
+            break;
+        case ";":
+            if (opener_stack[0]?.for) {
+                opener_stack[0].for.for_semicolon = [];
             }
             break;
 
@@ -4189,6 +4196,9 @@ function jslint_phase2_lex(state) {
             break;
         case "] =":
             opener_popped.assignment = the_token;
+            break;
+        case "for (":
+            the_token.for = token_prv_expr;
             break;
         }
 
@@ -5078,10 +5088,6 @@ function jslint_phase3_parse(state) {
 // 3.cat.2 - Mark 'alive', the catch-variable, before catch-block.
 // 3.cat.3 - Mark 'init', the catch-variable, before catch-block.
 //
-// 3.for.1 - Mark 'declared', the for-variable, ???.
-// 3.for.2 - Mark 'alive', the for-variable, before for-block.
-// 3.for.3 - Mark 'init', the for-variable, before for-block.
-//
 // 3.glo.1 - Mark 'declared', the global-variable, immediately.
 // 3.glo.2 - Mark 'alive', the global-variable, immediately.
 // 3.glo.3 - Mark 'init', the global-variable, immediately.
@@ -5174,6 +5180,7 @@ function jslint_phase3_parse(state) {
 // function aa(){try{aa();}catch(aa){aa();}}
 // ", "name_declare", "scope_outer", "aa", 0]
 // ["function aa(){var aa}", "name_declare", "scope_outer", "aa", 0]
+// ["let aa;for(let aa;;){}", "name_declare", "scope_outer", "aa", 0]
 
             test_cause("scope_outer", id);
             warn("redefinition_a_b", name, id, earlier.line);
@@ -6839,68 +6846,140 @@ function jslint_phase3_parse(state) {
     }
 
     function stmt_for() {
-        let first;
-        let the_for = token_now;
-        if (!option_dict.for) {
-
-// test_cause:
-// ["for", "stmt_for", "unexpected_a", "for", 1]
-
-            warn("unexpected_a", the_for);
-        }
+        const the_for = token_now;
+        let the_operator;
+        let the_variable;
         check_not_top_level(the_for);
         scope_function.loop += 1;
+
+// PR-xxx - Add implicit scope_block for:
+// - for-loop
+
+        scope_block = scope_stack_push(block_stack, token_now, token_now);
         advance("(");
         token_now.free = true;
-        if (token_nxt.id === ";") {
+        if (the_for.for_semicolon) {
+            switch (token_nxt.id) {
+            case ";":
 
 // test_cause:
 // ["for(;;){}", "stmt_for", "expected_a_b", "for (;", 1]
 
-            return stop("expected_a_b", the_for, "while (", "for (;");
-        }
-        switch (token_nxt.id) {
-        case "const":
-        case "let":
-        case "var":
+                warn("expected_a_b", the_for, "while (", "for (;");
+                break;
+            case "const":
+            case "var":
 
 // test_cause:
-// ["for(const aa in aa){}", "stmt_for", "unexpected_a", "const", 5]
+// ["for(const aa;;){}", "stmt_for", "expected_a_b", "const", 5]
+// ["for(var aa;;){}", "stmt_for", "expected_a_b", "var", 5]
 
-            warn("unexpected_a");
-            advance();
-            break;
-        }
-        first = parse_expression(0);
-        if (first.id === "in") {
-            if (first.expression[0].arity !== "variable") {
+                warn("expected_a_b", token_nxt, "let", token_nxt.id);
+                break;
+            case "let":
 
 // test_cause:
-// ["for(0 in aa){}", "stmt_for", "bad_assignment_a", "0", 5]
+// ["for(let aa;;){}", "stmt_for", "let", "let", 0]
 
-                warn("bad_assignment_a", first.expression[0]);
+                test_cause("let", token_nxt.id);
+                break;
+            default:
+
+// test_cause:
+// ["for(aa;;){}", "stmt_for", "expected_a", "let", 5]
+
+                warn("expected_a", token_nxt, "let");
             }
-            the_for.name = first.expression[0];
-            the_for.expression = first.expression[1];
-            warn("expected_a_b", the_for, "Object.keys", "for in");
-        } else if (first.id === "of") {
+            token_nxt.for_init = true;
+            the_for.for_semicolon.push(parse_statement_single());
+            token_nxt.for_init = true;
+            the_for.for_semicolon.push(parse_expression(0));
+            advance(";");
+            token_nxt.for_init = true;
+            the_for.for_semicolon.push(parse_expression(0));
+        } else {
+            switch (token_nxt.id) {
+            case "const":
+            case "let":
+
+// test_cause:
+// ["for(const aa in aa){}", "stmt_for", "for_of_const", "const", 0]
+// ["for(const aa of aa){}", "stmt_for", "for_of_const", "const", 0]
+// ["for(let aa in aa){}", "stmt_for", "for_of_const", "let", 0]
+// ["for(let aa of aa){}", "stmt_for", "for_of_const", "let", 0]
+
+                test_cause("for_of_const", token_nxt.id);
+                break;
+            case "var":
+
+// test_cause:
+// ["for(var aa in aa){}", "stmt_for", "expected_a_b", "var", 5]
+// ["for(var aa of aa){}", "stmt_for", "expected_a_b", "var", 5]
+
+                warn("expected_a_b", token_nxt, "const or let", "var");
+                break;
+            default:
+
+// test_cause:
+// ["for(aa in aa){}", "stmt_for", "expected_a", "const or let", 5]
+// ["for(aa of aa){}", "stmt_for", "expected_a", "const or let", 5]
+
+                warn("expected_a", token_nxt, "const or let");
+            }
+            token_nxt.for_init = true;
+            switch (token_nxt.id) {
+            case "const":
+            case "let":
+            case "var":
+                the_variable = parse_statement_single();
+                the_for.for_of = the_variable;
+                the_operator = the_variable.operator;
+                break;
+            default:
+                the_variable = parse_expression(0);
+                the_for.for_of = the_variable;
+                the_operator = the_variable;
+            }
+            the_variable.for_init = true;
+            switch (the_operator.id) {
+            case "in":
+
+// test_cause:
+// ["for(aa in aa){}", "stmt_for", "expected_a_b", "for in", 1]
+// ["for(const aa in aa){}", "stmt_for", "expected_a_b", "for in", 1]
+// ["for(let aa in aa){}", "stmt_for", "expected_a_b", "for in", 1]
+// ["for(var aa in aa){}", "stmt_for", "expected_a_b", "for in", 1]
+
+                warn("expected_a_b", the_for, "Object.keys", "for in");
+                break;
 
 // Issue #176 - Add ES2015-feature for..of.
 
-            the_for.name = first.expression[0];
-            the_for.expression = first.expression[1];
-        } else {
-            the_for.initial = first;
-            advance(";");
-            the_for.expression = parse_expression(0);
-            advance(";");
-            the_for.for_inc = parse_expression(0);
-            if (the_for.for_inc.id === "++") {
+            case "of":
 
 // test_cause:
-// ["for(aa;aa;aa++){}", "stmt_for", "expected_a_b", "++", 13]
+// ["for(aa of aa){}", "stmt_for", "of", "of", 0]
+// ["for(const aa of aa){}", "stmt_for", "of", "of", 0]
+// ["for(let aa of aa){}", "stmt_for", "of", "of", 0]
+// ["for(var aa of aa){}", "stmt_for", "of", "of", 0]
 
-                warn("expected_a_b", the_for.for_inc, "+= 1", "++");
+                test_cause("of", the_operator.id);
+                the_operator.for_init = true;
+                break;
+            default:
+
+// test_cause:
+// ["for(aa=aa){}", "stmt_for", "expected_a_b", "=", 7]
+// ["for(const aa=aa){}", "stmt_for", "expected_a_b", "=", 13]
+// ["for(let aa=aa){}", "stmt_for", "expected_a_b", "=", 11]
+// ["for(var aa=aa){}", "stmt_for", "expected_a_b", "=", 11]
+
+                return stop(
+                    "expected_a_b",
+                    the_operator,
+                    "of",
+                    the_operator.id
+                );
             }
         }
         advance(")");
@@ -6915,6 +6994,7 @@ function jslint_phase3_parse(state) {
 
             warn("weird_loop", the_for);
         }
+        scope_block = scope_stack_pop(block_stack);
         scope_function.loop -= 1;
         return the_for;
     }
@@ -7429,6 +7509,7 @@ function jslint_phase3_parse(state) {
     }
 
     function stmt_var() {
+        const for_init = token_now.for_init;
         const readonly = token_now.id === "const";
         const scope_declared = (
             token_now.id === "var"
@@ -7469,7 +7550,7 @@ function jslint_phase3_parse(state) {
             warn("var_switch", the_variable);
         }
         switch (
-            Boolean(scope_function.statement_prv)
+            Boolean(scope_function.statement_prv && !for_init)
             && scope_function.statement_prv.id
         ) {
         case "const":
@@ -7544,9 +7625,41 @@ function jslint_phase3_parse(state) {
 
                     warn("unexpected_a", name);
                 }
-                if (token_nxt.id === "=" || readonly) {
+                switch (token_nxt.id) {
+                case "=":
+                    the_variable.operator = token_nxt;
                     advance("=");
                     name.expression = parse_expression(0);
+                    break;
+                case "in":
+                case "of":
+                    if (for_init) {
+
+// test_cause:
+// ["for(let aa in 0){}", "stmt_var", "for_init", "in", 0]
+// ["for(let aa of 0){}", "stmt_var", "for_init", "of", 0]
+
+                        test_cause("for_init", token_nxt.id);
+                        the_variable.operator = token_nxt;
+                        advance();
+                        name.expression = parse_expression(0);
+                        break;
+                    }
+
+// test_cause:
+// ["let aa in 0", "stmt_var", "not_for_init", "in", 0]
+// ["let aa of 0", "stmt_var", "not_for_init", "of", 0]
+
+                    test_cause("not_for_init", token_nxt.id);
+                    the_variable.operator = token_nxt;
+                    advance("=");
+                    break;
+                default:
+                    if (readonly) {
+                        the_variable.operator = token_nxt;
+                        advance("=");
+                        name.expression = parse_expression(0);
+                    }
                 }
                 name_declare(
 
@@ -7607,7 +7720,9 @@ function jslint_phase3_parse(state) {
                 variable_prv.name_list[0].id
             );
         }
-        semicolon();
+        if (!for_init || token_nxt.id === ";") {
+            semicolon();
+        }
         return the_variable;
     }
 
@@ -7965,6 +8080,7 @@ function jslint_phase4_walk(state) {
         option_dict,
         scope_stack_pop,
         scope_stack_push,
+        stop,
         syntax_dict,
         test_cause,
         token_global,
@@ -8554,7 +8670,10 @@ function jslint_phase4_walk(state) {
 
 // Recurse walk_statement().
 
-        walk_statement(thing.for_inc);
+        if (thing.for_semicolon) {
+            walk_statement(thing.for_semicolon[2]);
+        }
+        scope_block = scope_stack_pop(block_stack);
     }
 
     function post_s_function(thing) {
@@ -8858,7 +8977,9 @@ function jslint_phase4_walk(state) {
 // test_cause:
 // ["aa in aa", "pre_b_in", "infix_in", "in", 4]
 
-        warn("infix_in", thing);
+        if (!thing.for_init) {
+            warn("infix_in", thing);
+        }
     }
 
     function pre_b_instanceof(thing) {
@@ -8877,6 +8998,16 @@ function jslint_phase4_walk(state) {
         warn("expected_a_b", thing, "!==", "!=");
     }
 
+    function pre_b_of(thing) {
+        if (!thing.for_init) {
+
+// test_cause:
+// ["0 of 0", "pre_b_of", "unexpected_a", "of", 3]
+
+            return stop("unexpected_a", thing);
+        }
+    }
+
     function pre_b_or(thing) {
         thing.expression.forEach(function (thang) {
             if (thang.id === "&&" && !thang.wrapped) {
@@ -8890,34 +9021,26 @@ function jslint_phase4_walk(state) {
     }
 
     function pre_s_for(thing) {
-        let the_variable;
-        if (thing.name?.identifier) {
 
-// 3.for.1 - Mark 'declared', the for-variable, ???.
-// 3.for.2 - Mark 'alive', the for-variable, before for-block.
+// PR-xxx - Add implicit scope_block for:
+// - for-loop
 
-            thing.name.alive = true;
-            the_variable = name_lookup(thing.name);
-            if (the_variable && !the_variable.readonly) {
-
-// 3.for.3 - Mark 'init', the for-variable, before for-block.
-
-                the_variable.init = true;
-            }
-            if (the_variable !== undefined) {
-                if (the_variable.init && the_variable.readonly) {
-
-// test_cause:
-// ["const aa=0;for(aa in aa){}", "pre_s_for", "bad_assignment_a", "aa", 16]
-
-                    warn("bad_assignment_a", thing.name);
-                }
+        scope_block = scope_stack_push(block_stack, thing, undefined);
+        if (thing.for_semicolon) {
+            walk_statement(thing.for_semicolon[0]);
+            walk_expression(thing.for_semicolon[1]);
+        }
+        if (thing.for_of) {
+            switch (thing.for_of.id) {
+            case "const":
+            case "let":
+            case "var":
+                post_s_var(thing.for_of);
+                break;
+            default:
+                walk_expression(thing.for_of);
             }
         }
-
-// Recurse walk_statement().
-
-        walk_statement(thing.initial);
     }
 
     function pre_s_function(thing) {
@@ -9039,6 +9162,8 @@ function jslint_phase4_walk(state) {
 // test_cause:
 // ["aa=++aa", "walk_expression", "unexpected_a", "++", 4]
 // ["aa=--aa", "walk_expression", "unexpected_a", "--", 4]
+// ["aa=aa++", "walk_expression", "unexpected_a", "++", 6]
+// ["aa=aa--", "walk_expression", "unexpected_a", "--", 6]
 
                     warn("unexpected_a", thing);
                 } else if (
@@ -9143,6 +9268,7 @@ function jslint_phase4_walk(state) {
     preaction("binary", "=>", pre_s_function);
     preaction("binary", "in", pre_b_in);
     preaction("binary", "instanceof", pre_b_instanceof);
+    preaction("binary", "of", pre_b_of);
     preaction("binary", "||", pre_b_or);
     preaction("statement", "for", pre_s_for);
     preaction("statement", "function", pre_s_function);
@@ -9581,14 +9707,13 @@ function jslint_phase5_whitage(state) {
 
 // test_cause:
 // ["
-// /*jslint for*/
 // function aa() {
 //     for (
-//         aa();
-// aa;
-//         aa()
+//         let bb = 0;
+// bb < 0;
+//         bb += 1
 //     ) {
-//         aa();
+//         aa(bb);
 //     }
 // }
 // ", "whitage_default", "for(;;)", ";", 0]
@@ -9742,7 +9867,10 @@ function jslint_phase5_whitage(state) {
             }
             return;
         }
-        if (right.statement || right.role === "label") {
+        if (
+            (right.statement || right.role === "label")
+            && (!right.for_init || left.line !== right.line)
+        ) {
 
 // test_cause:
 // ["function aa(){bb:while(aa){aa();}}", "whitage_opener", "{label", "bb", 0]

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -240,7 +240,7 @@
     jstestIt,
     jstestOnExit,
     keys,
-    label,
+    label_goto,
     lbp,
     led_infix,
     length,
@@ -280,6 +280,7 @@
     moduleName,
     module_list,
     name,
+    name_alias,
     name_list,
     node,
     nomen,
@@ -4258,8 +4259,8 @@ function jslint_phase3_parse(state) {
 // a token may be given any of these properties:
 
 //      arity       string
-//      label       identifier
 //      name        identifier
+//      name_alias  identifier
 //      expression  expressions
 //      block       statements
 //      else        statements (else, default, catch)
@@ -5132,10 +5133,10 @@ function jslint_phase3_parse(state) {
 // 4.par.2 - Mark 'alive', the function-parameter, after destructuring.
 // 4.par.3 - Mark 'init', the function-parameter, if unwrapped.
 //
-// 5.lab.1 - Mark 'declared', the label-statement, before control-flow-block.
-// 5.lab.2 - Mark 'alive', the label-statement, before control-flow-block.
-// 5.lab.3 - Mark 'init', the label-statement, before control-flow-block.
-// 5.lab.4 - Mark 'out-of-scope', the label-statement, after control-flow-block.
+// 5.lab.1 - Mark 'declared', the statement-label, before control-flow-block.
+// 5.lab.2 - Mark 'alive', the statement-label, before control-flow-block.
+// 5.lab.3 - Mark 'init', the statement-label, before control-flow-block.
+// 5.lab.4 - Mark 'out-of-scope', the statement-label, after control-flow-block.
 
         const id = name.id;
         let earlier;
@@ -5493,7 +5494,7 @@ function jslint_phase3_parse(state) {
                         Object.assign(
                             parse_json(),
                             {
-                                label: name
+                                name_alias: name
                             }
                         )
                     );
@@ -5563,7 +5564,6 @@ function jslint_phase3_parse(state) {
 // an assignment expression, or an invocation expression.
 
         let first;
-        let the_label;
         let the_statement;
         let the_symbol;
         if (token_nxt.id === ";") {
@@ -5572,67 +5572,9 @@ function jslint_phase3_parse(state) {
         }
         advance();
         if (token_now.identifier && token_nxt.id === ":") {
-            the_label = token_now;
-            if (the_label.id === "ignore") {
-
-// test_cause:
-// ["ignore:", "parse_statement_single", "unexpected_a", "ignore", 1]
-
-                warn("unexpected_a", the_label);
-            }
-            advance(":");
-            switch (token_nxt.id) {
-            case "do":
-            case "for":
-            case "switch":
-            case "while":
-
-// test_cause:
-// ["aa:do", "parse_statement_single", "label", "do", 0]
-// ["aa:for", "parse_statement_single", "label", "for", 0]
-// ["aa:switch", "parse_statement_single", "label", "switch", 0]
-// ["aa:while", "parse_statement_single", "label", "while", 0]
-
-                test_cause("label", token_nxt.id);
-                name_declare(
-
-// 5.lab.1 - Mark 'declared', the label-statement, before control-flow-block.
-
-                    scope_function,     // scope_declared
-                    "label",            // role
-                    true,               // readonly
-                    [],                 // name_list
-                    the_label,          // name
-
-// 5.lab.3 - Mark 'init', the label-statement, before control-flow-block.
-
-                    true                // init
-                );
-
-// 5.lab.2 - Mark 'alive', the label-statement, before control-flow-block.
-
-                the_label.alive = true;
-                the_statement = parse_statement_single();
-
-// 5.lab.4 - Mark 'out-of-scope', the label-statement, after control-flow-block.
-
-                the_label.alive = false;
-                the_statement.label = the_label;
-                the_statement.statement = true;
-                scope_function.statement_prv = the_statement;
+            the_statement = stmt_label();
+            if (the_statement) {
                 return the_statement;
-            default:
-
-// test_cause:
-// ["()=>{aa:0}", "parse_statement_single", "unexpected_label_a", "aa", 6]
-// [";{aa:0}", "parse_statement_single", "unexpected_label_a", "aa", 3]
-// ["aa:", "parse_statement_single", "unexpected_label_a", "aa", 1]
-// ["aa:0", "parse_statement_single", "unexpected_label_a", "aa", 1]
-// ["aa:0?0:0", "parse_statement_single", "unexpected_label_a", "aa", 1]
-// ["aa:bb:0", "parse_statement_single", "unexpected_label_a", "aa", 1]
-
-                warn("unexpected_label_a", the_label);
-                advance();
             }
         }
 
@@ -5921,7 +5863,7 @@ function jslint_phase3_parse(state) {
                     name_parse();
                     return;
                 }
-                token_nxt.label = name;
+                token_nxt.name_alias = name;
                 name = token_nxt;
                 name_declare(
                     scope_declared,     // scope_declared
@@ -6125,6 +6067,9 @@ function jslint_phase3_parse(state) {
 //
 //             warn("function_in_loop", the_function);
 //         }
+
+// PR-xxx - Add hidden scope_block for:
+// - function-parameter
 
 // Push the current function context and establish a new one.
 
@@ -6354,7 +6299,7 @@ function jslint_phase3_parse(state) {
                 test_cause("colon");
                 advance(":");
                 value = parse_expression(0);
-                value.label = name;
+                value.name_alias = name;
                 return value;
             }
             if (token_nxt.id === "}" || token_nxt.id === ",") {
@@ -6413,7 +6358,7 @@ function jslint_phase3_parse(state) {
                     warn("unexpected_a", the_colon, ": " + name.id);
                 }
             }
-            value.label = name;
+            value.name_alias = name;
             if (typeof extra === "string") {
                 value.extra = extra;
             }
@@ -6447,9 +6392,9 @@ function jslint_phase3_parse(state) {
         check_ordered(
             "property",
             the_brace.expression.map(function ({
-                label
+                name_alias
             }) {
-                return label;
+                return name_alias;
             })
         );
         advance("}");
@@ -6651,7 +6596,7 @@ function jslint_phase3_parse(state) {
             ) {
                 if (the_label && !the_label.alive) {
 
-// Warn label-statement is 'out-of-scope'.
+// Warn statement-label is 'out-of-scope'.
 
 // test_cause:
 // ["aa:{function aa(aa){break aa}}", "stmt_break", "out_of_scope_a", "aa", 27]
@@ -6667,7 +6612,7 @@ function jslint_phase3_parse(state) {
             } else {
                 the_label.used = true;
             }
-            the_break.label = token_nxt;
+            the_break.label_goto = token_nxt;
             advance();
         }
         semicolon();
@@ -7249,6 +7194,74 @@ function jslint_phase3_parse(state) {
         return the_import;
     }
 
+    function stmt_label() {
+        const the_label = token_now;
+        let the_statement;
+        if (the_label.id === "ignore") {
+
+// test_cause:
+// ["ignore:", "stmt_label", "unexpected_a", "ignore", 1]
+
+            warn("unexpected_a", the_label);
+        }
+        advance(":");
+        switch (token_nxt.id) {
+        case "do":
+        case "for":
+        case "switch":
+        case "while":
+
+// test_cause:
+// ["aa:do", "stmt_label", "label", "do", 0]
+// ["aa:for", "stmt_label", "label", "for", 0]
+// ["aa:switch", "stmt_label", "label", "switch", 0]
+// ["aa:while", "stmt_label", "label", "while", 0]
+
+            test_cause("label", token_nxt.id);
+            break;
+        default:
+
+// test_cause:
+// ["()=>{aa:0}", "stmt_label", "unexpected_label_a", "aa", 6]
+// [";{aa:0}", "stmt_label", "unexpected_label_a", "aa", 3]
+// ["aa:", "stmt_label", "unexpected_label_a", "aa", 1]
+// ["aa:0", "stmt_label", "unexpected_label_a", "aa", 1]
+// ["aa:0?0:0", "stmt_label", "unexpected_label_a", "aa", 1]
+// ["aa:bb:0", "stmt_label", "unexpected_label_a", "aa", 1]
+
+            warn("unexpected_label_a", the_label);
+            advance();
+            return;
+        }
+        name_declare(
+
+// 5.lab.1 - Mark 'declared', the statement-label, before control-flow-block.
+
+            scope_function,     // scope_declared
+            "label",            // role
+            true,               // readonly
+            [],                 // name_list
+            the_label,          // name
+
+// 5.lab.3 - Mark 'init', the statement-label, before control-flow-block.
+
+            true                // init
+        );
+
+// 5.lab.2 - Mark 'alive', the statement-label, before control-flow-block.
+
+        the_label.alive = true;
+        the_statement = parse_statement_single();
+
+// 5.lab.4 - Mark 'out-of-scope', the statement-label, after control-flow-block.
+
+        the_label.alive = false;
+        //!! the_statement.label = the_label;
+        //!! the_statement.statement = true;
+        scope_function.statement_prv = the_statement;
+        return the_statement;
+    }
+
     function stmt_lbrace() {
 
 // test_cause:
@@ -7387,7 +7400,7 @@ function jslint_phase3_parse(state) {
             the_cases.push(the_case);
             last = parsed_block[parsed_block.length - 1];
             if (last.disrupt) {
-                if (last.id === "break" && last.label === undefined) {
+                if (last.id === "break" && last.label_goto === undefined) {
                     the_disrupt = false;
                 }
             } else {
@@ -7442,7 +7455,7 @@ function jslint_phase3_parse(state) {
                 ];
                 if (
                     the_last.id === "break"
-                    && the_last.label === undefined
+                    && the_last.label_goto === undefined
                 ) {
 
 // test_cause:
@@ -8756,12 +8769,10 @@ function jslint_phase4_walk(state) {
     }
 
     function post_s_import(the_thing) {
-        the_thing.name_list.forEach(function (name) {
 
 // 1.imp.2 - Mark 'alive', the import-name, after import-statement.
 
-            name.alive = true;
-        });
+        post_s_var(the_thing);
         post_s_export_toplevel(the_thing);
     }
 
@@ -9120,6 +9131,10 @@ function jslint_phase4_walk(state) {
 
             warn("unexpected_a", thing);
         }
+
+// PR-xxx - Add hidden scope_block for:
+// - function-parameter
+
         scope_block = scope_stack_push(block_stack, thing, undefined);
         scope_function = scope_stack_push(function_stack, thing, undefined);
         if (thing.extra === "get") {
@@ -9145,27 +9160,10 @@ function jslint_phase4_walk(state) {
                 warn("bad_set", thing);
             }
         }
-        thing.name_list.forEach(function (name) {
-            if (name.expression) {
-
-// test_cause:
-// ["(aa=0)=>0", "pre_s_function", "(aa=0)=>0", "", 0]
-
-                test_cause("(aa=0)=>0");
-            } else {
-
-// test_cause:
-// ["(aa)=>0", "pre_s_function", "(aa)=>0", "", 0]
-// ["aa=>0", "pre_s_function", "(aa)=>0", "", 0]
-
-                test_cause("(aa)=>0");
-            }
-            walk_expression(name.expression);
 
 // 4.par.2 - Mark 'alive', the function-parameter, after destructuring.
 
-            name.alive = true;
-        });
+        post_s_var(thing);
     }
 
     function pre_v_var(thing) {

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -95,6 +95,8 @@
     JSLINT_BETA,
     NODE_V8_COVERAGE,
     a,
+    alive,
+    alive_list,
     all,
     argv,
     arity,
@@ -251,8 +253,6 @@
     lines,
     linesCovered,
     linesTotal,
-    live,
-    live_list,
     log,
     long,
     loop,
@@ -1117,6 +1117,7 @@ function jslint(
     let syntax_dict = empty();  // The object containing the parser.
     let tenure = empty();       // The predefined property registry.
     let token_global = {        // The global object; the outermost context.
+        alive_list: [],
         async: 0,
         body: true,
         context: empty(),
@@ -1125,7 +1126,6 @@ function jslint(
         id: "(global)",
         level: 0,
         line: jslint_fudge,
-        live_list: [],
         loop: 0,
         switch: 0,
         thru: 0,
@@ -4375,6 +4375,7 @@ function jslint_phase3_parse(state) {
             the_token.arity = "assignment";
             right = parse_expression(20 - 1);
             if (id === "=" && left.arity === "variable") {
+                the_token.expression = right;
                 the_token.name_list = [];       // 1. name_list for "aa = ..."
                 name_enroll(
                     false,              // enroll
@@ -4384,7 +4385,6 @@ function jslint_phase3_parse(state) {
                     left,               // name
                     true                // init
                 );
-                the_token.expression = right;
             } else {
                 the_token.expression = [left, right];
             }
@@ -5067,39 +5067,39 @@ function jslint_phase3_parse(state) {
 // and its lifecycle.  Here is a list of all lifecycle comments.
 //
 // 1.imp.1 - Mark 'enrolled', the import-name, during import-statement.
-// 1.imp.2 - Mark 'live', the import-name, after import-statement.
-// 1.imp.3 - Mark 'out-of-scope', the import-name, after module-scope.
+// 1.imp.2 - Mark 'alive', the import-name, after import-statement.
+// 1.imp.4 - Mark 'out-of-scope', the import-name, after module-scope.
 //
 // 2.fun.1 - Mark 'enrolled', the function-name, immediately.
-// 2.fun.2 - Mark 'live', the function-name, immediately.
-// 2.fun.3 - Mark 'out-of-scope', the function-name, after expression-scope.
-// 2.fun.3 - Mark 'out-of-scope', the function-name, after function-scope.
+// 2.fun.2 - Mark 'alive', the function-name, immediately.
+// 2.fun.4 - Mark 'out-of-scope', the function-name, after expression-scope.
+// 2.fun.4 - Mark 'out-of-scope', the function-name, after function-scope.
 //
 // 3.exc.1 - Mark 'enrolled', the exception-variable, before catch-block.
-// 3.exc.2 - Mark 'live', the exception-variable, before catch-block.
-// 3.exc.3 - Mark 'out-of-scope', the exception-variable, after catch-block.
+// 3.exc.2 - Mark 'alive', the exception-variable, before catch-block.
+// 3.exc.4 - Mark 'out-of-scope', the exception-variable, after catch-block.
 //
-// 3.for.1 - Mark 'enrolled', the iterator-variable, ???.
-// 3.for.2 - Mark 'live', the iterator-variable, before for-block.
-// 3.for.3 - Mark 'out-of-scope', the iterator-variable, ???.
+// 3.for.1 - Mark 'enrolled', the for-variable, ???.
+// 3.for.2 - Mark 'alive', the for-variable, before for-block.
+// 3.for.4 - Mark 'out-of-scope', the for-variable, ???.
 //
-// 3.glo.1 - Mark 'enrolled', the global-variable, never.
-// 3.glo.2 - Mark 'live', the global-variable, immediately.
-// 3.glo.3 - Mark 'out-of-scope', the global-variable, never.
+// 3.glo.1 - Mark 'enrolled', the global-variable, immediately.
+// 3.glo.2 - Mark 'alive', the global-variable, immediately.
+// 3.glo.4 - Mark 'out-of-scope', the global-variable, never.
 //
 // 3.var.1 - Mark 'enrolled', the variable, during variable-initialization.
-// 3.var.2 - Mark 'live', the variable, after variable-initialization.
-// 3.var.3 - Mark 'out-of-scope', the variable, after block-scope.
-// 3.var.3 - Mark 'out-of-scope', the variable, after function-scope.
+// 3.var.2 - Mark 'alive', the variable, after variable-initialization.
+// 3.var.4 - Mark 'out-of-scope', the variable, after block-scope.
+// 3.var.4 - Mark 'out-of-scope', the variable, after function-scope.
 //
 // 4.par.1 - Mark 'enrolled', the function-parameter, during destructuring.
 // 4.par.1 - Mark 'enrolled', the function-parameter, if unwrapped.
-// 4.par.2 - Mark 'live', the function-parameter, after destructuring.
-// 4.par.3 - Mark 'out-of-scope', the function-parameter, after function-scope.
+// 4.par.2 - Mark 'alive', the function-parameter, after destructuring.
+// 4.par.4 - Mark 'out-of-scope', the function-parameter, after function-scope.
 //
 // 5.lab.1 - Mark 'enrolled', the label-statement, before control-flow-block.
-// 5.lab.2 - Mark 'live', the label-statement, before control-flow-block.
-// 5.lab.3 - Mark 'out-of-scope', the label-statement, after control-flow-block.
+// 5.lab.2 - Mark 'alive', the label-statement, before control-flow-block.
+// 5.lab.4 - Mark 'out-of-scope', the label-statement, after control-flow-block.
 
         let earlier;
         let id = name.id;
@@ -5498,10 +5498,10 @@ function jslint_phase3_parse(state) {
 // ["aa:while{}", "parse_statement", "the_statement_label", "while", 0]
 
                 test_cause("the_statement_label", token_nxt.id);
+                name_enroll(
 
 // 5.lab.1 - Mark 'enrolled', the label-statement, before control-flow-block.
 
-                name_enroll(
                     true,               // enroll
                     "label",            // role
                     true,               // readonly
@@ -5510,14 +5510,14 @@ function jslint_phase3_parse(state) {
                     true                // init
                 );
 
-// 5.lab.2 - Mark 'live', the label-statement, before control-flow-block.
+// 5.lab.2 - Mark 'alive', the label-statement, before control-flow-block.
 
-                the_label.live = true;
+                the_label.alive = true;
                 the_statement = parse_statement();
 
-// 5.lab.3 - Mark 'out-of-scope', the label-statement, after control-flow-block.
+// 5.lab.4 - Mark 'out-of-scope', the label-statement, after control-flow-block.
 
-                the_label.live = false;
+                the_label.alive = false;
                 functionage.statement_prv = the_statement;
                 the_statement.label = the_label;
                 the_statement.statement = true;
@@ -5962,7 +5962,7 @@ function jslint_phase3_parse(state) {
     function prefix_function(the_function, mode_fart, mode_fart_unwrapped) {
         const name = !mode_fart && token_nxt.identifier && token_nxt;
         the_function = the_function || token_now;
-        the_function.live_list = [];
+        the_function.alive_list = [];
         if (mode_fart) {
             the_function.arity = "binary";
         }
@@ -5981,10 +5981,10 @@ function jslint_phase3_parse(state) {
         }
         if (name) {
             advance();
+            name_enroll(
 
 // 2.fun.1 - Mark 'enrolled', the function-name, immediately.
 
-            name_enroll(
                 true,                   // enroll
                 (                       // role
                     the_function.arity === "statement"
@@ -5997,19 +5997,19 @@ function jslint_phase3_parse(state) {
                 true                    // init
             );
 
-// 2.fun.2 - Mark 'live', the function-name, immediately.
+// 2.fun.2 - Mark 'alive', the function-name, immediately.
 
-            name.live = true;
+            name.alive = true;
             if (the_function.arity === "statement") {
 
-// 2.fun.3 - Mark 'out-of-scope', the function-name, after function-scope.
+// 2.fun.4 - Mark 'out-of-scope', the function-name, after function-scope.
 
-                functionage.live_list.push(name);
+                functionage.alive_list.push(name);
             } else {
 
-// 2.fun.3 - Mark 'out-of-scope', the function-name, after expression-scope.
+// 2.fun.4 - Mark 'out-of-scope', the function-name, after expression-scope.
 
-                the_function.live_list.push(name);
+                the_function.alive_list.push(name);
                 name.used += 1;
             }
         }
@@ -6070,10 +6070,10 @@ function jslint_phase3_parse(state) {
 // ["aa=>0", "prefix_function", "wrap_fart_parameter", "aa", 1]
 
             warn("wrap_fart_parameter", token_prv);
+            name_enroll(
 
 // 4.par.1 - Mark 'enrolled', the function-parameter, if unwrapped.
 
-            name_enroll(
                 true,                   // enroll
                 "parameter",            // role
                 false,                  // readonly
@@ -6086,10 +6086,10 @@ function jslint_phase3_parse(state) {
             if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
 
 // PR-500 - Unify ES2015-destructure-logic. - function ([aa]) {...}
+                prefix_destructure(
 
 // 4.par.1 - Mark 'enrolled', the function-parameter, during destructuring.
 
-                prefix_destructure(
                     true,               // enroll
                     "parameter",        // role
                     false,              // readonly
@@ -6564,9 +6564,9 @@ function jslint_phase3_parse(state) {
             if (
                 !the_label
                 || the_label.role !== "label"
-                || !the_label.live
+                || !the_label.alive
             ) {
-                if (the_label && !the_label.live) {
+                if (the_label && !the_label.alive) {
 
 // Warn label-statement is 'out-of-scope'.
 
@@ -6970,10 +6970,10 @@ function jslint_phase3_parse(state) {
 
                     warn("unexpected_a", name);
                 }
+                name_enroll(
 
 // 1.imp.1 - Mark 'enrolled', the import-name, during import-statement.
 
-                name_enroll(
                     true,               // enroll
                     "variable",         // role
                     true,               // readonly
@@ -7006,10 +7006,10 @@ function jslint_phase3_parse(state) {
 
                             warn("unexpected_a", name);
                         }
+                        name_enroll(
 
 // 1.imp.1 - Mark 'enrolled', the import-name, during import-statement.
 
-                        name_enroll(
                             true,       // enroll
                             "variable", // role
                             true,       // readonly
@@ -7340,10 +7340,10 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id !== "ignore") {
                     ignored = undefined;
                     the_catch.name = token_nxt;
+                    name_enroll(
 
 // 3.exc.1 - Mark 'enrolled', the exception-variable, before catch-block.
 
-                    name_enroll(
                         true,           // enroll
                         "exception",    // role
                         true,           // readonly
@@ -7496,10 +7496,10 @@ function jslint_phase3_parse(state) {
                     advance("=");
                     name.expression = parse_expression(0);
                 }
+                name_enroll(
 
 // 3.var.1 - Mark 'enrolled', the variable, during variable-initialization.
 
-                name_enroll(
                     true,               // enroll
                     "variable",         // role
                     readonly,           // readonly
@@ -8043,14 +8043,12 @@ function jslint_phase4_walk(state) {
 
             if (!the_variable) {
                 the_variable = {
+
+// 3.glo.2 - Mark 'alive', the global-variable, immediately.
+
+                    alive: true,
                     id,
                     init: true,
-
-// 3.glo.1 - Mark 'enrolled', the global-variable, never.
-// 3.glo.2 - Mark 'live', the global-variable, immediately.
-// 3.glo.3 - Mark 'out-of-scope', the global-variable, never.
-
-                    live: true,
                     parent: token_global,
                     readonly: true,
                     role: "variable",
@@ -8059,7 +8057,12 @@ function jslint_phase4_walk(state) {
                 token_global.context[id] = the_variable;
             }
             the_variable.closure = true;
+
+// 3.glo.1 - Mark 'enrolled', the global-variable, immediately.
+
             functionage.context[id] = the_variable;
+
+// 3.glo.4 - Mark 'out-of-scope', the global-variable, never.
         }
         if (
             (
@@ -8067,7 +8070,7 @@ function jslint_phase4_walk(state) {
                 || !functionage.name
                 || !the_variable.calls[functionage.name.id]
             )
-            && !the_variable.live
+            && !the_variable.alive
         ) {
 
 // Warn variable is 'out-of-scope'.
@@ -8509,22 +8512,22 @@ function jslint_phase4_walk(state) {
     function post_s_import(the_thing) {
         the_thing.name_list.forEach(function (name) {
 
-// 1.imp.2 - Mark 'live', the import-name, after import-statement.
+// 1.imp.2 - Mark 'alive', the import-name, after import-statement.
 
-            name.live = true;
+            name.alive = true;
 
-// 1.imp.3 - Mark 'out-of-scope', the import-name, after module-scope.
+// 1.imp.4 - Mark 'out-of-scope', the import-name, after module-scope.
 
-            blockage.live_list.push(name);
+            blockage.alive_list.push(name);
         });
         post_s_export_toplevel(the_thing);
     }
 
     function post_s_lbrace_pop_block() {
-        blockage.live_list.forEach(function (name) {
-            name.live = false;
+        blockage.alive_list.forEach(function (name) {
+            name.alive = false;
         });
-        delete blockage.live_list;
+        delete blockage.alive_list;
         blockage = block_stack.pop();
     }
 
@@ -8534,9 +8537,9 @@ function jslint_phase4_walk(state) {
         }
         if (thing.catch.name) {
 
-// 3.exc.2 - Mark 'live', the exception-variable, before catch-block.
+// 3.exc.2 - Mark 'alive', the exception-variable, before catch-block.
 
-            catchage.context[thing.catch.name.id].live = true;
+            catchage.context[thing.catch.name.id].alive = true;
         }
 
 // Recurse walk_statement().
@@ -8544,9 +8547,9 @@ function jslint_phase4_walk(state) {
         walk_statement(thing.catch.block);
         if (thing.catch.name) {
 
-// 3.exc.3 - Mark 'out-of-scope', the exception-variable, after catch-block.
+// 3.exc.4 - Mark 'out-of-scope', the exception-variable, after catch-block.
 
-            catchage.context[thing.catch.name.id].live = false;
+            catchage.context[thing.catch.name.id].alive = false;
         }
 
 // Restore previous catch-scope after catch-block.
@@ -8574,23 +8577,23 @@ function jslint_phase4_walk(state) {
 // PR-502 - Fix long-running regression where 'let x = x;'
 // doesn't warn about temporal-dead-zone.
 
-// 3.var.2 - Mark 'live', the variable, after variable-initialization.
+// 3.var.2 - Mark 'alive', the variable, after variable-initialization.
 
-            name.live = true;
+            name.alive = true;
             switch (thing.id) {
             case "const":
             case "let":
 
-// 3.var.3 - Mark 'out-of-scope', the variable, after block-scope.
+// 3.var.4 - Mark 'out-of-scope', the variable, after block-scope.
 
-                blockage.live_list.push(name);
+                blockage.alive_list.push(name);
                 break;
             // case "var":
             default:
 
-// 3.var.3 - Mark 'out-of-scope', the variable, after function-scope.
+// 3.var.4 - Mark 'out-of-scope', the variable, after function-scope.
 
-                functionage.live_list.push(name);
+                functionage.alive_list.push(name);
             }
         });
     }
@@ -8914,7 +8917,7 @@ function jslint_phase4_walk(state) {
 //                 if (
 //                     left_variable !== undefined
 // // Probably deadcode.
-// // && !left_variable.live
+// // && !left_variable.alive
 //                     && left_variable.parent === parent
 //                     && left_variable.calls !== undefined
 //                     && left_variable.calls[functionage.name.id] !== undefined
@@ -8924,7 +8927,7 @@ function jslint_phase4_walk(state) {
 // // false so JSLint won't raise an error for
 // // calling it before its line is executed.
 //
-//                     left_variable.live = true;
+//                     left_variable.alive = true;
 //                 }
 //             }
 //         }
@@ -8954,11 +8957,11 @@ function jslint_phase4_walk(state) {
         let the_variable;
         if (thing.name !== undefined) {
 
-// 3.for.1 - Mark 'enrolled', the iterator-variable, ???.
-// 3.for.2 - Mark 'live', the iterator-variable, before for-block.
-// 3.for.3 - Mark 'out-of-scope', the iterator-variable, ???.
+// 3.for.1 - Mark 'enrolled', the for-variable, ???.
+// 3.for.2 - Mark 'alive', the for-variable, before for-block.
+// 3.for.4 - Mark 'out-of-scope', the for-variable, ???.
 
-            thing.name.live = true;
+            thing.name.alive = true;
             the_variable = name_lookup(thing.name, true);
             if (the_variable !== undefined) {
                 if (the_variable.init && the_variable.readonly) {
@@ -9035,23 +9038,23 @@ function jslint_phase4_walk(state) {
             }
             walk_expression(name.expression);
 
-// 4.par.2 - Mark 'live', the function-parameter, after destructuring.
+// 4.par.2 - Mark 'alive', the function-parameter, after destructuring.
 
-            name.live = true;
+            name.alive = true;
 
-// 4.par.3 - Mark 'out-of-scope', the function-parameter, after function-scope.
+// 4.par.4 - Mark 'out-of-scope', the function-parameter, after function-scope.
 
-            functionage.live_list.push(name);
+            functionage.alive_list.push(name);
         });
     }
 
     function pre_s_lbrace(thing) {
         block_stack.push(blockage);
         blockage = thing;
-        thing.live_list = [];
+        thing.alive_list = [];
     }
 
-    function pre_try(thing) {
+    function pre_s_try(thing) {
         if (thing.catch !== undefined) {
 
 // Create new catch-scope for catch-parameter.
@@ -9061,7 +9064,7 @@ function jslint_phase4_walk(state) {
         }
     }
 
-    function pre_v(thing) {
+    function pre_s_var(thing) {
         const the_variable = name_lookup(thing, false);
         if (the_variable !== undefined) {
             thing.variable = the_variable;
@@ -9216,11 +9219,11 @@ function jslint_phase4_walk(state) {
     preaction("binary", pre_a_bitwise);
     preaction("statement", "for", pre_s_for);
     preaction("statement", "function", pre_s_function);
-    preaction("statement", "try", pre_try);
+    preaction("statement", "try", pre_s_try);
     preaction("statement", "{", pre_s_lbrace);
     preaction("unary", "function", pre_s_function);
     preaction("unary", "~", pre_a_bitwise);
-    preaction("variable", pre_v);
+    preaction("variable", pre_s_var);
 
     walk_statement(state.token_tree);
 }
@@ -9859,10 +9862,10 @@ function jslint_phase5_whitage(state) {
             }
         }
         nr_comments_skipped = 0;
+        delete left.alive;
         delete left.calls;
         delete left.free;
         delete left.init;
-        delete left.live;
         delete left.open;
         delete left.used;
         left = right;

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -111,6 +111,7 @@
     beta,
     bitwise,
     block,
+    block_stack,
     body,
     browser,
     c,
@@ -292,7 +293,6 @@
     ok,
     on,
     open,
-    opener_stack,
     opening,
     option,
     option_dict,
@@ -1087,6 +1087,7 @@ function jslint(
 
 // The jslint function itself.
 
+    const block_stack = [];     // The stack of blocks.
     const catch_list = [];      // The array containing all catch-blocks.
     const catch_stack = [       // The stack of catch-blocks.
         {
@@ -1108,7 +1109,6 @@ function jslint(
             line_source
         };
     });
-    const opener_stack = [];    // Stack of opener tokens: (, [.
     const property_dict = empty();      // The object containing the tallied
                                         // ... property names.
                                 // jslint functions.
@@ -1365,7 +1365,7 @@ function jslint(
 // likely that the first warning will be the most meaningful.
 
         if (the_token.warning) {
-            warning_list.pop();
+            jslint_assert_and_pop(warning_list, "warning_list");
             return the_warning;
         }
         the_token.warning = the_warning;
@@ -1754,6 +1754,7 @@ function jslint(
             state,
             {
                 artifact,
+                block_stack,
                 catch_list,
                 catch_stack,
                 directive_list,
@@ -1771,7 +1772,6 @@ function jslint(
                 mode_property: false,   // true if directive /*property*/ is
                                         // ... used.
                 mode_shebang: false,    // true if #! is seen on the first line.
-                opener_stack,
                 option_dict,
                 property_dict,
                 source,
@@ -1796,10 +1796,15 @@ function jslint(
 // PHASE 2. Lex <line_list> into <token_list>.
 
         jslint_phase2_lex(state);
+        block_stack.length = 0;
 
 // PHASE 3. Parse <token_list> into <token_tree> using the Pratt-parser.
 
         jslint_phase3_parse(state);
+        jslint_assert(
+            block_stack.length === 0,
+            `block_stack.length=${block_stack.length}.`
+        );
         jslint_assert(
             catch_stack.length === 1,
             `catch_stack.length=${catch_stack.length}.`
@@ -1807,10 +1812,6 @@ function jslint(
         jslint_assert(
             function_stack.length === 0,
             `function_stack.length=${function_stack.length}.`
-        );
-        jslint_assert(
-            opener_stack.length === 0,
-            `opener_stack.length=${opener_stack.length}.`
         );
 
 // PHASE 4. Walk <token_tree>, traversing all nodes of the tree. It is a
@@ -1820,6 +1821,10 @@ function jslint(
         if (!state.mode_json) {
             jslint_phase4_walk(state);
         }
+        jslint_assert(
+            block_stack.length === 0,
+            `block_stack.length=${block_stack.length}.`
+        );
         jslint_assert(
             catch_stack.length === 1,
             `catch_stack.length=${catch_stack.length}.`
@@ -1835,8 +1840,8 @@ function jslint(
             jslint_phase5_whitage(state);
         }
         jslint_assert(
-            opener_stack.length === 0,
-            `opener_stack.length=${opener_stack.length}.`
+            block_stack.length === 0,
+            `block_stack.length=${block_stack.length}.`
         );
 
 // PR-347 - Disable warning "missing_browser".
@@ -2277,6 +2282,14 @@ ${String(message).slice(0, 2000)}`
     throw error;
 }
 
+function jslint_assert_and_pop(list, list_name) {
+
+// This function will assert <list>.length > 0, before returning <list>.pop().
+
+    jslint_assert(list.length > 0, `${list_name}.length=${list.length}`);
+    return list.pop();
+}
+
 async function jslint_cli({
     console_error,
     console_log,
@@ -2662,11 +2675,11 @@ function jslint_phase2_lex(state) {
 
     const {
         artifact,
+        block_stack,
         directive_list,
         global_dict,
         global_list,
         line_list,
-        opener_stack,
         option_dict,
         stop,
         stop_at,
@@ -2693,7 +2706,7 @@ function jslint_phase2_lex(state) {
                                 // ... literal.
     let mode_regexp;            // true if regular expression literal seen on
                                 // ... this line.
-    let opener_popped = empty();        // Last token popped from opener_stack.
+    let opener_popped = empty();        // Last token popped from block_stack.
     let snippet = "";           // A piece of string.
     let token_1;                // The first token.
     let token_prv = token_global;       // The previous token including
@@ -4170,14 +4183,14 @@ function jslint_phase2_lex(state) {
         switch (id) {
         case "(":
         case "[":
-            opener_stack.push(the_token);
+            block_stack.push(the_token);
             break;
         case ")":
         case "]":
 
 // PR-503 - Fix jslint crashing before warning about dangling ')' or ']'.
 
-            opener_popped = opener_stack.pop() || empty();
+            opener_popped = block_stack.pop() || empty();
             if (
                 (id === ")" && opener_popped.id !== "(")
                 || (id === "]" && opener_popped.id !== "[")
@@ -4271,6 +4284,7 @@ function jslint_phase3_parse(state) {
 
     const {
         artifact,
+        block_stack,
         catch_list,
         catch_stack,
         export_dict,
@@ -4291,6 +4305,7 @@ function jslint_phase3_parse(state) {
         warn_at
     } = state;
     let anon = "anonymous";     // The guessed name for anonymous functions.
+    let blockage = token_global;        // The current block.
     let catchage = catch_stack[0];      // The current catch-block.
     let functionage = token_global;     // The current function.
     let mode_var;               // "var" if using var; "let" if using let.
@@ -4423,6 +4438,8 @@ function jslint_phase3_parse(state) {
             advance("{");
         }
         the_block = token_now;
+        block_stack.push(blockage);
+        blockage = token_now;
         if (special !== "body") {
             functionage.statement_prv = the_block;
         }
@@ -4455,6 +4472,7 @@ function jslint_phase3_parse(state) {
             the_block.disrupt = stmts[stmts.length - 1].disrupt;
         }
         advance("}");
+        blockage = jslint_assert_and_pop(block_stack, "block_stack");
         return the_block;
     }
 
@@ -6089,6 +6107,8 @@ function jslint_phase3_parse(state) {
 
 // Push the current function context and establish a new one.
 
+        block_stack.push(blockage);
+        blockage = the_function;
         function_list.push(the_function);
         function_stack.push(functionage);
         functionage = the_function;
@@ -6233,7 +6253,8 @@ function jslint_phase3_parse(state) {
 
 // Restore the previous context.
 
-        functionage = function_stack.pop();
+        blockage = jslint_assert_and_pop(block_stack, "block_stack");
+        functionage = jslint_assert_and_pop(function_stack, "function_stack");
         return the_function;
     }
 
@@ -7411,7 +7432,7 @@ function jslint_phase3_parse(state) {
 
 // Restore previous catch-scope after catch-block.
 
-            catchage = catch_stack.pop();
+            catchage = jslint_assert_and_pop(catch_stack, "catch_stack");
 
 // PR-404 - Relax warning about missing `catch` in `try...finally` statement.
 //
@@ -7934,6 +7955,7 @@ function jslint_phase4_walk(state) {
 
     const {
         artifact,
+        block_stack,
         catch_stack,
         function_stack,
         global_dict,
@@ -7945,7 +7967,6 @@ function jslint_phase4_walk(state) {
         token_global,
         warn
     } = state;
-    let block_stack = [];               // The stack of blocks.
     let blockage = token_global;        // The current block.
     let catchage = catch_stack[0];      // The current catch-block.
     let functionage = token_global;     // The current function.
@@ -8546,7 +8567,7 @@ function jslint_phase4_walk(state) {
         delete functionage.statement_prv;
         delete functionage.switch;
         delete functionage.try;
-        functionage = function_stack.pop();
+        functionage = jslint_assert_and_pop(function_stack, "function_stack");
         if (thing.wrapped) {
 
 // test_cause:
@@ -8576,7 +8597,7 @@ function jslint_phase4_walk(state) {
             name.alive = false;
         });
         delete blockage.alive_list;
-        blockage = block_stack.pop();
+        blockage = jslint_assert_and_pop(block_stack, "block_stack");
     }
 
     function post_s_try(thing) {
@@ -8602,7 +8623,7 @@ function jslint_phase4_walk(state) {
 
 // Restore previous catch-scope after catch-block.
 
-        catchage = catch_stack.pop();
+        catchage = jslint_assert_and_pop(catch_stack, "catch_stack");
     }
 
     function post_s_var(thing) {
@@ -9048,10 +9069,10 @@ function jslint_phase4_walk(state) {
 
             warn("unexpected_a", thing);
         }
-        function_stack.push(functionage);
         block_stack.push(blockage);
-        functionage = thing;
         blockage = thing;
+        function_stack.push(functionage);
+        functionage = thing;
         if (thing.extra === "get") {
             if (thing.parameter_count !== 0) {
 
@@ -9288,9 +9309,9 @@ function jslint_phase5_whitage(state) {
 
     const {
         artifact,
+        block_stack,
         catch_list,
         function_list,
-        opener_stack,
         option_dict,
         test_cause,
         token_global,
@@ -9479,7 +9500,7 @@ function jslint_phase5_whitage(state) {
 
 // If right is a closer, then pop the previous state.
 
-        indentage = opener_stack.pop();
+        indentage = jslint_assert_and_pop(block_stack, "block_stack");
         closer = indentage.closer;
         free = indentage.free;
         margin = indentage.margin;
@@ -9792,7 +9813,7 @@ function jslint_phase5_whitage(state) {
             open,
             opening
         };
-        opener_stack.push(indentage);
+        block_stack.push(indentage);
 
 // Commit 3903449a - Cleanup indent for multiline-method-chaining.
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -7078,7 +7078,7 @@ function jslint_phase3_parse(state) {
                 warn("expected_a_b", the_for, "Object.keys", "for in");
                 break;
 
-// Issue #176 - Add ES2015-feature for..of.
+// PR-504 - Add ES2015-feature for..of.
 
             case "of":
 
@@ -8043,7 +8043,7 @@ function jslint_phase3_parse(state) {
     infix(110, "in");
     infix(110, "instanceof");
 
-// Issue #176 - Add ES2015-feature for..of.
+// PR-504 - Add ES2015-feature for..of.
 
     infix(110, "of");
     infix(120, "<<");

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -139,6 +139,7 @@
     cwd,
     d,
     debugInline,
+    declared_scope,
     default,
     delta,
     devel,
@@ -300,7 +301,6 @@
     padEnd,
     padStart,
     parameter_count,
-    parent,
     parentIi,
     parse,
     pathname,
@@ -4385,8 +4385,8 @@ function jslint_phase3_parse(state) {
             if (id === "=" && left.arity === "variable") {
                 the_token.expression = right;
                 the_token.name_list = [];       // 1. name_list for "aa = ..."
-                name_enroll(
-                    undefined,          // enroll_parent
+                name_declare(
+                    undefined,          // declared_scope
                     "variable",         // role
                     false,              // readonly
                     the_token.name_list,        // name_list
@@ -5060,10 +5060,10 @@ function jslint_phase3_parse(state) {
         return the_symbol;
     }
 
-// PR-502 - Unify name_list.push() logic with helper-function name_enroll().
+// PR-502 - Unify name_list.push() logic with helper-function name_declare().
 
-    function name_enroll(
-        enroll_parent,
+    function name_declare(
+        declared_scope,
         role,
         readonly,
         name_list,
@@ -5075,52 +5075,52 @@ function jslint_phase3_parse(state) {
 // 1. Push variable or function-parameter <name> to <name_list>.
 // 2. Set <name>.init = true, if its an assigned-variable,
 //    a function-parameter, or existing variable assigned new value.
-// 3. Enroll <name> in <enroll_parent>.context, if its a declared-variable,
+// 3. Declare <name> in <declared_scope>.context, if its a declared-variable,
 //    or function-parameter.
-
-// Most calls to name_enroll() are commented about the thing being enrolled,
-// and its lifecycle.  Here is a list of all lifecycle comments.
 //
-// 1.imp.1 - Mark 'enrolled', the import-name, during import-statement.
+// Most calls to name_declare() are commented regarding thing being declared,
+// and its lifecycle.  Below is a copy of all such comments.
+//
+// 1.imp.1 - Mark 'declared', the import-name, during import-statement.
 // 1.imp.2 - Mark 'alive', the import-name, after import-statement.
 // 1.imp.3 - Mark 'init', the import-name, during import-statement.
 // 1.imp.4 - Mark 'out-of-scope', the import-name, after module-scope.
 //
-// 2.fun.1 - Mark 'enrolled', the function-name, immediately.
-// 2.fun.2 - Mark 'alive', the function-name, immediately.
-// 2.fun.3 - Mark 'init', the function-name, immediately.
+// 2.fun.1 - Mark 'declared', the function-name, during function-declaration.
+// 2.fun.2 - Mark 'alive', the function-name, during function-declaration.
+// 2.fun.3 - Mark 'init', the function-name, during function-declaration.
 // 2.fun.4 - Mark 'out-of-scope', the function-name, after expression-scope.
 // 2.fun.4 - Mark 'out-of-scope', the function-name, after function-scope.
 //
-// 3.exc.1 - Mark 'enrolled', the exception-variable, before catch-block.
+// 3.exc.1 - Mark 'declared', the exception-variable, before catch-block.
 // 3.exc.2 - Mark 'alive', the exception-variable, before catch-block.
 // 3.exc.3 - Mark 'init', the exception-variable, before catch-block.
 // 3.exc.4 - Mark 'out-of-scope', the exception-variable, after catch-block.
 //
-// 3.for.1 - Mark 'enrolled', the for-variable, ???.
+// 3.for.1 - Mark 'declared', the for-variable, ???.
 // 3.for.2 - Mark 'alive', the for-variable, before for-block.
 // 3.for.3 - Mark 'init', the for-variable, before for-block.
 // 3.for.4 - Mark 'out-of-scope', the for-variable, ???.
 //
-// 3.glo.1 - Mark 'enrolled', the global-variable, immediately.
+// 3.glo.1 - Mark 'declared', the global-variable, immediately.
 // 3.glo.2 - Mark 'alive', the global-variable, immediately.
 // 3.glo.3 - Mark 'init', the global-variable, immediately.
 // 3.glo.4 - Mark 'out-of-scope', the global-variable, never.
 //
-// 3.var.1 - Mark 'enrolled', the variable, during variable-initialization.
-// 3.var.2 - Mark 'alive', the variable, after variable-initialization.
+// 3.var.1 - Mark 'declared', the variable, during variable-declaration.
+// 3.var.2 - Mark 'alive', the variable, after variable-declaration.
 // 3.var.3 - Mark 'init', the variable, after assignment.
-// 3.var.3 - Mark 'init', the variable, during variable-initialization.
+// 3.var.3 - Mark 'init', the variable, during variable-declaration.
 // 3.var.4 - Mark 'out-of-scope', the variable, after block-scope.
 // 3.var.4 - Mark 'out-of-scope', the variable, after function-scope.
 //
-// 4.par.1 - Mark 'enrolled', the function-parameter, during destructuring.
-// 4.par.1 - Mark 'enrolled', the function-parameter, if unwrapped.
+// 4.par.1 - Mark 'declared', the function-parameter, during destructuring.
+// 4.par.1 - Mark 'declared', the function-parameter, if unwrapped.
 // 4.par.2 - Mark 'alive', the function-parameter, after destructuring.
 // 4.par.3 - Mark 'init', the function-parameter, if unwrapped.
 // 4.par.4 - Mark 'out-of-scope', the function-parameter, after function-scope.
 //
-// 5.lab.1 - Mark 'enrolled', the label-statement, before control-flow-block.
+// 5.lab.1 - Mark 'declared', the label-statement, before control-flow-block.
 // 5.lab.2 - Mark 'alive', the label-statement, before control-flow-block.
 // 5.lab.3 - Mark 'init', the label-statement, before control-flow-block.
 // 5.lab.4 - Mark 'out-of-scope', the label-statement, after control-flow-block.
@@ -5128,44 +5128,44 @@ function jslint_phase3_parse(state) {
         let earlier;
         let id = name.id;
         name_list.push(name);
-        if (init) {
-            name.init = true;
-        }
+        name.init = init;
+        name.readonly = readonly;
+        name.role = role;
         if (role === "variable") {
             name.arity = "variable";
         }
-        if (!enroll_parent) {
+        if (!declared_scope) {
             return;
         }
 
-// Enroll a name into the current function context. The role can be exception,
-// function, label, parameter, or variable. We look for variable redefinition
-// because it causes confusion.
+// Declare a name into the current declared_scope's context. The role can be
+// exception, function, label, parameter, or variable. We look for variable
+// redefinition because it causes confusion.
 
-// Reserved words may not be enrolled.
+// Reserved words may not be declared.
 
         if (syntax_dict[id] !== undefined && id !== "ignore") {
 
 // test_cause:
-// ["let undefined", "name_enroll", "reserved_a", "undefined", 5]
+// ["let undefined", "name_declare", "reserved_a", "undefined", 5]
 
             warn("reserved_a", name);
             return;
         }
 
-// Has the name been enrolled in this context?
+// Has the name been declared in this context?
 
         earlier = functionage.context[id] || catchage.context[id];
         if (earlier) {
 
 // test_cause:
-// ["let aa;let aa", "name_enroll", "redefinition_a_b", "1", 12]
+// ["let aa;let aa", "name_declare", "redefinition_a_b", "1", 12]
 
             warn("redefinition_a_b", name, id, earlier.line);
             return;
         }
 
-// Has the name been enrolled in an outer context?
+// Has the name been declared in an outer context?
 
         function_stack.forEach(function ({
             context
@@ -5176,7 +5176,7 @@ function jslint_phase3_parse(state) {
             if (earlier.role === "variable") {
 
 // test_cause:
-// ["let ignore;(ignore)=>0", "name_enroll", "redefinition_a_b", "1", 13]
+// ["let ignore;(ignore)=>0", "name_declare", "redefinition_a_b", "1", 13]
 
                 warn("redefinition_a_b", name, id, earlier.line);
             }
@@ -5189,8 +5189,8 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // function aa(){try{aa();}catch(aa){aa();}}
-// ", "name_enroll", "redefinition_a_b", "1", 31]
-// ["function aa(){var aa}", "name_enroll", "redefinition_a_b", "1", 19]
+// ", "name_declare", "redefinition_a_b", "1", 31]
+// ["function aa(){var aa}", "name_declare", "redefinition_a_b", "1", 19]
 
             warn("redefinition_a_b", name, id, earlier.line);
         } else if (
@@ -5200,18 +5200,15 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["let Array", "name_enroll", "redefinition_global_a_b", "Array", 5]
+// ["let Array", "name_declare", "redefinition_global_a_b", "Array", 5]
 
             warn("redefinition_global_a_b", name, global_dict[id], id);
         }
 
-// Enroll it.
+// Declare it.
 
-        enroll_parent.context[id] = name;
-        name.parent = enroll_parent;
-        name.readonly = readonly;
-        name.role = role;
-        name.used = 0;
+        declared_scope.context[id] = name;
+        name.declared_scope = declared_scope;
     }
 
     function parse_expression(rbp, initial) {
@@ -5519,11 +5516,11 @@ function jslint_phase3_parse(state) {
 // ["aa:while{}", "parse_statement", "the_statement_label", "while", 0]
 
                 test_cause("the_statement_label", token_nxt.id);
-                name_enroll(
+                name_declare(
 
-// 5.lab.1 - Mark 'enrolled', the label-statement, before control-flow-block.
+// 5.lab.1 - Mark 'declared', the label-statement, before control-flow-block.
 
-                    functionage,        // enroll_parent
+                    functionage,        // declared_scope
                     "label",            // role
                     true,               // readonly
                     [],                 // name_list
@@ -5756,7 +5753,7 @@ function jslint_phase3_parse(state) {
     }
 
     function prefix_destructure(
-        enroll_parent,
+        declared_scope,
         role,
         readonly,
         name_list,
@@ -5834,7 +5831,7 @@ function jslint_phase3_parse(state) {
                 test_cause("recurse_element");
                 advance_and_signature_push(token_nxt.id);
                 prefix_destructure(
-                    enroll_parent,      // enroll_parent
+                    declared_scope,     // declared_scope
                     role,               // role
                     readonly,           // readonly
                     name_list,          // name_list
@@ -5885,8 +5882,8 @@ function jslint_phase3_parse(state) {
                 }
                 token_nxt.label = name;
                 name = token_nxt;
-                name_enroll(
-                    enroll_parent,      // enroll_parent
+                name_declare(
+                    declared_scope,     // declared_scope
                     role,               // role
                     readonly,           // readonly
                     sub_list,           // name_list
@@ -5896,8 +5893,8 @@ function jslint_phase3_parse(state) {
                 advance_and_signature_push(token_nxt.id);
                 return;
             }
-            name_enroll(
-                enroll_parent,          // enroll_parent
+            name_declare(
+                declared_scope,         // declared_scope
                 role,                   // role
                 readonly,               // readonly
                 sub_list,               // name_list
@@ -6019,11 +6016,11 @@ function jslint_phase3_parse(state) {
         }
         if (name) {
             advance();
-            name_enroll(
+            name_declare(
 
-// 2.fun.1 - Mark 'enrolled', the function-name, immediately.
+// 2.fun.1 - Mark 'declared', the function-name, during function-declaration.
 
-                functionage,            // enroll_parent
+                functionage,            // declared_scope
                 (                       // role
                     the_function.arity === "statement"
                     ? "variable"
@@ -6033,12 +6030,12 @@ function jslint_phase3_parse(state) {
                 [],                     // name_list
                 name,                   // name
 
-// 2.fun.3 - Mark 'init', the function-name, immediately.
+// 2.fun.3 - Mark 'init', the function-name, during function-declaration.
 
                 true                    // init
             );
 
-// 2.fun.2 - Mark 'alive', the function-name, immediately.
+// 2.fun.2 - Mark 'alive', the function-name, during function-declaration.
 
             name.alive = true;
             if (the_function.arity === "statement") {
@@ -6051,7 +6048,7 @@ function jslint_phase3_parse(state) {
 // 2.fun.4 - Mark 'out-of-scope', the function-name, after expression-scope.
 
                 the_function.alive_list.push(name);
-                name.used += 1;
+                name.used = true;
             }
         }
 
@@ -6109,11 +6106,11 @@ function jslint_phase3_parse(state) {
 // ["aa=>0", "prefix_function", "wrap_fart_parameter", "aa", 1]
 
             warn("wrap_fart_parameter", token_prv);
-            name_enroll(
+            name_declare(
 
-// 4.par.1 - Mark 'enrolled', the function-parameter, if unwrapped.
+// 4.par.1 - Mark 'declared', the function-parameter, if unwrapped.
 
-                functionage,            // enroll_parent
+                functionage,            // declared_scope
                 "parameter",            // role
                 false,                  // readonly
                 the_function.name_list, // name_list
@@ -6131,9 +6128,9 @@ function jslint_phase3_parse(state) {
 
                 prefix_destructure(
 
-// 4.par.1 - Mark 'enrolled', the function-parameter, during destructuring.
+// 4.par.1 - Mark 'declared', the function-parameter, during destructuring.
 
-                    functionage,        // enroll_parent
+                    functionage,        // declared_scope
                     "parameter",        // role
                     false,              // readonly
                     the_function.name_list,     // name_list
@@ -6427,7 +6424,7 @@ function jslint_phase3_parse(state) {
 // PR-500 - Unify ES2015-destructure-logic. - [aa] = ...;
 
             element = prefix_destructure(
-                undefined,              // enroll_parent
+                undefined,              // declared_scope
                 "variable",             // role
                 false,                  // readonly
                 the_token.name_list,    // name_list
@@ -6625,7 +6622,7 @@ function jslint_phase3_parse(state) {
                     warn("not_label_a");
                 }
             } else {
-                the_label.used += 1;
+                the_label.used = true;
             }
             the_break.label = token_nxt;
             advance();
@@ -6762,7 +6759,7 @@ function jslint_phase3_parse(state) {
                 the_thing = parse_statement();
                 the_name = the_thing.name;
                 the_id = the_name.id;
-                the_name.used += 1;
+                the_name.used = true;
                 if (export_dict[the_id] !== undefined) {
 
 // test_cause:
@@ -6814,7 +6811,7 @@ function jslint_phase3_parse(state) {
 
                         warn("unexpected_a");
                     } else {
-                        the_name.used += 1;
+                        the_name.used = true;
                         if (export_dict[the_id] !== undefined) {
 
 // test_cause:
@@ -7013,11 +7010,11 @@ function jslint_phase3_parse(state) {
 
                     warn("unexpected_a", name);
                 }
-                name_enroll(
+                name_declare(
 
-// 1.imp.1 - Mark 'enrolled', the import-name, during import-statement.
+// 1.imp.1 - Mark 'declared', the import-name, during import-statement.
 
-                    functionage,        // enroll_parent
+                    functionage,        // declared_scope
                     "variable",         // role
                     true,               // readonly
                     the_import.name_list,       // name_list
@@ -7052,11 +7049,11 @@ function jslint_phase3_parse(state) {
 
                             warn("unexpected_a", name);
                         }
-                        name_enroll(
+                        name_declare(
 
-// 1.imp.1 - Mark 'enrolled', the import-name, during import-statement.
+// 1.imp.1 - Mark 'declared', the import-name, during import-statement.
 
-                            functionage,        // enroll_parent
+                            functionage,        // declared_scope
                             "variable", // role
                             true,       // readonly
                             the_import.name_list,       // name_list
@@ -7389,11 +7386,11 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id !== "ignore") {
                     ignored = undefined;
                     the_catch.name = token_nxt;
-                    name_enroll(
+                    name_declare(
 
-// 3.exc.1 - Mark 'enrolled', the exception-variable, before catch-block.
+// 3.exc.1 - Mark 'declared', the exception-variable, before catch-block.
 
-                        catchage,       // enroll_parent
+                        catchage,       // declared_scope
                         "exception",    // role
                         true,           // readonly
                         [],             // name_list
@@ -7523,7 +7520,7 @@ function jslint_phase3_parse(state) {
 // PR-500 - Unify ES2015-destructure-logic. - let [aa] = ...;
 
                 prefix_destructure(
-                    functionage,        // enroll_parent
+                    functionage,        // declared_scope
                     "variable",         // role
                     readonly,           // readonly
                     the_variable.name_list,     // name_list
@@ -7548,17 +7545,17 @@ function jslint_phase3_parse(state) {
                     advance("=");
                     name.expression = parse_expression(0);
                 }
-                name_enroll(
+                name_declare(
 
-// 3.var.1 - Mark 'enrolled', the variable, during variable-initialization.
+// 3.var.1 - Mark 'declared', the variable, during variable-declaration.
 
-                    functionage,        // enroll_parent
+                    functionage,        // declared_scope
                     "variable",         // role
                     readonly,           // readonly
                     the_variable.name_list,     // name_list
                     name,               // name
 
-// 3.var.3 - Mark 'init', the variable, during variable-initialization.
+// 3.var.3 - Mark 'init', the variable, during variable-declaration.
 
                     Boolean(name.expression)    // init
                 );
@@ -7865,8 +7862,6 @@ function jslint_phase3_parse(state) {
     symbol(":");
     symbol(";");
     symbol("]");
-    symbol("async");
-    symbol("await");
     symbol("case");
     symbol("catch");
     symbol("class");
@@ -8100,23 +8095,22 @@ function jslint_phase4_walk(state) {
 // 3.glo.2 - Mark 'alive', the global-variable, immediately.
 
                     alive: true,
+                    declared_scope: token_global,
                     id,
 
 // 3.glo.3 - Mark 'init', the global-variable, immediately.
 
                     init: true,
-                    parent: token_global,
                     readonly: true,
-                    role: "variable",
-                    used: 0
+                    role: "variable"
                 };
                 token_global.context[id] = the_variable;
             }
             the_variable.closure = true;
 
-// 3.glo.1 - Mark 'enrolled', the global-variable, immediately.
+// 3.glo.1 - Mark 'declared', the global-variable, immediately.
 
-            functionage.context[id] = the_variable;
+            token_global.context[id] = the_variable;
 
 // 3.glo.4 - Mark 'out-of-scope', the global-variable, never.
         }
@@ -8631,7 +8625,7 @@ function jslint_phase4_walk(state) {
 // PR-502 - Fix long-running regression where 'let x = x;'
 // doesn't warn about temporal-dead-zone.
 
-// 3.var.2 - Mark 'alive', the variable, after variable-initialization.
+// 3.var.2 - Mark 'alive', the variable, after variable-declaration.
 
             name.alive = true;
             switch (thing.id) {
@@ -8938,7 +8932,7 @@ function jslint_phase4_walk(state) {
 // //     function active_function() { ... }
 // // }
 //
-//             parent = functionage.name.parent;
+//             parent = functionage.name.declared_scope;
 //             if (parent) {
 //
 // // Step 4: Look up the variable we are calling ("foo")
@@ -8972,7 +8966,7 @@ function jslint_phase4_walk(state) {
 //                     left_variable !== undefined
 // // Probably deadcode.
 // // && !left_variable.alive
-//                     && left_variable.parent === parent
+//                     && left_variable.declared_scope === parent
 //                     && left_variable.calls !== undefined
 //                     && left_variable.calls[functionage.name.id] !== undefined
 //                 ) {
@@ -9011,7 +9005,7 @@ function jslint_phase4_walk(state) {
         let the_variable;
         if (thing.name !== undefined) {
 
-// 3.for.1 - Mark 'enrolled', the for-variable, ???.
+// 3.for.1 - Mark 'declared', the for-variable, ???.
 // 3.for.2 - Mark 'alive', the for-variable, before for-block.
 // 3.for.4 - Mark 'out-of-scope', the for-variable, ???.
 
@@ -9128,7 +9122,7 @@ function jslint_phase4_walk(state) {
         const the_variable = name_lookup(thing);
         if (the_variable !== undefined) {
             thing.variable = the_variable;
-            the_variable.used += 1;
+            the_variable.used = true;
         }
     }
 
@@ -9371,7 +9365,7 @@ function jslint_phase5_whitage(state) {
     function delve(the_function) {
         Object.keys(the_function.context).forEach(function (id) {
             const name = the_function.context[id];
-            if (id !== "ignore" && name.parent === the_function) {
+            if (id !== "ignore" && name.declared_scope === the_function) {
 
 // test_cause:
 // ["function aa(aa) {return aa;}", "delve", "id", "", 0]
@@ -10485,7 +10479,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
         html += detail("variable", list.filter(function (id) {
             return (
                 context[id].role === "variable"
-                && context[id].parent === the_function
+                && context[id].declared_scope === the_function
             );
         }));
         html += detail("exception", list.filter(function (id) {
@@ -10494,17 +10488,17 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
         html += detail("closure", list.filter(function (id) {
             return (
                 context[id].closure === true
-                && context[id].parent === the_function
+                && context[id].declared_scope === the_function
             );
         }));
         html += detail("outer", list.filter(function (id) {
             return (
-                context[id].parent !== the_function
-                && context[id].parent.id !== "(global)"
+                context[id].declared_scope.id !== "(global)"
+                && context[id].declared_scope !== the_function
             );
         }));
         html += detail(module, list.filter(function (id) {
-            return context[id].parent.id === "(global)";
+            return context[id].declared_scope.id === "(global)";
         }));
         html += detail("label", list.filter(function (id) {
             return context[id].role === "label";

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -291,6 +291,7 @@
     ok,
     on,
     open,
+    opener_stack,
     opening,
     option,
     option_dict,
@@ -1086,27 +1087,28 @@ function jslint(
 
 // The jslint function itself.
 
-    let catch_list = [];        // The array containing all catch-blocks.
-    let catch_stack = [         // The stack of catch-blocks.
+    const catch_list = [];      // The array containing all catch-blocks.
+    const catch_stack = [       // The stack of catch-blocks.
         {
             context: empty()
         }
     ];
-    let cause_dict = empty();   // The object of test-causes.
-    let directive_list = [];    // The directive comments.
-    let export_dict = empty();  // The exported names and values.
-    let function_list = [];     // The array containing all functions.
-    let function_stack = [];    // The stack of functions.
-    let global_dict = empty();  // The object containing the global
-                                // ... declarations.
-    let import_list = [];       // The array collecting all import-from strings.
-    let line_list = String(     // The array containing source lines.
+    const cause_dict = empty(); // The object of test-causes.
+    const directive_list = [];  // The directive comments.
+    const export_dict = empty();        // The exported names and values.
+    const function_list = [];   // The array containing all functions.
+    const function_stack = [];  // The stack of functions.
+    const global_dict = empty();        // The object containing the global
+                                        // ... declarations.
+    const import_list = [];     // The array collecting all import-from strings.
+    const line_list = String(   // The array containing source lines.
         "\n" + source
     ).split(jslint_rgx_crlf).map(function (line_source) {
         return {
             line_source
         };
     });
+    const opener_stack = [];    // Stack of opener tokens: (, [.
     let mode_stop = false;      // true if JSLint cannot finish.
     let property_dict = empty();        // The object containing the tallied
                                         // ... property names.
@@ -1764,6 +1766,7 @@ function jslint(
             mode_property: false,       // true if directive /*property*/ is
                                         // ... used.
             mode_shebang: false,        // true if #! is seen on the first line.
+            opener_stack,
             option_dict,
             property_dict,
             source,
@@ -1783,28 +1786,25 @@ function jslint(
 // PHASE 1. Split <source> by newlines into <line_list>.
 
         jslint_phase1_split(state);
-        jslint_assert(catch_stack.length === 1, `catch_stack.length === 1.`);
-        jslint_assert(
-            function_stack.length === 0,
-            `function_stack.length === 0.`
-        );
 
 // PHASE 2. Lex <line_list> into <token_list>.
 
         jslint_phase2_lex(state);
-        jslint_assert(catch_stack.length === 1, `catch_stack.length === 1.`);
-        jslint_assert(
-            function_stack.length === 0,
-            `function_stack.length === 0.`
-        );
 
 // PHASE 3. Parse <token_list> into <token_tree> using the Pratt-parser.
 
         jslint_phase3_parse(state);
-        jslint_assert(catch_stack.length === 1, `catch_stack.length === 1.`);
+        jslint_assert(
+            catch_stack.length === 1,
+            `catch_stack.length=${catch_stack.length}.`
+        );
         jslint_assert(
             function_stack.length === 0,
-            `function_stack.length === 0.`
+            `function_stack.length=${function_stack.length}.`
+        );
+        jslint_assert(
+            opener_stack.length === 0,
+            `opener_stack.length=${opener_stack.length}.`
         );
 
 // PHASE 4. Walk <token_tree>, traversing all nodes of the tree. It is a
@@ -1814,10 +1814,13 @@ function jslint(
         if (!state.mode_json) {
             jslint_phase4_walk(state);
         }
-        jslint_assert(catch_stack.length === 1, `catch_stack.length === 1.`);
+        jslint_assert(
+            catch_stack.length === 1,
+            `catch_stack.length=${catch_stack.length}.`
+        );
         jslint_assert(
             function_stack.length === 0,
-            `function_stack.length === 0.`
+            `function_stack.length=${function_stack.length}.`
         );
 
 // PHASE 5. Check whitespace between tokens in <token_list>.
@@ -1825,10 +1828,9 @@ function jslint(
         if (!state.mode_json && warning_list.length === 0) {
             jslint_phase5_whitage(state);
         }
-        jslint_assert(catch_stack.length === 1, `catch_stack.length === 1.`);
         jslint_assert(
-            function_stack.length === 0,
-            `function_stack.length === 0.`
+            opener_stack.length === 0,
+            `opener_stack.length=${opener_stack.length}.`
         );
 
 // PR-347 - Disable warning "missing_browser".
@@ -2656,6 +2658,7 @@ function jslint_phase2_lex(state) {
         global_dict,
         global_list,
         line_list,
+        opener_stack,
         option_dict,
         stop,
         stop_at,
@@ -2683,7 +2686,6 @@ function jslint_phase2_lex(state) {
     let mode_regexp;            // true if regular expression literal seen on
                                 // ... this line.
     let opener_popped = empty();        // Last token popped from opener_stack.
-    let opener_stack = [];      // Stack of opener tokens: (, [.
     let snippet = "";           // A piece of string.
     let token_1;                // The first token.
     let token_prv = token_global;       // The previous token including
@@ -6788,7 +6790,9 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["for(const aa in aa){}", "stmt_for", "unexpected_a", "const", 5]
 
-            return stop("unexpected_a");
+            warn("unexpected_a");
+            advance();
+            break;
         }
         first = parse_expression(0);
         if (first.id === "in") {
@@ -6802,6 +6806,12 @@ function jslint_phase3_parse(state) {
             the_for.name = first.expression[0];
             the_for.expression = first.expression[1];
             warn("expected_a_b", the_for, "Object.keys", "for in");
+        } else if (first.id === "of") {
+
+// Issue #176 - Add ES2015-feature for..of.
+
+            the_for.name = first.expression[0];
+            the_for.expression = first.expression[1];
         } else {
             the_for.initial = first;
             advance(";");
@@ -7665,6 +7675,10 @@ function jslint_phase3_parse(state) {
     infix(110, ">=");
     infix(110, "in");
     infix(110, "instanceof");
+
+// Issue #176 - Add ES2015-feature for..of.
+
+    infix(110, "of");
     infix(120, "<<");
     infix(120, ">>");
     infix(120, ">>>");
@@ -8520,7 +8534,7 @@ function jslint_phase4_walk(state) {
         });
     }
 
-    function post_t(thing) {
+    function post_ternary(thing) {
         if (
             is_weird(thing.expression[0])
             || thing.expression[0].constant === true
@@ -8528,20 +8542,20 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["let aa=(aa?`${0}`:`${0}`)", "post_t", "unexpected_a", "?", 11]
-// ["let aa=(aa?`0`:`0`)", "post_t", "unexpected_a", "?", 11]
+// ["let aa=(aa?`${0}`:`${0}`)", "post_ternary", "unexpected_a", "?", 11]
+// ["let aa=(aa?`0`:`0`)", "post_ternary", "unexpected_a", "?", 11]
 
             warn("unexpected_a", thing);
         } else if (is_equal(thing.expression[0], thing.expression[1])) {
 
 // test_cause:
-// ["aa?aa:0", "post_t", "expected_a_b", "?", 3]
+// ["aa?aa:0", "post_ternary", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "||", "?");
         } else if (is_equal(thing.expression[0], thing.expression[2])) {
 
 // test_cause:
-// ["aa?0:aa", "post_t", "expected_a_b", "?", 3]
+// ["aa?0:aa", "post_ternary", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "&&", "?");
         } else if (
@@ -8550,7 +8564,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa?true:false", "post_t", "expected_a_b", "?", 3]
+// ["aa?true:false", "post_ternary", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "Boolean(...)", "?");
         } else if (
@@ -8559,7 +8573,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa?false:true", "post_t", "expected_a_b", "?", 3]
+// ["aa?false:true", "post_ternary", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "!", "?");
         } else if (
@@ -8571,7 +8585,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["(aa&&!aa?0:1)", "post_t", "wrap_condition", "&&", 4]
+// ["(aa&&!aa?0:1)", "post_ternary", "wrap_condition", "&&", 4]
 
             warn("wrap_condition", thing.expression[0]);
         }
@@ -9120,7 +9134,7 @@ function jslint_phase4_walk(state) {
     postaction("statement", "try", post_s_try);
     postaction("statement", "var", post_s_var);
     postaction("statement", "{", post_s_lbrace_pop_block);
-    postaction("ternary", post_t);
+    postaction("ternary", post_ternary);
     postaction("unary", "+", post_u_plus);
     postaction("unary", "function", post_s_function);
     postaction("unary", post_u);
@@ -9157,7 +9171,7 @@ function jslint_phase5_whitage(state) {
         artifact,
         catch_list,
         function_list,
-        function_stack,
+        opener_stack,
         option_dict,
         test_cause,
         token_global,
@@ -9346,7 +9360,7 @@ function jslint_phase5_whitage(state) {
 
 // If right is a closer, then pop the previous state.
 
-        indentage = function_stack.pop();
+        indentage = opener_stack.pop();
         closer = indentage.closer;
         free = indentage.free;
         margin = indentage.margin;
@@ -9659,7 +9673,7 @@ function jslint_phase5_whitage(state) {
             open,
             opening
         };
-        function_stack.push(indentage);
+        opener_stack.push(indentage);
 
 // Commit 3903449a - Cleanup indent for multiline-method-chaining.
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -1741,6 +1741,7 @@ function jslint(
 // automatic semicolon insertion and nested megastring literals, which allows
 // full tokenization to precede parsing.
 
+        block_list.push(token_global);
         option_dict = {
             ...option_dict
         };
@@ -4421,8 +4422,7 @@ function jslint_phase3_parse(state) {
             advance("{");
         }
         the_block = token_now;
-        block_stack.push(blockage);
-        blockage = token_now;
+        block_stack_push(token_now);
         if (special !== "body") {
             functionage.statement_prv = the_block;
         }
@@ -4454,9 +4454,16 @@ function jslint_phase3_parse(state) {
         } else {
             the_block.disrupt = stmts[stmts.length - 1].disrupt;
         }
-        advance("}");
         blockage = jslint_assert_and_pop(block_stack, "block_stack");
+        advance("}");
         return the_block;
+    }
+
+    function block_stack_push(blockage_nxt) {
+        block_stack.push(blockage);
+        blockage = blockage_nxt;
+        blockage.context = empty();
+        block_list.push(blockage);
     }
 
     function check_left(left, right) {
@@ -5085,13 +5092,11 @@ function jslint_phase3_parse(state) {
 // 1.imp.1 - Mark 'declared', the import-name, during import-statement.
 // 1.imp.2 - Mark 'alive', the import-name, after import-statement.
 // 1.imp.3 - Mark 'init', the import-name, during import-statement.
-// 1.imp.4 - Mark 'out-of-scope', the import-name, after module-scope.
 //
 // 2.fun.1 - Mark 'declared', the function-name, during function-declaration.
 // 2.fun.2 - Mark 'alive', the function-name, during function-declaration.
 // 2.fun.3 - Mark 'init', the function-name, during function-declaration.
 // 2.fun.4 - Mark 'out-of-scope', the function-name, after function-body.
-// 2.fun.4 - Mark 'out-of-scope', the function-name, after function-scope.
 //
 // 3.cat.1 - Mark 'declared', the catch-variable, before catch-block.
 // 3.cat.2 - Mark 'alive', the catch-variable, before catch-block.
@@ -5105,25 +5110,21 @@ function jslint_phase3_parse(state) {
 // 3.glo.1 - Mark 'declared', the global-variable, immediately.
 // 3.glo.2 - Mark 'alive', the global-variable, immediately.
 // 3.glo.3 - Mark 'init', the global-variable, immediately.
-// 3.glo.4 - Mark 'out-of-scope', the global-variable, never.
 //
 // 3.var.1 - Mark 'declared', the variable, during variable-declaration.
 // 3.var.2 - Mark 'alive', the variable, after variable-declaration.
 // 3.var.3 - Mark 'init', the variable, after assignment.
 // 3.var.3 - Mark 'init', the variable, during variable-declaration.
 // 3.var.4 - Mark 'out-of-scope', the variable, after block-scope.
-// 3.var.4 - Mark 'out-of-scope', the variable, after function-scope.
 //
 // 4.par.1 - Mark 'declared', the function-parameter, during destructuring.
 // 4.par.1 - Mark 'declared', the function-parameter, if unwrapped.
 // 4.par.2 - Mark 'alive', the function-parameter, after destructuring.
 // 4.par.3 - Mark 'init', the function-parameter, if unwrapped.
-// 4.par.4 - Mark 'out-of-scope', the function-parameter, after function-scope.
 //
 // 5.lab.1 - Mark 'declared', the label-statement, before control-flow-block.
 // 5.lab.2 - Mark 'alive', the label-statement, before control-flow-block.
 // 5.lab.3 - Mark 'init', the label-statement, before control-flow-block.
-// 5.lab.4 - Mark 'out-of-scope', the label-statement, after control-flow-block.
 
         let earlier;
         let id = name.id;
@@ -5155,7 +5156,7 @@ function jslint_phase3_parse(state) {
 
 // Has the name been declared in this context?
 
-        earlier = declared_scope?.context?.[id];
+        earlier = declared_scope.context[id];
         if (earlier) {
 
 // test_cause:
@@ -5167,10 +5168,8 @@ function jslint_phase3_parse(state) {
 
 // Has the name been declared in an outer context?
 
-        function_stack.forEach(function ({
-            context
-        }) {
-            earlier = context[id] || earlier;
+        block_stack.forEach(function (blockage) {
+            earlier = blockage.context[id] || earlier;
         });
         if (earlier && id === "ignore") {
             if (earlier.role === "variable") {
@@ -5535,10 +5534,6 @@ function jslint_phase3_parse(state) {
 
                 the_label.alive = true;
                 the_statement = parse_statement();
-
-// 5.lab.4 - Mark 'out-of-scope', the label-statement, after control-flow-block.
-
-                the_label.alive = false;
                 functionage.statement_prv = the_statement;
                 the_statement.label = the_label;
                 the_statement.statement = true;
@@ -6021,6 +6016,11 @@ function jslint_phase3_parse(state) {
 // 2.fun.1 - Mark 'declared', the function-name, during function-declaration.
 
                 functionage,            // declared_scope
+                //!! (                       // declared_scope
+                    //!! the_function.arity === "statement"
+                    //!! ? functionage
+                    //!! : the_function
+                //!! ),
                 (                       // role
                     the_function.arity === "statement"
                     ? "variable"
@@ -6038,12 +6038,7 @@ function jslint_phase3_parse(state) {
 // 2.fun.2 - Mark 'alive', the function-name, during function-declaration.
 
             name.alive = true;
-            if (the_function.arity === "statement") {
-
-// 2.fun.4 - Mark 'out-of-scope', the function-name, after function-scope.
-
-                functionage.alive_list.push(name);
-            } else {
+            if (the_function.arity !== "statement") {
 
 // 2.fun.4 - Mark 'out-of-scope', the function-name, after function-body.
 
@@ -6089,8 +6084,7 @@ function jslint_phase3_parse(state) {
 
 // Push the current function context and establish a new one.
 
-        block_stack.push(blockage);
-        blockage = the_function;
+        block_stack_push(the_function);
         function_list.push(the_function);
         function_stack.push(functionage);
         functionage = the_function;
@@ -7373,10 +7367,7 @@ function jslint_phase3_parse(state) {
 
 // Create new catch-scope for catch-parameter.
 
-            block_stack.push(blockage);
-            blockage = the_catch;
-            block_list.push(blockage);
-            the_catch.context = empty();
+            block_stack_push(the_catch);
             if (token_nxt.id === "(") {
                 advance("(");
                 if (!token_nxt.identifier) {
@@ -8065,14 +8056,14 @@ function jslint_phase4_walk(state) {
 
 // Look up the variable in the current context.
 
-        the_variable = functionage.context[id];
+        the_variable = blockage.context[id];
 
 // If it isn't local, search all the other contexts. If there are name
 // collisions, take the most recent.
 
         if (!the_variable) {
             block_stack.forEach(function (blockage) {
-                the_variable = blockage?.context?.[id] || the_variable;
+                the_variable = blockage.context[id] || the_variable;
             });
             if (!the_variable && !global_dict[id]) {
 
@@ -8110,9 +8101,6 @@ function jslint_phase4_walk(state) {
 // 3.glo.1 - Mark 'declared', the global-variable, immediately.
 
             token_global.context[id] = the_variable;
-
-// 3.glo.4 - Mark 'out-of-scope', the global-variable, never.
-
         }
         if (the_variable?.role === "label") {
 
@@ -8571,10 +8559,6 @@ function jslint_phase4_walk(state) {
 // 1.imp.2 - Mark 'alive', the import-name, after import-statement.
 
             name.alive = true;
-
-// 1.imp.4 - Mark 'out-of-scope', the import-name, after module-scope.
-
-            blockage.alive_list.push(name);
         });
         post_s_export_toplevel(the_thing);
     }
@@ -8631,12 +8615,6 @@ function jslint_phase4_walk(state) {
 
                 blockage.alive_list.push(name);
                 break;
-            // case "var":
-            default:
-
-// 3.var.4 - Mark 'out-of-scope', the variable, after function-scope.
-
-                functionage.alive_list.push(name);
             }
         });
     }
@@ -9090,10 +9068,6 @@ function jslint_phase4_walk(state) {
 // 4.par.2 - Mark 'alive', the function-parameter, after destructuring.
 
             name.alive = true;
-
-// 4.par.4 - Mark 'out-of-scope', the function-parameter, after function-scope.
-
-            functionage.alive_list.push(name);
         });
     }
 
@@ -9285,7 +9259,6 @@ function jslint_phase5_whitage(state) {
         artifact,
         block_list,
         block_stack,
-        function_list,
         option_dict,
         test_cause,
         token_global,
@@ -9873,9 +9846,7 @@ function jslint_phase5_whitage(state) {
 
 // PR-502 - tighten warning of unused variables to be always on.
 
-    delve(token_global);
     block_list.forEach(delve);
-    function_list.forEach(delve);
     if (option_dict.white) {
         return;
     }

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -240,7 +240,8 @@
     jstestIt,
     jstestOnExit,
     keys,
-    label_goto,
+    label_break,
+    label_name,
     lbp,
     led_infix,
     length,
@@ -1564,9 +1565,6 @@ function jslint(
         case "nested_comment":
             mm = `Nested comment.`;
             break;
-        case "not_label_a":
-            mm = `'${a}' is not a label.`;
-            break;
         case "number_isNaN":
             mm = `Use Number.isNaN function to compare with NaN.`;
             break;
@@ -1614,6 +1612,9 @@ function jslint(
             break;
         case "undeclared_a":
             mm = `Undeclared '${a}'.`;
+            break;
+        case "undeclared_label_a":
+            mm = `Undeclared label '${a}'.`;
             break;
         case "unexpected_a":
             mm = `Unexpected '${a}'.`;
@@ -4451,8 +4452,7 @@ function jslint_phase3_parse(state) {
 // - do-while
 
 // test_cause:
-// ["do;while(0);", "block", "expected_a", "{", 12]
-// ["do;while(0);", "block", "expected_a", "{", 3]
+// ["do;while(0)", "block", "expected_a", "{", 3]
 // ["for(;;);", "block", "expected_a", "{", 8]
 // ["if(0);else if(0);else;", "block", "expected_a", "{", 17]
 // ["if(0);else if(0);else;", "block", "expected_a", "{", 22]
@@ -5154,10 +5154,9 @@ function jslint_phase3_parse(state) {
 // 4.par.2 - Mark 'alive', the function-parameter, after destructuring.
 // 4.par.3 - Mark 'init', the function-parameter, if unwrapped.
 //
-// 5.lab.1 - Mark 'declared', the statement-label, before control-flow-block.
-// 5.lab.2 - Mark 'alive', the statement-label, before control-flow-block.
-// 5.lab.3 - Mark 'init', the statement-label, before control-flow-block.
-// 5.lab.4 - Mark 'out-of-scope', the statement-label, after control-flow-block.
+// 5.lab.1 - Mark 'declared', the label-name, before control-flow-block.
+// 5.lab.2 - Mark 'alive', the label-name, before control-flow-block.
+// 5.lab.3 - Mark 'init', the label-name, before control-flow-block.
 
         const id = name.id;
         let earlier;
@@ -5193,6 +5192,7 @@ function jslint_phase3_parse(state) {
         if (earlier) {
 
 // test_cause:
+// ["aa:let aa", "name_declare", "scope_current", "aa", 0]
 // ["let aa;(function aa(){})", "name_declare", "scope_current", "aa", 0]
 // ["let aa;function aa(){}", "name_declare", "scope_current", "aa", 0]
 // ["let aa;let aa", "name_declare", "scope_current", "aa", 0]
@@ -5206,6 +5206,31 @@ function jslint_phase3_parse(state) {
 
         block_stack.slice(1).some(function (scope_block) {
             earlier = scope_block.context[id];
+            switch (Boolean(earlier) && role) {
+            case "label":
+                if (earlier.role !== "label") {
+
+// test_cause:
+// ["let aa;aa:0", "name_declare", "label_vs_not_label", "aa", 0]
+
+                    test_cause("label_vs_not_label", id);
+                    warn("redefinition_a_b", name, id, earlier.line);
+                    earlier = undefined;
+                }
+                break;
+            case false:
+                break;
+            default:
+                if (earlier.role === "label") {
+
+// test_cause:
+// ["aa:{let aa}", "name_declare", "default_vs_label", "aa", 0]
+
+                    test_cause("default_vs_label", id);
+                    warn("redefinition_a_b", name, id, earlier.line);
+                    earlier = undefined;
+                }
+            }
             return earlier;
         });
 
@@ -5593,10 +5618,11 @@ function jslint_phase3_parse(state) {
         }
         advance();
         if (token_now.identifier && token_nxt.id === ":") {
-            the_statement = stmt_label();
-            if (the_statement) {
-                return the_statement;
-            }
+            //!! the_statement = stmt_label();
+            //!! if (the_statement) {
+                //!! return the_statement;
+            //!! }
+            return stmt_label();
         }
 
 // Parse the statement.
@@ -6605,31 +6631,25 @@ function jslint_phase3_parse(state) {
         }
         the_break.disrupt = true;
         if (token_nxt.identifier && token_now.line === token_nxt.line) {
-            the_label = scope_function.context[token_nxt.id];
-            if (
-                !the_label
-                || the_label.role !== "label"
-                || !the_label.alive
-            ) {
-                if (the_label && !the_label.alive) {
-
-// Warn statement-label is 'out-of-scope'.
-
-// test_cause:
-// ["aa:{function aa(aa){break aa}}", "stmt_break", "out_of_scope_a", "aa", 27]
-
-                    warn("out_of_scope_a");
-                } else {
-
-// test_cause:
-// ["aa:{break aa}", "stmt_break", "not_label_a", "aa", 11]
-
-                    warn("not_label_a");
+            block_stack.some(function (scope_block) {
+                the_label = scope_block.context[token_nxt.id];
+                if (the_label?.role !== "label") {
+                    the_label = undefined;
                 }
-            } else {
-                the_label.used = true;
+                if (the_label) {
+                    the_label.used = true;
+                    return true;
+                }
+            });
+            if (!the_label) {
+
+// test_cause:
+// ["aa:while(0){}break aa", "stmt_break", "undeclared_label_a", "aa", 20]
+// ["break aa", "stmt_break", "undeclared_label_a", "aa", 7]
+
+                warn("undeclared_label_a", token_nxt);
             }
-            the_break.label_goto = token_nxt;
+            the_break.label_break = token_nxt;
             advance();
         }
         semicolon();
@@ -6643,8 +6663,8 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["continue", "stmt_continue", "unexpected_a", "continue", 1]
 // ["
-// function aa(){while(0){try{}finally{continue}}}
-// ", "stmt_continue", "unexpected_a", "continue", 37]
+// while(0){try{}finally{continue}}
+// ", "stmt_continue", "unexpected_a", "continue", 23]
 
             warn("unexpected_a", the_continue);
         }
@@ -6697,7 +6717,7 @@ function jslint_phase3_parse(state) {
         if (the_do.block.disrupt === true) {
 
 // test_cause:
-// ["function aa(){do{break}while(0)}", "stmt_do", "weird_loop", "do", 15]
+// ["do{break}while(0)", "stmt_do", "weird_loop", "do", 1]
 
             warn("weird_loop", the_do);
         }
@@ -7214,6 +7234,11 @@ function jslint_phase3_parse(state) {
     function stmt_label() {
         const the_label = token_now;
         let the_statement;
+
+// PR-xxx - Add hidden scope_block for:
+// - label-name
+
+        scope_block = scope_block_push(the_label, true);
         if (the_label.id === "ignore") {
 
 // test_cause:
@@ -7247,35 +7272,31 @@ function jslint_phase3_parse(state) {
 // ["aa:bb:0", "stmt_label", "unexpected_label_a", "aa", 1]
 
             warn("unexpected_label_a", the_label);
-            advance();
-            return;
+            //!! advance();
+            //!! return;
         }
         name_declare(
 
-// 5.lab.1 - Mark 'declared', the statement-label, before control-flow-block.
+// 5.lab.1 - Mark 'declared', the label-name, before control-flow-block.
 
-            scope_function,     // scope_declared
+            scope_block,        // scope_declared
             "label",            // role
             true,               // readonly
             [],                 // name_list
             the_label,          // name
 
-// 5.lab.3 - Mark 'init', the statement-label, before control-flow-block.
+// 5.lab.3 - Mark 'init', the label-name, before control-flow-block.
 
             true                // init
         );
 
-// 5.lab.2 - Mark 'alive', the statement-label, before control-flow-block.
+// 5.lab.2 - Mark 'alive', the label-name, before control-flow-block.
 
         the_label.alive = true;
         the_statement = parse_statement_single();
-
-// 5.lab.4 - Mark 'out-of-scope', the statement-label, after control-flow-block.
-
-        the_label.alive = false;
-        //!! the_statement.label = the_label;
-        //!! the_statement.statement = true;
+        the_statement.label_name = the_label;
         scope_function.statement_prv = the_statement;
+        scope_block = scope_block_pop();
         return the_statement;
     }
 
@@ -7417,7 +7438,7 @@ function jslint_phase3_parse(state) {
             the_cases.push(the_case);
             last = parsed_block[parsed_block.length - 1];
             if (last.disrupt) {
-                if (last.id === "break" && last.label_goto === undefined) {
+                if (last.id === "break" && last.label_break === undefined) {
                     the_disrupt = false;
                 }
             } else {
@@ -7472,7 +7493,7 @@ function jslint_phase3_parse(state) {
                 ];
                 if (
                     the_last.id === "break"
-                    && the_last.label_goto === undefined
+                    && the_last.label_break === undefined
                 ) {
 
 // test_cause:
@@ -7826,7 +7847,7 @@ function jslint_phase3_parse(state) {
         if (the_while.block.disrupt === true) {
 
 // test_cause:
-// ["function aa(){while(0){break}}", "stmt_while", "weird_loop", "while", 15]
+// ["while(0){break}", "stmt_while", "weird_loop", "while", 1]
 
             warn("weird_loop", the_while);
         }
@@ -8307,8 +8328,6 @@ function jslint_phase4_walk(state) {
 // ["if(0){function aa(){}}aa", "name_lookup", "undeclared_a", "aa", 23]
 // ["if(0){let aa}aa", "name_lookup", "undeclared_a", "aa", 14]
 // ["try{}catch(aa){}aa", "name_lookup", "undeclared_a", "aa", 17]
-
-//!! // ["aa:while(0){}aa", "name_lookup", "undeclared_a", "aa", 14]
 
             warn("undeclared_a", thing);
             return;
@@ -9268,6 +9287,13 @@ function jslint_phase4_walk(state) {
             thing.forEach(walk_statement);
             return;
         }
+
+// PR-xxx - Add hidden scope_block for:
+// - label-name
+
+        if (thing.label_name) {
+            scope_block = scope_block_push(thing.label_name, false);
+        }
         if (thing.scope_block) {
             scope_block = scope_block_push(thing, false);
         }
@@ -9303,6 +9329,9 @@ function jslint_phase4_walk(state) {
         walk_statement(thing.else);
         postamble(thing);
         if (thing.scope_block) {
+            scope_block = scope_block_pop();
+        }
+        if (thing.label_name) {
             scope_block = scope_block_pop();
         }
     }

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -4400,7 +4400,7 @@ function jslint_phase3_parse(state) {
 //          "naked"     No advance.
 //          undefined   An ordinary block.
 
-        let stmts;
+        let parsed_block;
         let the_block;
         if (special !== "naked") {
             advance("{");
@@ -4424,9 +4424,9 @@ function jslint_phase3_parse(state) {
             advance("(string)");
             semicolon();
         }
-        stmts = parse_statements();
-        the_block.block = stmts;
-        if (stmts.length === 0) {
+        parsed_block = parse_statement_block();
+        the_block.block = parsed_block;
+        if (parsed_block.length === 0) {
             if (!option_dict.devel && special !== "ignore") {
 
 // test_cause:
@@ -4436,7 +4436,7 @@ function jslint_phase3_parse(state) {
             }
             the_block.disrupt = false;
         } else {
-            the_block.disrupt = stmts[stmts.length - 1].disrupt;
+            the_block.disrupt = parsed_block[parsed_block.length - 1].disrupt;
         }
         blockage = block_stack_pop(block_stack);
         advance("}");
@@ -5464,7 +5464,49 @@ function jslint_phase3_parse(state) {
         }
     }
 
-    function parse_statement() {
+    function parse_statement_block() {
+
+// Parse a list of statements. Give a warning if an unreachable statement
+// follows a disruptive statement.
+
+        const statement_list = [];
+        let a_statement;
+        let disrupt = false;
+
+// Parse/loop each statement until a statement-terminator is reached.
+
+        while (true) {
+            switch (token_nxt.id) {
+            case "(end)":
+            case "case":
+            case "default":
+            case "else":
+            case "}":
+
+// test_cause:
+// [";", "parse_statement_block", "closer", "", 0]
+// ["case", "parse_statement_block", "closer", "", 0]
+// ["default", "parse_statement_block", "closer", "", 0]
+// ["else", "parse_statement_block", "closer", "", 0]
+// ["}", "parse_statement_block", "closer", "", 0]
+
+                test_cause("closer");
+                return statement_list;
+            }
+            a_statement = parse_statement_single();
+            statement_list.push(a_statement);
+            if (disrupt) {
+
+// test_cause:
+// ["while(0){break;0}", "parse_statement_block", "unreachable_a", "0", 16]
+
+                warn("unreachable_a", a_statement);
+            }
+            disrupt = a_statement.disrupt;
+        }
+    }
+
+    function parse_statement_single() {
 
 // Parse a statement. Any statement may have a label, but only four statements
 // have use for one. A statement can be one of the standard statements, or
@@ -5480,7 +5522,7 @@ function jslint_phase3_parse(state) {
             if (the_label.id === "ignore") {
 
 // test_cause:
-// ["ignore:", "parse_statement", "unexpected_a", "ignore", 1]
+// ["ignore:", "parse_statement_single", "unexpected_a", "ignore", 1]
 
                 warn("unexpected_a", the_label);
             }
@@ -5492,10 +5534,10 @@ function jslint_phase3_parse(state) {
             case "while":
 
 // test_cause:
-// ["aa:do", "parse_statement", "label", "do", 0]
-// ["aa:for", "parse_statement", "label", "for", 0]
-// ["aa:switch", "parse_statement", "label", "switch", 0]
-// ["aa:while", "parse_statement", "label", "while", 0]
+// ["aa:do", "parse_statement_single", "label", "do", 0]
+// ["aa:for", "parse_statement_single", "label", "for", 0]
+// ["aa:switch", "parse_statement_single", "label", "switch", 0]
+// ["aa:while", "parse_statement_single", "label", "while", 0]
 
                 test_cause("label", token_nxt.id);
                 name_declare(
@@ -5516,7 +5558,7 @@ function jslint_phase3_parse(state) {
 // 5.lab.2 - Mark 'alive', the label-statement, before control-flow-block.
 
                 the_label.alive = true;
-                the_statement = parse_statement();
+                the_statement = parse_statement_single();
 
 // 5.lab.4 - Mark 'out-of-scope', the label-statement, after control-flow-block.
 
@@ -5528,12 +5570,12 @@ function jslint_phase3_parse(state) {
             default:
 
 // test_cause:
-// ["()=>{aa:0}", "parse_statement", "unexpected_label_a", "aa", 6]
-// [";{aa:0}", "parse_statement", "unexpected_label_a", "aa", 3]
-// ["aa:", "parse_statement", "unexpected_label_a", "aa", 1]
-// ["aa:0", "parse_statement", "unexpected_label_a", "aa", 1]
-// ["aa:0?0:0", "parse_statement", "unexpected_label_a", "aa", 1]
-// ["aa:bb:0", "parse_statement", "unexpected_label_a", "aa", 1]
+// ["()=>{aa:0}", "parse_statement_single", "unexpected_label_a", "aa", 6]
+// [";{aa:0}", "parse_statement_single", "unexpected_label_a", "aa", 3]
+// ["aa:", "parse_statement_single", "unexpected_label_a", "aa", 1]
+// ["aa:0", "parse_statement_single", "unexpected_label_a", "aa", 1]
+// ["aa:0?0:0", "parse_statement_single", "unexpected_label_a", "aa", 1]
+// ["aa:bb:0", "parse_statement_single", "unexpected_label_a", "aa", 1]
 
                 warn("unexpected_label_a", the_label);
                 advance();
@@ -5565,7 +5607,7 @@ function jslint_phase3_parse(state) {
             if (the_statement.wrapped && the_statement.id !== "(") {
 
 // test_cause:
-// ["(0)", "parse_statement", "unexpected_a", "(", 1]
+// ["(0)", "parse_statement_single", "unexpected_a", "(", 1]
 
                 warn("unexpected_a", first);
             }
@@ -5573,48 +5615,6 @@ function jslint_phase3_parse(state) {
         }
         functionage.statement_prv = the_statement;
         return the_statement;
-    }
-
-    function parse_statements() {
-
-// Parse a list of statements. Give a warning if an unreachable statement
-// follows a disruptive statement.
-
-        const statement_list = [];
-        let a_statement;
-        let disrupt = false;
-
-// Parse/loop each statement until a statement-terminator is reached.
-
-        while (true) {
-            switch (token_nxt.id) {
-            case "(end)":
-            case "case":
-            case "default":
-            case "else":
-            case "}":
-
-// test_cause:
-// [";", "parse_statements", "closer", "", 0]
-// ["case", "parse_statements", "closer", "", 0]
-// ["default", "parse_statements", "closer", "", 0]
-// ["else", "parse_statements", "closer", "", 0]
-// ["}", "parse_statements", "closer", "", 0]
-
-                test_cause("closer");
-                return statement_list;
-            }
-            a_statement = parse_statement();
-            statement_list.push(a_statement);
-            if (disrupt) {
-
-// test_cause:
-// ["while(0){break;0}", "parse_statements", "unreachable_a", "0", 16]
-
-                warn("unreachable_a", a_statement);
-            }
-            disrupt = a_statement.disrupt;
-        }
     }
 
     function postassign(id) {
@@ -6745,7 +6745,7 @@ function jslint_phase3_parse(state) {
 // ["export function aa(){}", "stmt_export", "freeze_exports", "function", 8]
 
                 warn("freeze_exports");
-                the_thing = parse_statement();
+                the_thing = parse_statement_single();
                 the_name = the_thing.name;
                 the_id = the_name.id;
                 the_name.used = true;
@@ -6774,7 +6774,7 @@ function jslint_phase3_parse(state) {
 // ["export var", "stmt_export", "unexpected_a", "var", 8]
 
                 warn("unexpected_a");
-                parse_statement();
+                parse_statement_single();
             } else if (token_nxt.id === "{") {
 
 // test_cause:
@@ -6929,7 +6929,7 @@ function jslint_phase3_parse(state) {
             the_else = token_now;
             the_if.else = (
                 token_nxt.id === "if"
-                ? parse_statement()
+                ? parse_statement_single()
                 : block()
             );
 
@@ -7151,7 +7151,7 @@ function jslint_phase3_parse(state) {
         let dups = [];
         let exp;
         let last;
-        let stmts;
+        let parsed_block;
         let the_case;
         let the_default;
         let the_disrupt = true;
@@ -7225,8 +7225,8 @@ function jslint_phase3_parse(state) {
 // ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 24]
 
             check_ordered_case(the_case.expression);
-            stmts = parse_statements();
-            if (stmts.length < 1) {
+            parsed_block = parse_statement_block();
+            if (parsed_block.length < 1) {
 
 // test_cause:
 // ["
@@ -7240,9 +7240,9 @@ function jslint_phase3_parse(state) {
 
                 break;
             }
-            the_case.block = stmts;
+            the_case.block = parsed_block;
             the_cases.push(the_case);
-            last = stmts[stmts.length - 1];
+            last = parsed_block[parsed_block.length - 1];
             if (last.disrupt) {
                 if (last.id === "break" && last.label === undefined) {
                     the_disrupt = false;
@@ -7283,7 +7283,7 @@ function jslint_phase3_parse(state) {
             advance("default");
             token_now.switch = true;
             advance(":");
-            the_switch.else = parse_statements();
+            the_switch.else = parse_statement_block();
             if (the_switch.else.length < 1) {
 
 // test_cause:
@@ -7918,7 +7918,7 @@ function jslint_phase3_parse(state) {
         advance("(string)");
         semicolon();
     }
-    state.token_tree = parse_statements();
+    state.token_tree = parse_statement_block();
     advance("(end)");
 
 // Check global functions are ordered.

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -5101,8 +5101,8 @@ function jslint_phase3_parse(state) {
 // 5.lab.3 - Mark 'init', the label-statement, before control-flow-block.
 // 5.lab.4 - Mark 'out-of-scope', the label-statement, after control-flow-block.
 
+        const id = name.id;
         let earlier;
-        let id = name.id;
         name_list.push(name);
         name.init = init;
         name.readonly = readonly;
@@ -5492,12 +5492,12 @@ function jslint_phase3_parse(state) {
             case "while":
 
 // test_cause:
-// ["aa:do{}", "parse_statement", "the_statement_label", "do", 0]
-// ["aa:for{}", "parse_statement", "the_statement_label", "for", 0]
-// ["aa:switch{}", "parse_statement", "the_statement_label", "switch", 0]
-// ["aa:while{}", "parse_statement", "the_statement_label", "while", 0]
+// ["aa:do", "parse_statement", "label", "do", 0]
+// ["aa:for", "parse_statement", "label", "for", 0]
+// ["aa:switch", "parse_statement", "label", "switch", 0]
+// ["aa:while", "parse_statement", "label", "while", 0]
 
-                test_cause("the_statement_label", token_nxt.id);
+                test_cause("label", token_nxt.id);
                 name_declare(
 
 // 5.lab.1 - Mark 'declared', the label-statement, before control-flow-block.
@@ -5521,17 +5521,23 @@ function jslint_phase3_parse(state) {
 // 5.lab.4 - Mark 'out-of-scope', the label-statement, after control-flow-block.
 
                 the_label.alive = false;
-                functionage.statement_prv = the_statement;
                 the_statement.label = the_label;
                 the_statement.statement = true;
+                functionage.statement_prv = the_statement;
                 return the_statement;
-            }
-            advance();
+            default:
 
 // test_cause:
+// ["()=>{aa:0}", "parse_statement", "unexpected_label_a", "aa", 6]
+// [";{aa:0}", "parse_statement", "unexpected_label_a", "aa", 3]
 // ["aa:", "parse_statement", "unexpected_label_a", "aa", 1]
+// ["aa:0", "parse_statement", "unexpected_label_a", "aa", 1]
+// ["aa:0?0:0", "parse_statement", "unexpected_label_a", "aa", 1]
+// ["aa:bb:0", "parse_statement", "unexpected_label_a", "aa", 1]
 
-            warn("unexpected_label_a", the_label);
+                warn("unexpected_label_a", the_label);
+                advance();
+            }
         }
 
 // Parse the statement.
@@ -5551,13 +5557,11 @@ function jslint_phase3_parse(state) {
             the_symbol.statement = true;
             token_now.arity = "statement";
             the_statement = the_symbol.fud_stmt();
-            functionage.statement_prv = the_statement;
         } else {
 
 // It is an expression statement.
 
             the_statement = parse_expression(0, true);
-            functionage.statement_prv = the_statement;
             if (the_statement.wrapped && the_statement.id !== "(") {
 
 // test_cause:
@@ -5567,6 +5571,7 @@ function jslint_phase3_parse(state) {
             }
             semicolon();
         }
+        functionage.statement_prv = the_statement;
         return the_statement;
     }
 
@@ -7991,14 +7996,6 @@ function jslint_phase4_walk(state) {
             let a_set = when[arity];
             let i_set;
 
-// The id parameter is optional. If excluded, the task will be applied to all
-// ids.
-
-            if (typeof id !== "string") {
-                task = id;
-                id = "(all)";
-            }
-
 // If this arity has no registrations yet, then create a set object to hold
 // them.
 
@@ -8066,9 +8063,16 @@ function jslint_phase4_walk(state) {
 
         const id = thing.id;
         let the_variable;
-        if (thing.arity !== "variable") {
-            return;
-        }
+
+// PR-xxx - Probably deadcode.
+// if (thing.arity !== "variable") {
+//     return;
+// }
+
+        jslint_assert(
+            thing.arity === "variable",
+            `Expected thing.arity === "variable".`
+        );
 
 // Look up the variable, from current-scope, moving up the scope-chain.
 
@@ -8568,7 +8572,7 @@ function jslint_phase4_walk(state) {
 
             warn("unexpected_parens", thing);
         }
-        post_s_lbrace_pop_block();
+        blockage = block_stack_pop(block_stack);
     }
 
     function post_s_import(the_thing) {
@@ -8887,7 +8891,7 @@ function jslint_phase4_walk(state) {
 
     function pre_s_for(thing) {
         let the_variable;
-        if (thing.name !== undefined) {
+        if (thing.name?.identifier) {
 
 // 3.for.1 - Mark 'declared', the for-variable, ???.
 // 3.for.2 - Mark 'alive', the for-variable, before for-block.
@@ -9110,14 +9114,14 @@ function jslint_phase4_walk(state) {
     postamble = amble(posts);
     preaction = action(pres);
     preamble = amble(pres);
+    postaction("assignment", "(all)", post_a_assignment);
     postaction("assignment", "+=", post_a_pluseq);
-    postaction("assignment", post_a_assignment);
     postaction("binary", "&&", post_b_and);
     postaction("binary", "(", post_b_lparen);
+    postaction("binary", "(all)", post_b_binary);
     postaction("binary", "=>", post_s_function);
     postaction("binary", "[", post_b_lbracket);
     postaction("binary", "||", post_b_or);
-    postaction("binary", post_b_binary);
     postaction("statement", "const", post_s_var);
     postaction("statement", "export", post_s_export_toplevel);
     postaction("statement", "for", post_s_for);
@@ -9127,26 +9131,26 @@ function jslint_phase4_walk(state) {
     postaction("statement", "try", post_s_try);
     postaction("statement", "var", post_s_var);
     postaction("statement", "{", post_s_lbrace_pop_block);
-    postaction("ternary", post_ternary);
+    postaction("ternary", "(all)", post_ternary);
+    postaction("unary", "(all)", post_u);
     postaction("unary", "+", post_u_plus);
     postaction("unary", "function", post_s_function);
-    postaction("unary", post_u);
-    preaction("assignment", pre_a_bitwise);
+    preaction("assignment", "(all)", pre_a_bitwise);
     preaction("binary", "!=", pre_b_noteq);
+    preaction("binary", "(all)", pre_a_bitwise);
+    preaction("binary", "(all)", pre_b_binary);
     preaction("binary", "==", pre_b_eqeq);
     preaction("binary", "=>", pre_s_function);
     preaction("binary", "in", pre_b_in);
     preaction("binary", "instanceof", pre_b_instanceof);
     preaction("binary", "||", pre_b_or);
-    preaction("binary", pre_b_binary);
-    preaction("binary", pre_a_bitwise);
     preaction("statement", "for", pre_s_for);
     preaction("statement", "function", pre_s_function);
     preaction("statement", "try", pre_s_try);
     preaction("statement", "{", pre_s_lbrace);
     preaction("unary", "function", pre_s_function);
     preaction("unary", "~", pre_a_bitwise);
-    preaction("variable", pre_v_var);
+    preaction("variable", "(all)", pre_v_var);
 
 // Init block_stack, function_stack.
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -362,6 +362,7 @@
     test,
     test_cause,
     test_internal_error,
+    test_unknown_warning_code,
     this,
     thru,
     toLocaleString,
@@ -1723,8 +1724,8 @@ function jslint(
         case "wrap_unary":
             mm = `Wrap the unary expression in parens.`;
             break;
-        //!! default:
-            //!! jslint_assert(undefined, `warning_code=${code}`);
+        default:
+            jslint_assert(undefined, `unknown_warning_code=${code}`);
         }
 
 // Validate mm.
@@ -1828,6 +1829,9 @@ function jslint(
         }
         if (option_dict.test_internal_error) {
             jslint_assert(undefined, "test_internal_error");
+        }
+        if (option_dict.test_unknown_warning_code) {
+            warn_at("test_unknown_warning_code");
         }
     } catch (err) {
         mode_stop = true;
@@ -2243,8 +2247,11 @@ https://github.com/jslint-org/jslint/issues.
 edition = "${jslint_edition}";
 ${String(message).slice(0, 2000)}`
     );
-    if (message === "test_internal_error") {
+    switch (message) {
+    case "test_internal_error":
+    case "unknown_warning_code=test_unknown_warning_code":
         error = {};
+        break;
     }
     console.error(error);
     throw error;
@@ -3870,6 +3877,8 @@ function jslint_phase2_lex(state) {
         case "test_cause":      // Test jslint's causes.
         case "test_internal_error":     // Test jslint's internal-error
                                         // ... handling-ability.
+        case "test_unknown_warning_code": // Test jslint's unknown-warning-code
+                                        // ... handling-ability.
         case "this":            // Allow 'this'.
         case "trace":           // Include jslint stack-trace in warnings.
         case "unordered":       // Allow unordered cases, params, properties,
@@ -4947,7 +4956,7 @@ function jslint_phase3_parse(state) {
     function infix_lparen(left) {
         const the_paren = token_now;
         let the_argument;
-        if (left.id !== "function") {
+        if (left.id !== "function" && left.id !== "=>") {
 
 // test_cause:
 // ["(0?0:0)()", "check_left", "unexpected_a", "(", 8]

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -112,7 +112,6 @@
     block,
     block_list,
     block_stack,
-    body,
     browser,
     c,
     calls,
@@ -192,6 +191,7 @@
     fsWriteFileWithParents,
     fud_stmt,
     functionName,
+    function_body,
     function_list,
     function_stack,
     functions,
@@ -328,6 +328,7 @@
     reverse,
     role,
     round,
+    scope_block,
     scope_declared,
     scope_stack_pop,
     scope_stack_push,
@@ -1115,10 +1116,10 @@ function jslint(
     const tenure = empty();     // The predefined property registry.
     const token_global = {      // The global object; the outermost context.
         async: 0,
-        body: true,
         context: empty(),
         finally: 0,
         from: 0,
+        function_body: true,
         id: "(global)",
         level: 0,
         line: jslint_fudge,
@@ -4178,7 +4179,11 @@ function jslint_phase2_lex(state) {
             break;
         case ";":
             if (opener_stack[0]?.for) {
-                opener_stack[0].for.for_semicolon = [];
+                opener_stack[0].for.for_semicolon = [
+                    undefined,
+                    undefined,
+                    undefined
+                ];
             }
             break;
 
@@ -4406,22 +4411,45 @@ function jslint_phase3_parse(state) {
 
 // Parse a block, a sequence of statements wrapped in braces.
 //  special "body"      The block is a function body.
-//          "ignore"    No warning on an empty block.
-//          "naked"     No advance.
+//          "ignore"    No warning on an empty block '{}'.
+//          "naked"     No advance '{'.
 //          undefined   An ordinary block.
 
+        const implicit = (      // No advance '{'. No advance '}'.
+            token_nxt.id !== "{" && special !== "body" && special !== "naked"
+        );
         let parsed_block;
         let the_block;
-        if (special !== "naked") {
+        if (implicit) {
+
+// PR-xxx - Add implicit scope_block for:
+// - if-else
+// - for-loop
+// - while-loop
+// - do-while
+
+// test_cause:
+// ["do;while(0);", "block", "expected_a", "{", 12]
+// ["do;while(0);", "block", "expected_a", "{", 3]
+// ["for(;;);", "block", "expected_a", "{", 8]
+// ["if(0);else if(0);else;", "block", "expected_a", "{", 17]
+// ["if(0);else if(0);else;", "block", "expected_a", "{", 22]
+// ["if(0);else if(0);else;", "block", "expected_a", "{", 6]
+// ["while(0);", "block", "expected_a", "{", 9]
+
+            warn("expected_a", token_nxt, "{");
+        }
+        if (!implicit && special !== "naked") {
             advance("{");
         }
         the_block = token_now;
-        scope_block = scope_stack_push(block_stack, token_now, token_now);
+        the_block.scope_block = true;
+        scope_block = scope_stack_push(block_stack, the_block, the_block);
         if (special !== "body") {
             scope_function.statement_prv = the_block;
         }
         the_block.arity = "statement";
-        the_block.body = special === "body";
+        the_block.function_body = special === "body";
 
 // Top level function bodies may include the "use strict" pragma.
 
@@ -4449,7 +4477,9 @@ function jslint_phase3_parse(state) {
             the_block.disrupt = parsed_block[parsed_block.length - 1].disrupt;
         }
         scope_block = scope_stack_pop(block_stack);
-        advance("}");
+        if (!implicit) {
+            advance("}");
+        }
         return the_block;
     }
 
@@ -5134,20 +5164,26 @@ function jslint_phase3_parse(state) {
             warn("reserved_a", name);
             return;
         }
-        block_stack.some(function (scope_block, ii) {
-            earlier = scope_block.context[id];
-            if (earlier && ii === 0) {
 
 // Has the name been declared in this context?
+
+        earlier = scope_block.context[id];
+        if (earlier) {
 
 // test_cause:
 // ["let aa;(function aa(){})", "name_declare", "scope_current", "aa", 0]
 // ["let aa;function aa(){}", "name_declare", "scope_current", "aa", 0]
 // ["let aa;let aa", "name_declare", "scope_current", "aa", 0]
 
-                test_cause("scope_current", id);
-                warn("redefinition_a_b", name, id, earlier.line);
-            }
+            test_cause("scope_current", id);
+            warn("redefinition_a_b", name, id, earlier.line);
+            return;
+        }
+
+// Has the name been declared in an outer context?
+
+        block_stack.slice(1).some(function (scope_block) {
+            earlier = scope_block.context[id];
             return earlier;
         });
 
@@ -5176,11 +5212,18 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
+// ["for(let aa;;)let aa", "name_declare", "scope_outer", "aa", 0]
 // ["
 // function aa(){try{aa();}catch(aa){aa();}}
 // ", "name_declare", "scope_outer", "aa", 0]
 // ["function aa(){var aa}", "name_declare", "scope_outer", "aa", 0]
+// ["let aa;do let aa;while(0)", "name_declare", "scope_outer", "aa", 0]
+// ["let aa;do;while(0)let aa", "name_declare", "scope_outer", "aa", 0]
 // ["let aa;for(let aa;;){}", "name_declare", "scope_outer", "aa", 0]
+// ["let aa;if(0);else if(0)let aa", "name_declare", "scope_outer", "aa", 0]
+// ["let aa;if(0);else let aa", "name_declare", "scope_outer", "aa", 0]
+// ["let aa;if(0)let aa", "name_declare", "scope_outer", "aa", 0]
+// ["let aa;while(0)let aa", "name_declare", "scope_outer", "aa", 0]
 
             test_cause("scope_outer", id);
             warn("redefinition_a_b", name, id, earlier.line);
@@ -5523,6 +5566,10 @@ function jslint_phase3_parse(state) {
         let the_label;
         let the_statement;
         let the_symbol;
+        if (token_nxt.id === ";") {
+            semicolon();
+            return stmt_semicolon();
+        }
         advance();
         if (token_now.identifier && token_nxt.id === ":") {
             the_label = token_now;
@@ -6016,7 +6063,7 @@ function jslint_phase3_parse(state) {
 
 // A function expression may have an optional name.
 
-// PR-xxx - Restrict scope from scope_function to its own function-body:
+// PR-xxx - Restrict scope from scope_function to its own function_body:
 // - named-function-expression
 
             scope_declared = the_function;
@@ -6852,20 +6899,20 @@ function jslint_phase3_parse(state) {
         check_not_top_level(the_for);
         scope_function.loop += 1;
 
-// PR-xxx - Add implicit scope_block for:
-// - for-loop
+// PR-xxx - Add hidden scope_block for:
+// - for-variable
 
-        scope_block = scope_stack_push(block_stack, token_now, token_now);
+        scope_block = scope_stack_push(block_stack, the_for, the_for);
         advance("(");
-        token_now.free = true;
+        the_for.free = true;
         if (the_for.for_semicolon) {
             switch (token_nxt.id) {
             case ";":
 
 // test_cause:
-// ["for(;;){}", "stmt_for", "expected_a_b", "for (;", 1]
+// ["for(;;){}", "stmt_for", "expected_a_b", "for (;", 5]
 
-                warn("expected_a_b", the_for, "while (", "for (;");
+                warn("expected_a_b", token_nxt, "while (", "for (;");
                 break;
             case "const":
             case "var":
@@ -6891,12 +6938,28 @@ function jslint_phase3_parse(state) {
                 warn("expected_a", token_nxt, "let");
             }
             token_nxt.for_init = true;
-            the_for.for_semicolon.push(parse_statement_single());
+            the_for.for_semicolon[0] = parse_statement_single();
             token_nxt.for_init = true;
-            the_for.for_semicolon.push(parse_expression(0));
+            if (token_nxt.id === ";") {
+
+// test_cause:
+// ["for(;;){}", "stmt_for", "unexpected_a", ";", 6]
+
+                warn("unexpected_a", token_nxt);
+            } else {
+                the_for.for_semicolon[1] = parse_expression(0);
+            }
             advance(";");
             token_nxt.for_init = true;
-            the_for.for_semicolon.push(parse_expression(0));
+            if (token_nxt.id === ")") {
+
+// test_cause:
+// ["for(;;){}", "stmt_for", "unexpected_a", ")", 7]
+
+                warn("unexpected_a", token_nxt);
+            } else {
+                the_for.for_semicolon[2] = parse_expression(0);
+            }
         } else {
             switch (token_nxt.id) {
             case "const":
@@ -7437,7 +7500,8 @@ function jslint_phase3_parse(state) {
             the_try.catch = the_catch;
             advance("catch");
 
-// Create new catch-scope for catch-parameter.
+// PR-xxx - Add hidden scope_block for:
+// - catch-variable
 
             scope_block = scope_stack_push(block_stack, the_catch, the_catch);
             if (token_nxt.id === "(") {
@@ -7455,9 +7519,6 @@ function jslint_phase3_parse(state) {
                     name_declare(
 
 // 3.cat.1 - Mark 'declared', the catch-variable, before catch-block.
-
-// PR-xxx - Change scope from special-catch-scope to scope_block:
-// - catch-variable
 
                         scope_block,    // scope_declared
                         "exception",    // role
@@ -8683,7 +8744,6 @@ function jslint_phase4_walk(state) {
         delete scope_function.statement_prv;
         delete scope_function.switch;
         delete scope_function.try;
-        scope_function = scope_stack_pop(function_stack);
         if (thing.wrapped) {
 
 // test_cause:
@@ -8692,6 +8752,7 @@ function jslint_phase4_walk(state) {
             warn("unexpected_parens", thing);
         }
         scope_block = scope_stack_pop(block_stack);
+        scope_function = scope_stack_pop(function_stack);
     }
 
     function post_s_import(the_thing) {
@@ -8704,12 +8765,13 @@ function jslint_phase4_walk(state) {
         post_s_export_toplevel(the_thing);
     }
 
-    function post_s_lbrace_pop_block() {
-        scope_block = scope_stack_pop(block_stack);
-    }
-
     function post_s_try(thing) {
         if (thing.catch) {
+
+// PR-xxx - Add hidden scope_block for:
+// - catch-variable
+
+            scope_block = scope_stack_push(block_stack, thing.catch, undefined);
 
 // Recurse walk_statement().
 
@@ -9022,8 +9084,8 @@ function jslint_phase4_walk(state) {
 
     function pre_s_for(thing) {
 
-// PR-xxx - Add implicit scope_block for:
-// - for-loop
+// PR-xxx - Add hidden scope_block for:
+// - for-variable
 
         scope_block = scope_stack_push(block_stack, thing, undefined);
         if (thing.for_semicolon) {
@@ -9051,10 +9113,10 @@ function jslint_phase4_walk(state) {
 // ["function aa(){}", "pre_s_function", "", "", 0]
 
         test_cause("");
-        if (thing.arity === "statement" && scope_block.body !== true) {
+        if (thing.arity === "statement" && !scope_block.function_body) {
 
 // test_cause:
-// ["if(0){function aa(){}\n}", "pre_s_function", "unexpected_a", "function", 7]
+// ["if(0){function aa(){}}", "pre_s_function", "unexpected_a", "function", 7]
 
             warn("unexpected_a", thing);
         }
@@ -9104,19 +9166,6 @@ function jslint_phase4_walk(state) {
 
             name.alive = true;
         });
-    }
-
-    function pre_s_lbrace(thing) {
-        scope_block = scope_stack_push(block_stack, thing, undefined);
-    }
-
-    function pre_s_try(thing) {
-        if (thing.catch) {
-
-// Create new catch-scope for catch-parameter.
-
-            scope_block = scope_stack_push(block_stack, thing.catch, undefined);
-        }
     }
 
     function pre_v_var(thing) {
@@ -9202,6 +9251,9 @@ function jslint_phase4_walk(state) {
             thing.forEach(walk_statement);
             return;
         }
+        if (thing.scope_block) {
+            scope_block = scope_stack_push(block_stack, thing, undefined);
+        }
         preamble(thing);
         walk_expression(thing.expression);
         if (thing.arity === "binary") {
@@ -9233,6 +9285,9 @@ function jslint_phase4_walk(state) {
         walk_statement(thing.block);
         walk_statement(thing.else);
         postamble(thing);
+        if (thing.scope_block) {
+            scope_block = scope_stack_pop(block_stack);
+        }
     }
 
     postaction = action(posts);
@@ -9255,7 +9310,6 @@ function jslint_phase4_walk(state) {
     postaction("statement", "let", post_s_var);
     postaction("statement", "try", post_s_try);
     postaction("statement", "var", post_s_var);
-    postaction("statement", "{", post_s_lbrace_pop_block);
     postaction("ternary", "(all)", post_t_ternary);
     postaction("unary", "(all)", post_u_unary);
     postaction("unary", "+", post_u_plus);
@@ -9272,8 +9326,6 @@ function jslint_phase4_walk(state) {
     preaction("binary", "||", pre_b_or);
     preaction("statement", "for", pre_s_for);
     preaction("statement", "function", pre_s_function);
-    preaction("statement", "try", pre_s_try);
-    preaction("statement", "{", pre_s_lbrace);
     preaction("unary", "function", pre_s_function);
     preaction("unary", "~", pre_a_bitwise);
     preaction("variable", "(all)", pre_v_var);

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -180,6 +180,7 @@
     floor,
     for,
     forEach,
+    for_inc,
     formatted_message,
     free,
     freeze,
@@ -206,7 +207,6 @@
     import,
     import_list,
     import_meta_url,
-    inc,
     includeList,
     includes,
     indent2,
@@ -4376,12 +4376,12 @@ function jslint_phase3_parse(state) {
             right = parse_expression(20 - 1);
             if (id === "=" && left.arity === "variable") {
                 the_token.name_list = [];       // 1. name_list for "aa = ..."
-                name_push(
-                    the_token.name_list,        // name_list
+                name_enroll(
                     false,              // enroll
-                    left,               // name
                     "variable",         // role
                     false,              // readonly
+                    the_token.name_list,        // name_list
+                    left,               // name
                     true                // init
                 );
                 the_token.expression = right;
@@ -5052,14 +5052,71 @@ function jslint_phase3_parse(state) {
         return the_symbol;
     }
 
-    function name_enroll(name, role, readonly) {
+// PR-502 - Unify name_list.push() logic with helper-function name_enroll().
+
+    function name_enroll(enroll, role, readonly, name_list, name, init) {
+
+// This function will:
+// 1. Push variable or function-parameter <name> to <name_list>.
+// 2. Set <name>.init = true, if its an assigned-variable,
+//    a function-parameter, or existing variable assigned new value.
+// 3. Enroll <name> in <name>.parent.context, if its a declared-variable,
+//    or function-parameter.
+
+// Most calls to name_enroll() are commented about the thing being enrolled,
+// and its lifecycle.  Here is a list of all lifecycle comments.
+//
+// 1.imp.1 - Mark 'enrolled', the import-name, during import-statement.
+// 1.imp.2 - Mark 'live', the import-name, after import-statement.
+// 1.imp.3 - Mark 'out-of-scope', the import-name, after module-scope.
+//
+// 2.fun.1 - Mark 'enrolled', the function-name, immediately.
+// 2.fun.2 - Mark 'live', the function-name, immediately.
+// 2.fun.3 - Mark 'out-of-scope', the function-name, after expression-scope.
+// 2.fun.3 - Mark 'out-of-scope', the function-name, after function-scope.
+//
+// 3.exc.1 - Mark 'enrolled', the exception-variable, before catch-block.
+// 3.exc.2 - Mark 'live', the exception-variable, before catch-block.
+// 3.exc.3 - Mark 'out-of-scope', the exception-variable, after catch-block.
+//
+// 3.for.1 - Mark 'enrolled', the iterator-variable, ???.
+// 3.for.2 - Mark 'live', the iterator-variable, before for-block.
+// 3.for.3 - Mark 'out-of-scope', the iterator-variable, ???.
+//
+// 3.glo.1 - Mark 'enrolled', the global-variable, never.
+// 3.glo.2 - Mark 'live', the global-variable, immediately.
+// 3.glo.3 - Mark 'out-of-scope', the global-variable, never.
+//
+// 3.var.1 - Mark 'enrolled', the variable, during variable-initialization.
+// 3.var.2 - Mark 'live', the variable, after variable-initialization.
+// 3.var.3 - Mark 'out-of-scope', the variable, after block-scope.
+// 3.var.3 - Mark 'out-of-scope', the variable, after function-scope.
+//
+// 4.par.1 - Mark 'enrolled', the function-parameter, during destructuring.
+// 4.par.1 - Mark 'enrolled', the function-parameter, if unwrapped.
+// 4.par.2 - Mark 'live', the function-parameter, after destructuring.
+// 4.par.3 - Mark 'out-of-scope', the function-parameter, after function-scope.
+//
+// 5.lab.1 - Mark 'enrolled', the label-statement, before control-flow-block.
+// 5.lab.2 - Mark 'live', the label-statement, before control-flow-block.
+// 5.lab.3 - Mark 'out-of-scope', the label-statement, after control-flow-block.
+
+        let earlier;
+        let id = name.id;
+        name_list.push(name);
+        if (init) {
+            name.init = init;
+        }
+        if (role === "variable") {
+            name.arity = "variable";
+        }
+        if (!enroll) {
+            return;
+        }
 
 // Enroll a name into the current function context. The role can be exception,
 // function, label, parameter, or variable. We look for variable redefinition
 // because it causes confusion.
-
-        let earlier;
-        let id = name.id;
 
 // Reserved words may not be enrolled.
 
@@ -5137,26 +5194,6 @@ function jslint_phase3_parse(state) {
             used: 0
         });
         name.parent.context[id] = name;
-    }
-
-// PR-502 - Unify name_list.push() logic with helper-function name_push().
-
-    function name_push(name_list, enroll, name, role, readonly, init) {
-
-// This function will:
-// 1. Push variable or function-parameter <name> to <name_list>.
-// 2. Enroll <name> if its either a declared-variable or function-parameter.
-// 3. Set <name>.init = true, if its either an assigned-variable or
-//    function-parameter.
-
-        name_list.push(name);
-        if (enroll) {
-            name_enroll(name, role, readonly);
-        }
-        if (role === "variable") {
-            name.arity = "variable";
-        }
-        name.init = init;
     }
 
     function parse_expression(rbp, initial) {
@@ -5461,21 +5498,24 @@ function jslint_phase3_parse(state) {
 // ["aa:while{}", "parse_statement", "the_statement_label", "while", 0]
 
                 test_cause("the_statement_label", token_nxt.id);
-                name_push(
-                    [],                 // name_list
+
+// 5.lab.1 - Mark 'enrolled', the label-statement, before control-flow-block.
+
+                name_enroll(
                     true,               // enroll
-                    the_label,          // name
                     "label",            // role
                     true,               // readonly
+                    [],                 // name_list
+                    the_label,          // name
                     true                // init
                 );
 
-// 5.lab.1 - Mark 'initialized', the label-statement, before control-flow-block.
+// 5.lab.2 - Mark 'live', the label-statement, before control-flow-block.
 
                 the_label.live = true;
                 the_statement = parse_statement();
 
-// 5.lab.2 - Mark 'out-of-scope', the label-statement, after control-flow-block.
+// 5.lab.3 - Mark 'out-of-scope', the label-statement, after control-flow-block.
 
                 the_label.live = false;
                 functionage.statement_prv = the_statement;
@@ -5821,11 +5861,11 @@ function jslint_phase3_parse(state) {
                 }
                 token_nxt.label = name;
                 name = token_nxt;
-                name_push(sub_list, enroll, name, role, readonly, true);
+                name_enroll(enroll, role, readonly, sub_list, name, true);
                 advance_and_signature_push(token_nxt.id);
                 return;
             }
-            name_push(sub_list, enroll, name, role, readonly, true);
+            name_enroll(enroll, role, readonly, sub_list, name, true);
             if (token_nxt.id === "=") {
                 optional = the_function_toplevel && token_now;
                 advance_and_signature_push("=");
@@ -5941,30 +5981,33 @@ function jslint_phase3_parse(state) {
         }
         if (name) {
             advance();
-            name_push(
-                [],                     // name_list
+
+// 2.fun.1 - Mark 'enrolled', the function-name, immediately.
+
+            name_enroll(
                 true,                   // enroll
-                name,                   // name
                 (                       // role
                     the_function.arity === "statement"
                     ? "variable"
                     : "function"
                 ),
                 false,                  // readonly
+                [],                     // name_list
+                name,                   // name
                 true                    // init
             );
 
-// 2.fun.1 - Mark 'initialized', the function-name, immediately.
+// 2.fun.2 - Mark 'live', the function-name, immediately.
 
             name.live = true;
             if (the_function.arity === "statement") {
 
-// 2.fun.2 - Mark 'out-of-scope', the function-name, after function-scope.
+// 2.fun.3 - Mark 'out-of-scope', the function-name, after function-scope.
 
                 functionage.live_list.push(name);
             } else {
 
-// 2.fun.2 - Mark 'out-of-scope', the function-name, after expression-scope.
+// 2.fun.3 - Mark 'out-of-scope', the function-name, after expression-scope.
 
                 the_function.live_list.push(name);
                 name.used += 1;
@@ -6027,12 +6070,15 @@ function jslint_phase3_parse(state) {
 // ["aa=>0", "prefix_function", "wrap_fart_parameter", "aa", 1]
 
             warn("wrap_fart_parameter", token_prv);
-            name_push(
-                the_function.name_list, // name_list
+
+// 4.par.1 - Mark 'enrolled', the function-parameter, if unwrapped.
+
+            name_enroll(
                 true,                   // enroll
-                token_prv,              // name
                 "parameter",            // role
                 false,                  // readonly
+                the_function.name_list, // name_list
+                token_prv,              // name
                 true                    // init
             );
         } else {
@@ -6040,6 +6086,8 @@ function jslint_phase3_parse(state) {
             if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
 
 // PR-500 - Unify ES2015-destructure-logic. - function ([aa]) {...}
+
+// 4.par.1 - Mark 'enrolled', the function-parameter, during destructuring.
 
                 prefix_destructure(
                     true,               // enroll
@@ -6817,13 +6865,13 @@ function jslint_phase3_parse(state) {
             advance(";");
             the_for.expression = parse_expression(0);
             advance(";");
-            the_for.inc = parse_expression(0);
-            if (the_for.inc.id === "++") {
+            the_for.for_inc = parse_expression(0);
+            if (the_for.for_inc.id === "++") {
 
 // test_cause:
 // ["for(aa;aa;aa++){}", "stmt_for", "expected_a_b", "++", 13]
 
-                warn("expected_a_b", the_for.inc, "+= 1", "++");
+                warn("expected_a_b", the_for.for_inc, "+= 1", "++");
             }
         }
         advance(")");
@@ -6922,12 +6970,15 @@ function jslint_phase3_parse(state) {
 
                     warn("unexpected_a", name);
                 }
-                name_push(
-                    the_import.name_list,       // name_list
+
+// 1.imp.1 - Mark 'enrolled', the import-name, during import-statement.
+
+                name_enroll(
                     true,               // enroll
-                    name,               // name
                     "variable",         // role
                     true,               // readonly
+                    the_import.name_list,       // name_list
+                    name,               // name
                     true                // init
                 );
             } else {
@@ -6955,12 +7006,15 @@ function jslint_phase3_parse(state) {
 
                             warn("unexpected_a", name);
                         }
-                        name_push(
-                            the_import.name_list,       // name_list
+
+// 1.imp.1 - Mark 'enrolled', the import-name, during import-statement.
+
+                        name_enroll(
                             true,       // enroll
-                            name,       // name
                             "variable", // role
                             true,       // readonly
+                            the_import.name_list,       // name_list
+                            name,       // name
                             true        // init
                         );
                         if (token_nxt.id !== ",") {
@@ -7286,12 +7340,15 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id !== "ignore") {
                     ignored = undefined;
                     the_catch.name = token_nxt;
-                    name_push(
-                        [],             // name_list
+
+// 3.exc.1 - Mark 'enrolled', the exception-variable, before catch-block.
+
+                    name_enroll(
                         true,           // enroll
-                        token_nxt,      // name
                         "exception",    // role
                         true,           // readonly
+                        [],             // name_list
+                        token_nxt,      // name
                         true            // init
                     );
                 }
@@ -7439,12 +7496,15 @@ function jslint_phase3_parse(state) {
                     advance("=");
                     name.expression = parse_expression(0);
                 }
-                name_push(
-                    the_variable.name_list,     // name_list
+
+// 3.var.1 - Mark 'enrolled', the variable, during variable-initialization.
+
+                name_enroll(
                     true,               // enroll
-                    name,               // name
                     "variable",         // role
                     readonly,           // readonly
+                    the_variable.name_list,     // name_list
+                    name,               // name
                     Boolean(name.expression)    // init
                 );
             } else {
@@ -7986,8 +8046,9 @@ function jslint_phase4_walk(state) {
                     id,
                     init: true,
 
-// 3.glo.1 - Mark 'initialized', the global-variable, immediately.
-// 3.glo.2 - Mark 'out-of-scope', the global-variable, never.
+// 3.glo.1 - Mark 'enrolled', the global-variable, never.
+// 3.glo.2 - Mark 'live', the global-variable, immediately.
+// 3.glo.3 - Mark 'out-of-scope', the global-variable, never.
 
                     live: true,
                     parent: token_global,
@@ -8424,7 +8485,7 @@ function jslint_phase4_walk(state) {
 
 // Recurse walk_statement().
 
-        walk_statement(thing.inc);
+        walk_statement(thing.for_inc);
     }
 
     function post_s_function(thing) {
@@ -8448,11 +8509,11 @@ function jslint_phase4_walk(state) {
     function post_s_import(the_thing) {
         the_thing.name_list.forEach(function (name) {
 
-// 1.imp.1 - Mark 'initialized', the import-name, after import-statement.
+// 1.imp.2 - Mark 'live', the import-name, after import-statement.
 
             name.live = true;
 
-// 1.imp.2 - Mark 'out-of-scope', the import-name, after module-scope.
+// 1.imp.3 - Mark 'out-of-scope', the import-name, after module-scope.
 
             blockage.live_list.push(name);
         });
@@ -8473,7 +8534,7 @@ function jslint_phase4_walk(state) {
         }
         if (thing.catch.name) {
 
-// 3.exc.1 - Mark 'initialized', the exception-variable, before catch-block.
+// 3.exc.2 - Mark 'live', the exception-variable, before catch-block.
 
             catchage.context[thing.catch.name.id].live = true;
         }
@@ -8483,7 +8544,7 @@ function jslint_phase4_walk(state) {
         walk_statement(thing.catch.block);
         if (thing.catch.name) {
 
-// 3.exc.2 - Mark 'out-of-scope', the exception-variable, after catch-block.
+// 3.exc.3 - Mark 'out-of-scope', the exception-variable, after catch-block.
 
             catchage.context[thing.catch.name.id].live = false;
         }
@@ -8513,21 +8574,21 @@ function jslint_phase4_walk(state) {
 // PR-502 - Fix long-running regression where 'let x = x;'
 // doesn't warn about temporal-dead-zone.
 
-// 3.var.1 - Mark 'initialized', the variable, after variable-initialization.
+// 3.var.2 - Mark 'live', the variable, after variable-initialization.
 
             name.live = true;
             switch (thing.id) {
             case "const":
             case "let":
 
-// 3.var.2 - Mark 'out-of-scope', the variable, after block-scope.
+// 3.var.3 - Mark 'out-of-scope', the variable, after block-scope.
 
                 blockage.live_list.push(name);
                 break;
             // case "var":
             default:
 
-// 3.var.2 - Mark 'out-of-scope', the variable, after function-scope.
+// 3.var.3 - Mark 'out-of-scope', the variable, after function-scope.
 
                 functionage.live_list.push(name);
             }
@@ -8893,8 +8954,9 @@ function jslint_phase4_walk(state) {
         let the_variable;
         if (thing.name !== undefined) {
 
-// 3.for.1 - Mark 'initialized', the iterator-variable, in for-statement.
-// 3.for.2 - Mark 'out-of-scope', the iterator-variable, ???.
+// 3.for.1 - Mark 'enrolled', the iterator-variable, ???.
+// 3.for.2 - Mark 'live', the iterator-variable, before for-block.
+// 3.for.3 - Mark 'out-of-scope', the iterator-variable, ???.
 
             thing.name.live = true;
             the_variable = name_lookup(thing.name, true);
@@ -8973,11 +9035,11 @@ function jslint_phase4_walk(state) {
             }
             walk_expression(name.expression);
 
-// 4.par.1 - Mark 'initialized', the function-parameter, after destructuring.
+// 4.par.2 - Mark 'live', the function-parameter, after destructuring.
 
             name.live = true;
 
-// 4.par.2 - Mark 'out-of-scope', the function-parameter, after function-scope.
+// 4.par.3 - Mark 'out-of-scope', the function-parameter, after function-scope.
 
             functionage.live_list.push(name);
         });

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -4378,7 +4378,7 @@ function jslint_phase3_parse(state) {
                 the_token.expression = right;
                 the_token.name_list = [];       // 1. name_list for "aa = ..."
                 name_enroll(
-                    false,              // enroll
+                    undefined,          // enroll_parent
                     "variable",         // role
                     false,              // readonly
                     the_token.name_list,        // name_list
@@ -5054,13 +5054,20 @@ function jslint_phase3_parse(state) {
 
 // PR-502 - Unify name_list.push() logic with helper-function name_enroll().
 
-    function name_enroll(enroll, role, readonly, name_list, name, init) {
+    function name_enroll(
+        enroll_parent,
+        role,
+        readonly,
+        name_list,
+        name,
+        init
+    ) {
 
 // This function will:
 // 1. Push variable or function-parameter <name> to <name_list>.
 // 2. Set <name>.init = true, if its an assigned-variable,
 //    a function-parameter, or existing variable assigned new value.
-// 3. Enroll <name> in <name>.parent.context, if its a declared-variable,
+// 3. Enroll <name> in <enroll_parent>.context, if its a declared-variable,
 //    or function-parameter.
 
 // Most calls to name_enroll() are commented about the thing being enrolled,
@@ -5119,7 +5126,7 @@ function jslint_phase3_parse(state) {
         if (role === "variable") {
             name.arity = "variable";
         }
-        if (!enroll) {
+        if (!enroll_parent) {
             return;
         }
 
@@ -5193,16 +5200,12 @@ function jslint_phase3_parse(state) {
 // Enroll it.
 
         Object.assign(name, {
-            parent: (
-                role === "exception"
-                ? catchage
-                : functionage
-            ),
+            parent: enroll_parent,
             readonly,
             role,
             used: 0
         });
-        name.parent.context[id] = name;
+        enroll_parent.context[id] = name;
     }
 
     function parse_expression(rbp, initial) {
@@ -5511,7 +5514,7 @@ function jslint_phase3_parse(state) {
 
 // 5.lab.1 - Mark 'enrolled', the label-statement, before control-flow-block.
 
-                    true,               // enroll
+                    functionage,        // enroll_parent
                     "label",            // role
                     true,               // readonly
                     [],                 // name_list
@@ -5744,7 +5747,7 @@ function jslint_phase3_parse(state) {
     }
 
     function prefix_destructure(
-        enroll,
+        enroll_parent,
         role,
         readonly,
         name_list,
@@ -5822,7 +5825,7 @@ function jslint_phase3_parse(state) {
                 test_cause("recurse_element");
                 advance_and_signature_push(token_nxt.id);
                 prefix_destructure(
-                    enroll,             // enroll
+                    enroll_parent,      // enroll_parent
                     role,               // role
                     readonly,           // readonly
                     name_list,          // name_list
@@ -5873,11 +5876,25 @@ function jslint_phase3_parse(state) {
                 }
                 token_nxt.label = name;
                 name = token_nxt;
-                name_enroll(enroll, role, readonly, sub_list, name, true);
+                name_enroll(
+                    enroll_parent,      // enroll_parent
+                    role,               // role
+                    readonly,           // readonly
+                    sub_list,           // name_list
+                    name,               // name
+                    true                // init
+                );
                 advance_and_signature_push(token_nxt.id);
                 return;
             }
-            name_enroll(enroll, role, readonly, sub_list, name, true);
+            name_enroll(
+                enroll_parent,          // enroll_parent
+                role,                   // role
+                readonly,               // readonly
+                sub_list,               // name_list
+                name,                   // name
+                true                    // init
+            );
             if (token_nxt.id === "=") {
                 optional = the_function_toplevel && token_now;
                 advance_and_signature_push("=");
@@ -5997,7 +6014,7 @@ function jslint_phase3_parse(state) {
 
 // 2.fun.1 - Mark 'enrolled', the function-name, immediately.
 
-                true,                   // enroll
+                functionage,            // enroll_parent
                 (                       // role
                     the_function.arity === "statement"
                     ? "variable"
@@ -6089,7 +6106,7 @@ function jslint_phase3_parse(state) {
 
 // 4.par.1 - Mark 'enrolled', the function-parameter, if unwrapped.
 
-                true,                   // enroll
+                functionage,            // enroll_parent
                 "parameter",            // role
                 false,                  // readonly
                 the_function.name_list, // name_list
@@ -6108,7 +6125,7 @@ function jslint_phase3_parse(state) {
 
 // 4.par.1 - Mark 'enrolled', the function-parameter, during destructuring.
 
-                    true,               // enroll
+                    functionage,        // enroll_parent
                     "parameter",        // role
                     false,              // readonly
                     the_function.name_list,     // name_list
@@ -6402,7 +6419,7 @@ function jslint_phase3_parse(state) {
 // PR-500 - Unify ES2015-destructure-logic. - [aa] = ...;
 
             element = prefix_destructure(
-                false,                  // enroll
+                undefined,              // enroll_parent
                 "variable",             // role
                 false,                  // readonly
                 the_token.name_list,    // name_list
@@ -6992,7 +7009,7 @@ function jslint_phase3_parse(state) {
 
 // 1.imp.1 - Mark 'enrolled', the import-name, during import-statement.
 
-                    true,               // enroll
+                    functionage,        // enroll_parent
                     "variable",         // role
                     true,               // readonly
                     the_import.name_list,       // name_list
@@ -7031,7 +7048,7 @@ function jslint_phase3_parse(state) {
 
 // 1.imp.1 - Mark 'enrolled', the import-name, during import-statement.
 
-                            true,       // enroll
+                            functionage,        // enroll_parent
                             "variable", // role
                             true,       // readonly
                             the_import.name_list,       // name_list
@@ -7368,7 +7385,7 @@ function jslint_phase3_parse(state) {
 
 // 3.exc.1 - Mark 'enrolled', the exception-variable, before catch-block.
 
-                        true,           // enroll
+                        catchage,       // enroll_parent
                         "exception",    // role
                         true,           // readonly
                         [],             // name_list
@@ -7498,7 +7515,7 @@ function jslint_phase3_parse(state) {
 // PR-500 - Unify ES2015-destructure-logic. - let [aa] = ...;
 
                 prefix_destructure(
-                    true,               // enroll
+                    functionage,        // enroll_parent
                     "variable",         // role
                     readonly,           // readonly
                     the_variable.name_list,     // name_list
@@ -7527,7 +7544,7 @@ function jslint_phase3_parse(state) {
 
 // 3.var.1 - Mark 'enrolled', the variable, during variable-initialization.
 
-                    true,               // enroll
+                    functionage,        // enroll_parent
                     "variable",         // role
                     readonly,           // readonly
                     the_variable.name_list,     // name_list

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -4446,7 +4446,7 @@ function jslint_phase3_parse(state) {
         let the_block;
         if (implicit) {
 
-// PR-xxx - Add implicit scope_block for:
+// PR-504 - Add implicit scope_block for:
 // - if-else
 // - for-loop
 // - while-loop
@@ -6108,7 +6108,7 @@ function jslint_phase3_parse(state) {
         const name = !mode_fart && token_nxt.identifier && token_nxt;
         let role = "variable";
 
-// PR-xxx - Change scope from scope_function to scope_block:
+// PR-504 - Change scope from scope_function to scope_block:
 // - function-declaration
 
         let scope_declared = scope_block;
@@ -6132,7 +6132,7 @@ function jslint_phase3_parse(state) {
 
 // A function expression may have an optional name.
 
-// PR-xxx - Restrict scope from scope_function to its own function_body:
+// PR-504 - Restrict scope from scope_function to its own function_body:
 // - named-function-expression
 
             scope_declared = the_function;
@@ -6195,7 +6195,7 @@ function jslint_phase3_parse(state) {
 //             warn("function_in_loop", the_function);
 //         }
 
-// PR-xxx - Add hidden scope_block for:
+// PR-504 - Add hidden scope_block for:
 // - function-parameter
 
 // Push the current function context and establish a new one.
@@ -6961,7 +6961,7 @@ function jslint_phase3_parse(state) {
         check_not_top_level(the_for);
         scope_function.loop += 1;
 
-// PR-xxx - Add hidden scope_block for:
+// PR-504 - Add hidden scope_block for:
 // - for-variable
 
         scope_block = scope_block_push(the_for, true);
@@ -7351,7 +7351,7 @@ function jslint_phase3_parse(state) {
             return;
         }
 
-// PR-xxx - Add hidden scope_block for:
+// PR-504 - Add hidden scope_block for:
 // - label-name
 
         scope_block = scope_block_push(the_label, true);
@@ -7631,7 +7631,7 @@ function jslint_phase3_parse(state) {
             the_try.catch = the_catch;
             advance("catch");
 
-// PR-xxx - Add hidden scope_block for:
+// PR-504 - Add hidden scope_block for:
 // - catch-variable
 
             scope_block = scope_block_push(the_catch, true);
@@ -7707,7 +7707,7 @@ function jslint_phase3_parse(state) {
             token_now.id === "var"
             ? scope_function
 
-// PR-xxx - Change scope from scope_function to scope_block:
+// PR-504 - Change scope from scope_function to scope_block:
 // - const-declaration
 // - let-declaration
 
@@ -8319,7 +8319,7 @@ function jslint_phase4_walk(state) {
         const id = thing.id;
         let the_variable;
 
-// PR-xxx - Probably deadcode.
+// PR-504 - Probably deadcode.
 // if (thing.arity !== "variable") {
 //     return;
 // }
@@ -8841,7 +8841,7 @@ function jslint_phase4_walk(state) {
     function post_s_try(thing) {
         if (thing.catch !== undefined) {
 
-// PR-xxx - Add hidden scope_block for:
+// PR-504 - Add hidden scope_block for:
 // - catch-variable
 
             scope_block = scope_block_push(thing.catch, false);
@@ -9157,7 +9157,7 @@ function jslint_phase4_walk(state) {
 
     function pre_s_for(thing) {
 
-// PR-xxx - Add hidden scope_block for:
+// PR-504 - Add hidden scope_block for:
 // - for-variable
 
         scope_block = scope_block_push(thing, false);
@@ -9194,7 +9194,7 @@ function jslint_phase4_walk(state) {
             warn("unexpected_a", thing);
         }
 
-// PR-xxx - Add hidden scope_block for:
+// PR-504 - Add hidden scope_block for:
 // - function-parameter
 
         scope_block = scope_block_push(thing, false);
@@ -9312,7 +9312,7 @@ function jslint_phase4_walk(state) {
             return;
         }
 
-// PR-xxx - Add hidden scope_block for:
+// PR-504 - Add hidden scope_block for:
 // - label-name
 
         if (thing.label_name) {

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -111,14 +111,13 @@
     beta,
     bitwise,
     block,
+    block_list,
     block_stack,
     body,
     browser,
     c,
     calls,
     catch,
-    catch_list,
-    catch_stack,
     causes,
     char,
     children,
@@ -1087,13 +1086,8 @@ function jslint(
 
 // The jslint function itself.
 
-    const block_stack = [];     // The stack of blocks.
-    const catch_list = [];      // The array containing all catch-blocks.
-    const catch_stack = [       // The stack of catch-blocks.
-        {
-            context: empty()
-        }
-    ];
+    const block_list = [];      // The array containing all lexical-blocks.
+    const block_stack = [];     // The stack of lexical-blocks.
     const cause_dict = empty(); // The object of test-causes.
     const directive_list = [];  // The directive comments.
     const export_dict = empty();        // The exported names and values.
@@ -1754,9 +1748,8 @@ function jslint(
             state,
             {
                 artifact,
+                block_list,
                 block_stack,
-                catch_list,
-                catch_stack,
                 directive_list,
                 export_dict,
                 function_list,
@@ -1806,10 +1799,6 @@ function jslint(
             `block_stack.length=${block_stack.length}.`
         );
         jslint_assert(
-            catch_stack.length === 1,
-            `catch_stack.length=${catch_stack.length}.`
-        );
-        jslint_assert(
             function_stack.length === 0,
             `function_stack.length=${function_stack.length}.`
         );
@@ -1824,10 +1813,6 @@ function jslint(
         jslint_assert(
             block_stack.length === 0,
             `block_stack.length=${block_stack.length}.`
-        );
-        jslint_assert(
-            catch_stack.length === 1,
-            `catch_stack.length=${catch_stack.length}.`
         );
         jslint_assert(
             function_stack.length === 0,
@@ -4284,9 +4269,8 @@ function jslint_phase3_parse(state) {
 
     const {
         artifact,
+        block_list,
         block_stack,
-        catch_list,
-        catch_stack,
         export_dict,
         function_list,
         function_stack,
@@ -4306,7 +4290,6 @@ function jslint_phase3_parse(state) {
     } = state;
     let anon = "anonymous";     // The guessed name for anonymous functions.
     let blockage = token_global;        // The current block.
-    let catchage = catch_stack[0];      // The current catch-block.
     let functionage = token_global;     // The current function.
     let mode_var;               // "var" if using var; "let" if using let.
     let token_ii = 0;           // The number of the next token.
@@ -5107,13 +5090,12 @@ function jslint_phase3_parse(state) {
 // 2.fun.1 - Mark 'declared', the function-name, during function-declaration.
 // 2.fun.2 - Mark 'alive', the function-name, during function-declaration.
 // 2.fun.3 - Mark 'init', the function-name, during function-declaration.
-// 2.fun.4 - Mark 'out-of-scope', the function-name, after expression-scope.
+// 2.fun.4 - Mark 'out-of-scope', the function-name, after function-body.
 // 2.fun.4 - Mark 'out-of-scope', the function-name, after function-scope.
 //
-// 3.exc.1 - Mark 'declared', the exception-variable, before catch-block.
-// 3.exc.2 - Mark 'alive', the exception-variable, before catch-block.
-// 3.exc.3 - Mark 'init', the exception-variable, before catch-block.
-// 3.exc.4 - Mark 'out-of-scope', the exception-variable, after catch-block.
+// 3.cat.1 - Mark 'declared', the catch-variable, before catch-block.
+// 3.cat.2 - Mark 'alive', the catch-variable, before catch-block.
+// 3.cat.3 - Mark 'init', the catch-variable, before catch-block.
 //
 // 3.for.1 - Mark 'declared', the for-variable, ???.
 // 3.for.2 - Mark 'alive', the for-variable, before for-block.
@@ -5173,7 +5155,7 @@ function jslint_phase3_parse(state) {
 
 // Has the name been declared in this context?
 
-        earlier = functionage.context[id] || catchage.context[id];
+        earlier = declared_scope?.context?.[id];
         if (earlier) {
 
 // test_cause:
@@ -6063,7 +6045,7 @@ function jslint_phase3_parse(state) {
                 functionage.alive_list.push(name);
             } else {
 
-// 2.fun.4 - Mark 'out-of-scope', the function-name, after expression-scope.
+// 2.fun.4 - Mark 'out-of-scope', the function-name, after function-body.
 
                 the_function.alive_list.push(name);
                 name.used = true;
@@ -7391,9 +7373,9 @@ function jslint_phase3_parse(state) {
 
 // Create new catch-scope for catch-parameter.
 
-            catch_stack.push(catchage);
-            catchage = the_catch;
-            catch_list.push(catchage);
+            block_stack.push(blockage);
+            blockage = the_catch;
+            block_list.push(blockage);
             the_catch.context = empty();
             if (token_nxt.id === "(") {
                 advance("(");
@@ -7409,18 +7391,22 @@ function jslint_phase3_parse(state) {
                     the_catch.name = token_nxt;
                     name_declare(
 
-// 3.exc.1 - Mark 'declared', the exception-variable, before catch-block.
+// 3.cat.1 - Mark 'declared', the catch-variable, before catch-block.
 
-                        catchage,       // declared_scope
+                        blockage,       // declared_scope
                         "exception",    // role
                         true,           // readonly
                         [],             // name_list
                         token_nxt,      // name
 
-// 3.exc.3 - Mark 'init', the exception-variable, before catch-block.
+// 3.cat.3 - Mark 'init', the catch-variable, before catch-block.
 
                         true            // init
                     );
+
+// 3.cat.2 - Mark 'alive', the catch-variable, before catch-block.
+
+                    token_nxt.alive = true;
                 }
                 advance();
                 advance(")");
@@ -7432,7 +7418,7 @@ function jslint_phase3_parse(state) {
 
 // Restore previous catch-scope after catch-block.
 
-            catchage = jslint_assert_and_pop(catch_stack, "catch_stack");
+            blockage = jslint_assert_and_pop(block_stack, "block_stack");
 
 // PR-404 - Relax warning about missing `catch` in `try...finally` statement.
 //
@@ -7458,8 +7444,9 @@ function jslint_phase3_parse(state) {
 
     function stmt_var() {
         const readonly = token_now.id === "const";
+        const the_variable = token_now;
+        let declared_scope = functionage;
         let name;
-        let the_variable = token_now;
         let variable_prv;
         the_variable.name_list = [];    // 5. name_list for "let [aa] = ..."
 
@@ -7501,6 +7488,11 @@ function jslint_phase3_parse(state) {
 
             test_cause("var_prv", functionage.statement_prv.id);
             variable_prv = functionage.statement_prv;
+            //!! declared_scope = (
+                //!! variable_prv === "var"
+                //!! ? functionage
+                //!! : blockage
+            //!! );
             break;
         case "import":
 
@@ -7541,7 +7533,7 @@ function jslint_phase3_parse(state) {
 // PR-500 - Unify ES2015-destructure-logic. - let [aa] = ...;
 
                 prefix_destructure(
-                    functionage,        // declared_scope
+                    declared_scope,     // declared_scope
                     "variable",         // role
                     readonly,           // readonly
                     the_variable.name_list,     // name_list
@@ -7956,7 +7948,6 @@ function jslint_phase4_walk(state) {
     const {
         artifact,
         block_stack,
-        catch_stack,
         function_stack,
         global_dict,
         is_equal,
@@ -7968,7 +7959,6 @@ function jslint_phase4_walk(state) {
         warn
     } = state;
     let blockage = token_global;        // The current block.
-    let catchage = catch_stack[0];      // The current catch-block.
     let functionage = token_global;     // The current function.
     let postaction;
     let postamble;
@@ -8067,7 +8057,7 @@ function jslint_phase4_walk(state) {
 // This function will lookup and return variable or function-parameter
 // <the_variable> in current context from given <thing>.id.
 
-        let id = thing.id;
+        const id = thing.id;
         let the_variable;
         if (thing.arity !== "variable") {
             return;
@@ -8075,28 +8065,16 @@ function jslint_phase4_walk(state) {
 
 // Look up the variable in the current context.
 
-        the_variable = functionage.context[id] || catchage.context[id];
+        the_variable = functionage.context[id];
 
 // If it isn't local, search all the other contexts. If there are name
 // collisions, take the most recent.
 
-        if (the_variable && the_variable.role === "label") {
-
-// test_cause:
-// ["aa:while(0){aa}", "name_lookup", "label_a", "aa", 13]
-
-            warn("label_a", thing);
-            return the_variable;
-        }
         if (!the_variable) {
-            function_stack.forEach(function ({
-                context
-            }) {
-                if (context[id] && context[id].role !== "label") {
-                    the_variable = context[id];
-                }
+            block_stack.forEach(function (blockage) {
+                the_variable = blockage?.context?.[id] || the_variable;
             });
-            if (!the_variable && global_dict[id] === undefined) {
+            if (!the_variable && !global_dict[id]) {
 
 // test_cause:
 // ["aa", "name_lookup", "undeclared_a", "aa", 1]
@@ -8134,6 +8112,15 @@ function jslint_phase4_walk(state) {
             token_global.context[id] = the_variable;
 
 // 3.glo.4 - Mark 'out-of-scope', the global-variable, never.
+
+        }
+        if (the_variable?.role === "label") {
+
+// test_cause:
+// ["aa:while(0){aa}", "name_lookup", "label_a", "aa", 13]
+
+            warn("label_a", thing);
+            return the_variable;
         }
         if (
             (
@@ -8593,7 +8580,7 @@ function jslint_phase4_walk(state) {
     }
 
     function post_s_lbrace_pop_block() {
-        blockage.alive_list.forEach(function (name) {
+        blockage?.alive_list?.forEach(function (name) {
             name.alive = false;
         });
         delete blockage.alive_list;
@@ -8601,29 +8588,16 @@ function jslint_phase4_walk(state) {
     }
 
     function post_s_try(thing) {
-        if (!thing.catch) {
-            return;
-        }
-        if (thing.catch.name) {
-
-// 3.exc.2 - Mark 'alive', the exception-variable, before catch-block.
-
-            catchage.context[thing.catch.name.id].alive = true;
-        }
+        if (thing.catch) {
 
 // Recurse walk_statement().
 
-        walk_statement(thing.catch.block);
-        if (thing.catch.name) {
-
-// 3.exc.4 - Mark 'out-of-scope', the exception-variable, after catch-block.
-
-            catchage.context[thing.catch.name.id].alive = false;
-        }
+            walk_statement(thing?.catch?.block);
 
 // Restore previous catch-scope after catch-block.
 
-        catchage = jslint_assert_and_pop(catch_stack, "catch_stack");
+            blockage = jslint_assert_and_pop(block_stack, "block_stack");
+        }
     }
 
     function post_s_var(thing) {
@@ -9130,12 +9104,12 @@ function jslint_phase4_walk(state) {
     }
 
     function pre_s_try(thing) {
-        if (thing.catch !== undefined) {
+        if (thing.catch) {
 
 // Create new catch-scope for catch-parameter.
 
-            catch_stack.push(catchage);
-            catchage = thing.catch;
+            block_stack.push(blockage);
+            blockage = thing.catch;
         }
     }
 
@@ -9309,8 +9283,8 @@ function jslint_phase5_whitage(state) {
 
     const {
         artifact,
+        block_list,
         block_stack,
-        catch_list,
         function_list,
         option_dict,
         test_cause,
@@ -9900,7 +9874,7 @@ function jslint_phase5_whitage(state) {
 // PR-502 - tighten warning of unused variables to be always on.
 
     delve(token_global);
-    catch_list.forEach(delve);
+    block_list.forEach(delve);
     function_list.forEach(delve);
     if (option_dict.white) {
         return;

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -113,6 +113,8 @@
     block,
     block_list,
     block_stack,
+    block_stack_pop,
+    block_stack_push,
     body,
     browser,
     c,
@@ -1142,6 +1144,28 @@ function jslint(
         );
     }
 
+    function block_stack_pop(stack) {
+        jslint_assert(stack.length > 1, `block_stack.length=${stack.length}`);
+        stack.shift();
+        return stack[0];
+    }
+
+    function block_stack_push(stack, stack_pushed, list_pushed) {
+        stack.unshift(stack_pushed);
+        if (stack === block_stack && !stack_pushed.context) {
+            stack_pushed.context = empty();
+        }
+        switch (list_pushed && stack) {
+        case block_stack:
+            block_list.push(list_pushed);
+            break;
+        case function_stack:
+            function_list.push(list_pushed);
+            break;
+        }
+        return stack_pushed;
+    }
+
     function is_equal(aa, bb) {
 
 // test_cause:
@@ -1359,7 +1383,7 @@ function jslint(
 // likely that the first warning will be the most meaningful.
 
         if (the_token.warning) {
-            jslint_assert_and_pop(warning_list, "warning_list");
+            warning_list.pop();
             return the_warning;
         }
         the_token.warning = the_warning;
@@ -1511,13 +1535,6 @@ function jslint(
         case "missing_await_statement":
             mm = `Expected await statement in async function.`;
             break;
-
-// PR-347 - Disable warning "missing_browser".
-//
-//         case "missing_browser":
-//             mm = `/*global*/ requires the Assume a browser option.`;
-//             break;
-
         case "missing_m":
             mm = `Expected 'm' flag on a multiline regular expression.`;
             break;
@@ -1741,7 +1758,6 @@ function jslint(
 // automatic semicolon insertion and nested megastring literals, which allows
 // full tokenization to precede parsing.
 
-        block_list.push(token_global);
         option_dict = {
             ...option_dict
         };
@@ -1751,6 +1767,8 @@ function jslint(
                 artifact,
                 block_list,
                 block_stack,
+                block_stack_pop,
+                block_stack_push,
                 directive_list,
                 export_dict,
                 function_list,
@@ -1790,19 +1808,10 @@ function jslint(
 // PHASE 2. Lex <line_list> into <token_list>.
 
         jslint_phase2_lex(state);
-        block_stack.length = 0;
 
 // PHASE 3. Parse <token_list> into <token_tree> using the Pratt-parser.
 
         jslint_phase3_parse(state);
-        jslint_assert(
-            block_stack.length === 0,
-            `block_stack.length=${block_stack.length}.`
-        );
-        jslint_assert(
-            function_stack.length === 0,
-            `function_stack.length=${function_stack.length}.`
-        );
 
 // PHASE 4. Walk <token_tree>, traversing all nodes of the tree. It is a
 //          recursive traversal. Each node may be processed on the way down
@@ -1811,39 +1820,12 @@ function jslint(
         if (!state.mode_json) {
             jslint_phase4_walk(state);
         }
-        jslint_assert(
-            block_stack.length === 0,
-            `block_stack.length=${block_stack.length}.`
-        );
-        jslint_assert(
-            function_stack.length === 0,
-            `function_stack.length=${function_stack.length}.`
-        );
 
 // PHASE 5. Check whitespace between tokens in <token_list>.
 
         if (!state.mode_json && warning_list.length === 0) {
             jslint_phase5_whitage(state);
         }
-        jslint_assert(
-            block_stack.length === 0,
-            `block_stack.length=${block_stack.length}.`
-        );
-
-// PR-347 - Disable warning "missing_browser".
-//
-//         if (!option_dict.browser) {
-//             directive_list.forEach(function (comment) {
-//                 if (comment.directive === "global") {
-//
-// // test_cause:
-// // ["/*global aa*/", "jslint", "missing_browser", "(comment)", 1]
-//
-//                     warn("missing_browser", comment);
-//                 }
-//             });
-//         }
-
         if (option_dict.test_internal_error) {
             jslint_assert(undefined, "test_internal_error");
         }
@@ -2266,14 +2248,6 @@ ${String(message).slice(0, 2000)}`
     }
     console.error(error);
     throw error;
-}
-
-function jslint_assert_and_pop(list, list_name) {
-
-// This function will assert <list>.length > 0, before returning <list>.pop().
-
-    jslint_assert(list.length > 0, `${list_name}.length=${list.length}`);
-    return list.pop();
 }
 
 async function jslint_cli({
@@ -4270,8 +4244,9 @@ function jslint_phase3_parse(state) {
 
     const {
         artifact,
-        block_list,
         block_stack,
+        block_stack_pop,
+        block_stack_push,
         export_dict,
         function_list,
         function_stack,
@@ -4293,7 +4268,7 @@ function jslint_phase3_parse(state) {
     let blockage = token_global;        // The current block.
     let functionage = token_global;     // The current function.
     let mode_var;               // "var" if using var; "let" if using let.
-    let token_ii = 0;           // The number of the next token.
+    let token_ii = 0;           // The index of the next token in <token_list>.
     let token_now = token_global;       // The current token being examined in
                                         // ... the parse.
     let token_nxt = token_global;       // The next token to be examined in
@@ -4422,7 +4397,7 @@ function jslint_phase3_parse(state) {
             advance("{");
         }
         the_block = token_now;
-        block_stack_push(token_now);
+        blockage = block_stack_push(block_stack, token_now, token_now);
         if (special !== "body") {
             functionage.statement_prv = the_block;
         }
@@ -4433,7 +4408,7 @@ function jslint_phase3_parse(state) {
 
         if (
             special === "body"
-            && function_stack.length === 1
+            && function_stack.length === 2
             && token_nxt.value === "use strict"
         ) {
             token_nxt.statement = true;
@@ -4454,16 +4429,9 @@ function jslint_phase3_parse(state) {
         } else {
             the_block.disrupt = stmts[stmts.length - 1].disrupt;
         }
-        blockage = jslint_assert_and_pop(block_stack, "block_stack");
+        blockage = block_stack_pop(block_stack);
         advance("}");
         return the_block;
-    }
-
-    function block_stack_push(blockage_nxt) {
-        block_stack.push(blockage);
-        blockage = blockage_nxt;
-        blockage.context = empty();
-        block_list.push(blockage);
     }
 
     function check_left(left, right) {
@@ -5168,9 +5136,18 @@ function jslint_phase3_parse(state) {
 
 // Has the name been declared in an outer context?
 
-        block_stack.forEach(function (blockage) {
-            earlier = blockage.context[id] || earlier;
+        block_stack.some(function (blockage) {
+            earlier = blockage.context[id];
+            return earlier;
         });
+
+// Declare it.
+
+        declared_scope.context[id] = name;
+        name.declared_scope = declared_scope;
+
+// Warn about variable redefinition.
+
         if (earlier && id === "ignore") {
             if (earlier.role === "variable") {
 
@@ -5179,7 +5156,9 @@ function jslint_phase3_parse(state) {
 
                 warn("redefinition_a_b", name, id, earlier.line);
             }
-        } else if (
+            return;
+        }
+        if (
             earlier
             && role !== "parameter" && role !== "function"
             && (role !== "exception" || earlier.role !== "exception")
@@ -5192,7 +5171,9 @@ function jslint_phase3_parse(state) {
 // ["function aa(){var aa}", "name_declare", "redefinition_a_b", "1", 19]
 
             warn("redefinition_a_b", name, id, earlier.line);
-        } else if (
+            return;
+        }
+        if (
             option_dict.beta
             && global_dict[id]
             && role !== "parameter"
@@ -5202,12 +5183,8 @@ function jslint_phase3_parse(state) {
 // ["let Array", "name_declare", "redefinition_global_a_b", "Array", 5]
 
             warn("redefinition_global_a_b", name, global_dict[id], id);
+            return;
         }
-
-// Declare it.
-
-        declared_scope.context[id] = name;
-        name.declared_scope = declared_scope;
     }
 
     function parse_expression(rbp, initial) {
@@ -6051,7 +6028,6 @@ function jslint_phase3_parse(state) {
 // depth of loops and switches.
 
         the_function.async = the_function.async || 0;
-        the_function.context = empty();
         the_function.finally = 0;
         the_function.level = functionage.level + 1;
         the_function.loop = 0;
@@ -6084,10 +6060,12 @@ function jslint_phase3_parse(state) {
 
 // Push the current function context and establish a new one.
 
-        block_stack_push(the_function);
-        function_list.push(the_function);
-        function_stack.push(functionage);
-        functionage = the_function;
+        blockage = block_stack_push(block_stack, the_function, the_function);
+        functionage = block_stack_push(
+            function_stack,
+            the_function,
+            the_function
+        );
 
 // Parse the parameter list.
 
@@ -6229,8 +6207,8 @@ function jslint_phase3_parse(state) {
 
 // Restore the previous context.
 
-        blockage = jslint_assert_and_pop(block_stack, "block_stack");
-        functionage = jslint_assert_and_pop(function_stack, "function_stack");
+        blockage = block_stack_pop(block_stack);
+        functionage = block_stack_pop(function_stack);
         return the_function;
     }
 
@@ -7367,7 +7345,7 @@ function jslint_phase3_parse(state) {
 
 // Create new catch-scope for catch-parameter.
 
-            block_stack_push(the_catch);
+            blockage = block_stack_push(block_stack, the_catch, the_catch);
             if (token_nxt.id === "(") {
                 advance("(");
                 if (!token_nxt.identifier) {
@@ -7409,7 +7387,7 @@ function jslint_phase3_parse(state) {
 
 // Restore previous catch-scope after catch-block.
 
-            blockage = jslint_assert_and_pop(block_stack, "block_stack");
+            blockage = block_stack_pop(block_stack);
 
 // PR-404 - Relax warning about missing `catch` in `try...finally` statement.
 //
@@ -7886,6 +7864,13 @@ function jslint_phase3_parse(state) {
     symbol("}");
     ternary("?", ":");
 
+// Init block_stack, function_stack.
+
+    block_stack.length = 0;
+    function_stack.length = 0;
+    block_stack_push(block_stack, token_global, token_global);
+    block_stack_push(function_stack, token_global, undefined);
+
 // Init token_nxt.
 
     advance();
@@ -7928,6 +7913,19 @@ function jslint_phase3_parse(state) {
             return option_dict.beta && name && name.id;
         })
     );
+
+// Cleanup block_stack, function_stack.
+
+    jslint_assert(
+        block_stack.length === 1,
+        `block_stack.length=${block_stack.length}.`
+    );
+    jslint_assert(
+        function_stack.length === 1,
+        `function_stack.length=${function_stack.length}.`
+    );
+    block_stack.length = 0;
+    function_stack.length = 0;
 }
 
 function jslint_phase4_walk(state) {
@@ -7939,6 +7937,8 @@ function jslint_phase4_walk(state) {
     const {
         artifact,
         block_stack,
+        block_stack_pop,
+        block_stack_push,
         function_stack,
         global_dict,
         is_equal,
@@ -8062,8 +8062,9 @@ function jslint_phase4_walk(state) {
 // collisions, take the most recent.
 
         if (!the_variable) {
-            block_stack.forEach(function (blockage) {
-                the_variable = blockage.context[id] || the_variable;
+            block_stack.some(function (blockage) {
+                the_variable = blockage.context[id];
+                return the_variable;
             });
             if (!the_variable && !global_dict[id]) {
 
@@ -8542,7 +8543,7 @@ function jslint_phase4_walk(state) {
         delete functionage.statement_prv;
         delete functionage.switch;
         delete functionage.try;
-        functionage = jslint_assert_and_pop(function_stack, "function_stack");
+        functionage = block_stack_pop(function_stack);
         if (thing.wrapped) {
 
 // test_cause:
@@ -8568,7 +8569,7 @@ function jslint_phase4_walk(state) {
             name.alive = false;
         });
         delete blockage.alive_list;
-        blockage = jslint_assert_and_pop(block_stack, "block_stack");
+        blockage = block_stack_pop(block_stack);
     }
 
     function post_s_try(thing) {
@@ -8580,7 +8581,7 @@ function jslint_phase4_walk(state) {
 
 // Restore previous catch-scope after catch-block.
 
-            blockage = jslint_assert_and_pop(block_stack, "block_stack");
+            blockage = block_stack_pop(block_stack);
         }
     }
 
@@ -9021,10 +9022,8 @@ function jslint_phase4_walk(state) {
 
             warn("unexpected_a", thing);
         }
-        block_stack.push(blockage);
-        blockage = thing;
-        function_stack.push(functionage);
-        functionage = thing;
+        blockage = block_stack_push(block_stack, thing, undefined);
+        functionage = block_stack_push(function_stack, thing, undefined);
         if (thing.extra === "get") {
             if (thing.parameter_count !== 0) {
 
@@ -9072,8 +9071,7 @@ function jslint_phase4_walk(state) {
     }
 
     function pre_s_lbrace(thing) {
-        block_stack.push(blockage);
-        blockage = thing;
+        blockage = block_stack_push(block_stack, thing, undefined);
         thing.alive_list = [];
     }
 
@@ -9082,8 +9080,7 @@ function jslint_phase4_walk(state) {
 
 // Create new catch-scope for catch-parameter.
 
-            block_stack.push(blockage);
-            blockage = thing.catch;
+            blockage = block_stack_push(block_stack, thing.catch, undefined);
         }
     }
 
@@ -9248,7 +9245,29 @@ function jslint_phase4_walk(state) {
     preaction("unary", "~", pre_a_bitwise);
     preaction("variable", pre_v_var);
 
+// Init block_stack, function_stack.
+
+    block_stack.length = 0;
+    function_stack.length = 0;
+    block_stack_push(block_stack, token_global, undefined);
+    block_stack_push(function_stack, token_global, undefined);
+
+// Walk the token_tree.
+
     walk_statement(state.token_tree);
+
+// Cleanup block_stack, function_stack.
+
+    jslint_assert(
+        block_stack.length === 1,
+        `block_stack.length=${block_stack.length}.`
+    );
+    jslint_assert(
+        function_stack.length === 1,
+        `function_stack.length=${function_stack.length}.`
+    );
+    block_stack.length = 0;
+    function_stack.length = 0;
 }
 
 function jslint_phase5_whitage(state) {
@@ -9447,7 +9466,7 @@ function jslint_phase5_whitage(state) {
 
 // If right is a closer, then pop the previous state.
 
-        indentage = jslint_assert_and_pop(block_stack, "block_stack");
+        indentage = block_stack.pop();
         closer = indentage.closer;
         free = indentage.free;
         margin = indentage.margin;
@@ -9839,6 +9858,10 @@ function jslint_phase5_whitage(state) {
         no_space_only();
     }
 
+// Init block_stack.
+
+    block_stack.length = 0;
+
 // uninitialized_and_unused();
 // Delve into the functions looking for variables that were not initialized
 // or used. If the file imports or exports, then its global object is also
@@ -9890,6 +9913,14 @@ function jslint_phase5_whitage(state) {
         delete left.used;
         left = right;
     });
+
+// Cleanup block_stack.
+
+    jslint_assert(
+        block_stack.length === 0,
+        `block_stack.length=${block_stack.length}.`
+    );
+    block_stack.length = 0;
 }
 
 function jslint_report({

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -357,7 +357,6 @@
     startOffset,
     startsWith,
     statement,
-    statement_prv,
     stdio,
     stop,
     stop_at,
@@ -395,7 +394,9 @@
     v8CoverageListMerge,
     v8CoverageReportCreate,
     value,
+    var_on_top,
     variable,
+    variable_prv,
     version,
     versions,
     warn,
@@ -1703,8 +1704,8 @@ function jslint(
         case "use_spaces":
             mm = `Use spaces, not tabs.`;
             break;
-        case "var_on_top":
-            mm = `Move variable declaration to top of function or script.`;
+        case "var_on_top_a_b":
+            mm = `Move ${a} declaration to top of ${b} or script.`;
             break;
         case "var_switch":
             mm = `Don't declare variables in a switch.`;
@@ -4468,7 +4469,7 @@ function jslint_phase3_parse(state) {
         the_block.scope_block = true;
         scope_block = scope_block_push(the_block, true);
         if (special !== "body") {
-            scope_function.statement_prv = the_block;
+            check_ordered_var(the_block);
         }
         the_block.arity = "statement";
         the_block.function_body = special === "body";
@@ -4648,6 +4649,87 @@ function jslint_phase3_parse(state) {
             }
             return bb;
         }, undefined);
+    }
+
+    function check_ordered_var(the_variable) {
+
+// This function will check:
+// - const and let declarations are on top of scope_block.
+// - const and let declarations are ordered within scope_block
+// - var declarations are on top of scope_function.
+// - var declarations are ordered within scope_function
+
+        function check(variable_prv, bb) {
+            switch (
+                Boolean(variable_prv)
+                && !variable_prv.for_init
+                && variable_prv.id
+            ) {
+            case "const":
+            case "let":
+            case "var":
+                if (
+                    option_dict.beta
+                    && !option_dict.unordered
+                    && !option_dict.variable
+                    && variable_prv
+                    && (
+                        variable_prv.id + " " + variable_prv.name_list[0].id
+                        > the_variable.id + " " + the_variable.name_list[0].id
+                    )
+                ) {
+
+// test_cause:
+// ["const bb=0;const aa=0", "check", "expected_a_b_before_c_d", "aa", 12]
+// ["let bb;let aa", "check", "expected_a_b_before_c_d", "aa", 8]
+// ["var bb;var aa", "check", "expected_a_b_before_c_d", "aa", 8]
+
+                    warn(
+                        "expected_a_b_before_c_d",
+                        the_variable,
+                        the_variable.id,
+                        the_variable.name_list[0].id,
+                        variable_prv.id,
+                        variable_prv.name_list[0].id
+                    );
+                }
+                break;
+            case "import":
+            case false:
+
+// test_cause:
+// ["import \"aa\";let aa", "check", "import", "", 0]
+
+                test_cause("import");
+                break;
+            default:
+                if (option_dict.beta && !option_dict.variable) {
+
+// test_cause:
+// ["String();const aa=0", "check", "var_on_top_a_b", "block", 10]
+// ["String();let aa", "check", "var_on_top_a_b", "block", 10]
+// ["String();var aa", "check", "var_on_top_a_b", "function", 10]
+// ["try{}catch{var aa}", "check", "var_on_top_a_b", "function", 12]
+// ["while(0){var aa}", "check", "var_on_top_a_b", "function", 10]
+
+                    warn("var_on_top_a_b", the_variable, the_variable.id, bb);
+                }
+            }
+        }
+        switch (the_variable.id) {
+        case "const":
+        case "let":
+            check(scope_block.variable_prv, "block");
+            scope_block.variable_prv = the_variable;
+            break;
+        case "var":
+            check(scope_function.variable_prv, "function");
+            scope_function.variable_prv = the_variable;
+            break;
+        default:
+            scope_block.variable_prv = the_variable;
+            scope_function.variable_prv = the_variable;
+        }
     }
 
     function condition() {
@@ -5654,7 +5736,7 @@ function jslint_phase3_parse(state) {
             }
             semicolon();
         }
-        scope_function.statement_prv = the_statement;
+        check_ordered_var(the_statement);
         return the_statement;
     }
 
@@ -7293,7 +7375,7 @@ function jslint_phase3_parse(state) {
         the_label.alive = true;
         the_statement = parse_statement_single();
         the_statement.label_name = the_label;
-        scope_function.statement_prv = the_statement;
+        check_ordered_var(the_statement);
         scope_block = scope_block_pop();
         return the_statement;
     }
@@ -7634,7 +7716,6 @@ function jslint_phase3_parse(state) {
         const the_variable = token_now;
         let name;
         let the_operator;
-        let variable_prv;
         function advance_operator() {
             switch (the_operator.id) {
             case "=":
@@ -7698,46 +7779,6 @@ function jslint_phase3_parse(state) {
 // ["switch(0){case 0:var aa}", "stmt_var", "var_switch", "var", 18]
 
             warn("var_switch", the_variable);
-        }
-        switch (
-            Boolean(scope_function.statement_prv && !for_init)
-            && scope_function.statement_prv.id
-        ) {
-        case "const":
-        case "let":
-        case "var":
-
-// test_cause:
-// ["const aa=0;const bb=0", "stmt_var", "var_prv", "const", 0]
-// ["let aa=0;let bb=0", "stmt_var", "var_prv", "let", 0]
-// ["var aa=0;var bb=0", "stmt_var", "var_prv", "var", 0]
-
-            test_cause("var_prv", scope_function.statement_prv.id);
-            variable_prv = scope_function.statement_prv;
-            break;
-        case "import":
-
-// test_cause:
-// ["import aa from \"aa\";\nlet bb=0;", "stmt_var", "import_prv", "", 0]
-
-            test_cause("import_prv");
-            break;
-        case false:
-            break;
-        default:
-            if (
-                (option_dict.beta && !option_dict.variable)
-                || the_variable.id === "var"
-            ) {
-
-// test_cause:
-// ["console.log();let aa=0", "stmt_var", "var_on_top", "let", 15]
-// ["console.log();var aa=0", "stmt_var", "var_on_top", "var", 15]
-// ["try{}catch{var aa=0}", "stmt_var", "var_on_top", "var", 12]
-// ["while(0){var aa}", "stmt_var", "var_on_top", "var", 10]
-
-                warn("var_on_top", token_now);
-            }
         }
         while (true) {
             if (token_nxt.id === "{" || token_nxt.id === "[") {
@@ -7815,34 +7856,6 @@ function jslint_phase3_parse(state) {
 
             warn("expected_a_b", token_nxt, ";", ",");
             advance(",");
-        }
-
-// Warn if variable declarations are unordered.
-
-        if (
-            option_dict.beta
-            && !option_dict.unordered
-            && !option_dict.variable
-            && variable_prv
-            && (
-                variable_prv.id + " " + variable_prv.name_list[0].id
-                > the_variable.id + " " + the_variable.name_list[0].id
-            )
-        ) {
-
-// test_cause:
-// ["const bb=0;const aa=0", "stmt_var", "expected_a_b_before_c_d", "aa", 12]
-// ["let bb;let aa", "stmt_var", "expected_a_b_before_c_d", "aa", 8]
-// ["var bb;var aa", "stmt_var", "expected_a_b_before_c_d", "aa", 8]
-
-            warn(
-                "expected_a_b_before_c_d",
-                the_variable,
-                the_variable.id,
-                the_variable.name_list[0].id,
-                variable_prv.id,
-                variable_prv.name_list[0].id
-            );
         }
         if (!for_init || token_nxt.id === ";") {
             semicolon();
@@ -8804,7 +8817,6 @@ function jslint_phase4_walk(state) {
         delete scope_function.async;
         delete scope_function.finally;
         delete scope_function.loop;
-        delete scope_function.statement_prv;
         delete scope_function.switch;
         delete scope_function.try;
         if (thing.wrapped) {

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -1109,14 +1109,13 @@ function jslint(
         };
     });
     const opener_stack = [];    // Stack of opener tokens: (, [.
-    let mode_stop = false;      // true if JSLint cannot finish.
-    let property_dict = empty();        // The object containing the tallied
+    const property_dict = empty();      // The object containing the tallied
                                         // ... property names.
-    let state = empty();        // jslint state-object to be passed between
                                 // jslint functions.
-    let syntax_dict = empty();  // The object containing the parser.
-    let tenure = empty();       // The predefined property registry.
-    let token_global = {        // The global object; the outermost context.
+    const state = empty();      // jslint state-object to be passed between
+    const syntax_dict = empty();        // The object containing the parser.
+    const tenure = empty();     // The predefined property registry.
+    const token_global = {      // The global object; the outermost context.
         alive_list: [],
         async: 0,
         body: true,
@@ -1131,8 +1130,9 @@ function jslint(
         thru: 0,
         try: 0
     };
-    let token_list = [];        // The array of tokens.
-    let warning_list = [];      // The array collecting all generated warnings.
+    const token_list = [];      // The array of tokens.
+    const warning_list = [];    // The array collecting all generated warnings.
+    let mode_stop = false;      // true if JSLint cannot finish.
 
 // Error reportage functions:
 
@@ -1378,7 +1378,7 @@ function jslint(
 // resembles an exception.
 
         let mm;
-        let warning = Object.assign(empty(), {
+        let warning = {
             a,
             b,
             c,
@@ -1390,8 +1390,9 @@ function jslint(
             d,
             line,
             line_source: "",
-            name: "JSLintError"
-        }, line_list[line]);
+            name: "JSLintError",
+            ...line_list[line]
+        };
         warning.column = Math.max(
             Math.min(warning.column, warning.line_source.length),
             jslint_fudge
@@ -1746,42 +1747,47 @@ function jslint(
 // automatic semicolon insertion and nested megastring literals, which allows
 // full tokenization to precede parsing.
 
-        option_dict = Object.assign(empty(), option_dict);
-        Object.assign(state, {
-            artifact,
-            catch_list,
-            catch_stack,
-            directive_list,
-            export_dict,
-            function_list,
-            function_stack,
-            global_dict,
-            global_list,
-            import_list,
-            is_equal,
-            is_weird,
-            line_list,
-            mode_json: false,           // true if parsing JSON.
-            mode_module: false,         // true if import or export was used.
-            mode_property: false,       // true if directive /*property*/ is
+        option_dict = {
+            ...option_dict
+        };
+        Object.assign(
+            state,
+            {
+                artifact,
+                catch_list,
+                catch_stack,
+                directive_list,
+                export_dict,
+                function_list,
+                function_stack,
+                global_dict,
+                global_list,
+                import_list,
+                is_equal,
+                is_weird,
+                line_list,
+                mode_json: false,       // true if parsing JSON.
+                mode_module: false,     // true if import or export was used.
+                mode_property: false,   // true if directive /*property*/ is
                                         // ... used.
-            mode_shebang: false,        // true if #! is seen on the first line.
-            opener_stack,
-            option_dict,
-            property_dict,
-            source,
-            stop,
-            stop_at,
-            syntax_dict,
-            tenure,
-            test_cause,
-            token_global,
-            token_list,
-            token_nxt: token_global,
-            warn,
-            warn_at,
-            warning_list
-        });
+                mode_shebang: false,    // true if #! is seen on the first line.
+                opener_stack,
+                option_dict,
+                property_dict,
+                source,
+                stop,
+                stop_at,
+                syntax_dict,
+                tenure,
+                test_cause,
+                token_global,
+                token_list,
+                token_nxt: token_global,
+                warn,
+                warn_at,
+                warning_list
+            }
+        );
 
 // PHASE 1. Split <source> by newlines into <line_list>.
 
@@ -1855,12 +1861,10 @@ function jslint(
         err.message = "[JSLint was unable to finish] " + err.message;
         err.mode_stop = true;
         if (err.name !== "JSLintError") {
-            Object.assign(err, {
-                column: jslint_fudge,
-                line: jslint_fudge,
-                line_source: "",
-                stack_trace: err.stack
-            });
+            err.column = jslint_fudge;
+            err.line = jslint_fudge;
+            err.line_source = "";
+            err.stack_trace = err.stack;
         }
         if (warning_list.indexOf(err) === -1) {
             warning_list.push(err);
@@ -2312,9 +2316,10 @@ async function jslint_cli({
         ) {
             return;
         }
-        option = Object.assign(empty(), option, {
+        option = {
+            ...option,
             file
-        });
+        };
         switch ((
             /\.\w+?$|$/m
         ).exec(file)[0]) {
@@ -2329,9 +2334,10 @@ async function jslint_cli({
                     code: match1,
                     file: file + ".<script>.js",
                     line_offset: string_line_count(code.slice(0, ii)) + 1,
-                    option: Object.assign(empty(), {
-                        browser: true
-                    }, option)
+                    option: {
+                        browser: true,
+                        ...option
+                    }
                 });
                 return "";
             });
@@ -2411,15 +2417,16 @@ async function jslint_cli({
                 file: file + ".<node -e>.js",
                 line_offset: string_line_count(code.slice(0, ii)) + 1,
                 mode_conditional,
-                option: Object.assign(empty(), {
+                option: {
                     beta: Boolean(
                         process_env.JSLINT_BETA
                         && !(
                             /0|false|null|undefined/
                         ).test(process_env.JSLINT_BETA)
                     ),
-                    node: true
-                }, option)
+                    node: true,
+                    ...option
+                }
             });
             return "";
         });
@@ -2512,9 +2519,10 @@ async function jslint_cli({
 // PR-362 - Add API Doc.
 
     case "jslint_apidoc":
-        await jslint_apidoc(Object.assign(JSON.parse(process_argv[3]), {
+        await jslint_apidoc({
+            ...JSON.parse(process_argv[3]),
             pathname: command[1]
-        }));
+        });
         return;
 
 // PR-363 - Add command jslint_report.
@@ -5199,13 +5207,11 @@ function jslint_phase3_parse(state) {
 
 // Enroll it.
 
-        Object.assign(name, {
-            parent: enroll_parent,
-            readonly,
-            role,
-            used: 0
-        });
         enroll_parent.context[id] = name;
+        name.parent = enroll_parent;
+        name.readonly = readonly;
+        name.role = role;
+        name.used = 0;
     }
 
     function parse_expression(rbp, initial) {
@@ -5455,9 +5461,12 @@ function jslint_phase3_parse(state) {
 
 // Recurse parse_json().
 
-                        Object.assign(parse_json(), {
-                            label: name
-                        })
+                        Object.assign(
+                            parse_json(),
+                            {
+                                label: name
+                            }
+                        )
                     );
                     if (token_nxt.id !== ",") {
                         break;
@@ -6049,29 +6058,27 @@ function jslint_phase3_parse(state) {
 // Give the function properties for storing its names and for observing the
 // depth of loops and switches.
 
-        Object.assign(the_function, {
-            async: the_function.async || 0,
-            context: empty(),
-            finally: 0,
-            level: functionage.level + 1,
-            loop: 0,
-            name: (
-                name || (
-                    mode_fart_unwrapped
-                    ? "anonymous"
-                    : anon
-                )
-            ),
-            parameter_count: Number(Boolean(mode_fart_unwrapped)),
-            signature: (
+        the_function.async = the_function.async || 0;
+        the_function.context = empty();
+        the_function.finally = 0;
+        the_function.level = functionage.level + 1;
+        the_function.loop = 0;
+        the_function.name = (
+            name
+            || (
                 mode_fart_unwrapped
-                ? token_prv.id
-                : ["("]
-            ),
-            statement_prv: undefined,
-            switch: 0,
-            try: 0
-        });
+                ? "anonymous"
+                : anon
+            )
+        );
+        the_function.parameter_count = Number(Boolean(mode_fart_unwrapped));
+        the_function.signature = (
+            mode_fart_unwrapped
+            ? token_prv.id
+            : ["("]
+        );
+        the_function.switch = 0;
+        the_function.try = 0;
 
 // PR-384 - Relax warning "function_in_loop".
 //
@@ -6121,6 +6128,7 @@ function jslint_phase3_parse(state) {
             if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
 
 // PR-500 - Unify ES2015-destructure-logic. - function ([aa]) {...}
+
                 prefix_destructure(
 
 // 4.par.1 - Mark 'enrolled', the function-parameter, during destructuring.
@@ -11883,9 +11891,10 @@ function sentinel() {}
                 processArgv0,
                 processArgv.slice(1),
                 {
-                    env: Object.assign({}, process.env, {
+                    env: {
+                        ...process.env,
                         NODE_V8_COVERAGE: coverageDir
-                    }),
+                    },
 
 // PR-465
 // https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
@@ -12117,35 +12126,40 @@ function sentinel() {}
 
 // Export jslint as cjs/esm.
 
-jslint_export = Object.freeze(Object.assign(jslint, {
-    assertErrorThrownAsync,
-    assertJsonEqual,
-    assertOrThrow,
-    debugInline,
-    fsWriteFileWithParents,
-    globExclude,
-    htmlEscape,
-    jslint,
-    jslint_apidoc,
-    jslint_assert,
-    jslint_charset_ascii,
-    jslint_cli,
-    jslint_edition,
-    jslint_phase1_split,
-    jslint_phase2_lex,
-    jslint_phase3_parse,
-    jslint_phase4_walk,
-    jslint_phase5_whitage,
-    jslint_report,
-    jstestDescribe,
-    jstestIt,
-    jstestOnExit,
-    moduleFsInit,
-    noop,
-    objectDeepCopyWithKeysSorted,
-    v8CoverageListMerge,
-    v8CoverageReportCreate
-}));
+jslint_export = Object.freeze(
+    Object.assign(
+        jslint,
+        {
+            assertErrorThrownAsync,
+            assertJsonEqual,
+            assertOrThrow,
+            debugInline,
+            fsWriteFileWithParents,
+            globExclude,
+            htmlEscape,
+            jslint,
+            jslint_apidoc,
+            jslint_assert,
+            jslint_charset_ascii,
+            jslint_cli,
+            jslint_edition,
+            jslint_phase1_split,
+            jslint_phase2_lex,
+            jslint_phase3_parse,
+            jslint_phase4_walk,
+            jslint_phase5_whitage,
+            jslint_report,
+            jstestDescribe,
+            jstestIt,
+            jstestOnExit,
+            moduleFsInit,
+            noop,
+            objectDeepCopyWithKeysSorted,
+            v8CoverageListMerge,
+            v8CoverageReportCreate
+        }
+    )
+);
 // module.exports = jslint_export;              // Export jslint as cjs.
 export default Object.freeze(jslint_export);    // Export jslint as esm.
 jslint_import_meta_url = import.meta.url;

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -394,7 +394,6 @@
     v8CoverageListMerge,
     v8CoverageReportCreate,
     value,
-    var_on_top,
     variable,
     variable_prv,
     version,
@@ -1572,9 +1571,6 @@ function jslint(
         case "number_isNaN":
             mm = `Use Number.isNaN function to compare with NaN.`;
             break;
-        case "out_of_scope_a":
-            mm = `'${a}' is out of scope.`;
-            break;
         case "redefinition_a_b":
             mm = `Redefinition of '${a}' from line ${b}.`;
             break;
@@ -1590,6 +1586,9 @@ function jslint(
         case "subscript_a":
             mm = `['${a}'] is better written in dot notation.`;
             break;
+        case "temporal_dead_zone_a":
+            mm = `'${a}' was used before it was defined.`;
+            break;
         case "todo_comment":
             mm = `Unexpected TODO comment.`;
             break;
@@ -1598,6 +1597,9 @@ function jslint(
             break;
         case "too_many_digits":
             mm = `Too many digits.`;
+            break;
+        case "unassigned_var_a":
+            mm = `Unassigned variable '${a}'.`;
             break;
         case "unclosed_comment":
             mm = `Unclosed comment.`;
@@ -1664,9 +1666,6 @@ function jslint(
             mm = (
                 `Unexpected 'typeof'. Use '===' to compare directly with ${a}.`
             );
-            break;
-        case "uninitialized_a":
-            mm = `Uninitialized '${a}'.`;
             break;
         case "unopened_enable":
             mm = (
@@ -5242,10 +5241,10 @@ function jslint_phase3_parse(state) {
 
         const id = name.id;
         let earlier;
+        name_list.push(name);
         name.assigned = assigned;
         name.readonly = readonly;
         name.role = role;
-        name_list.push(name);
         if (role === "variable") {
             name.arity = "variable";
         }
@@ -6020,13 +6019,13 @@ function jslint_phase3_parse(state) {
                 name.expression = parse_expression(0);
 
 // test_cause:
-// ["function aa([aa=aa]){}", "name_lookup", "out_of_scope_a", "aa", 17]
+// ["function aa([aa=aa]){}", "name_lookup", "temporal_dead_zone_a", "aa", 17]
 // ["function aa([aa=aa]){}", "name_parse", "optional", "aa", 0]
-// ["function aa({aa=aa}){}", "name_lookup", "out_of_scope_a", "aa", 17]
+// ["function aa({aa=aa}){}", "name_lookup", "temporal_dead_zone_a", "aa", 17]
 // ["function aa({aa=aa}){}", "name_parse", "optional", "aa", 0]
-// ["let[aa=bb]=0;let bb", "name_lookup", "out_of_scope_a", "bb", 8]
+// ["let[aa=bb]=0;let bb", "name_lookup", "temporal_dead_zone_a", "bb", 8]
 // ["let[aa=bb]=0;let bb", "name_parse", "optional", "aa", 0]
-// ["let{aa=bb}=0;let bb", "name_lookup", "out_of_scope_a", "bb", 8]
+// ["let{aa=bb}=0;let bb", "name_lookup", "temporal_dead_zone_a", "bb", 8]
 // ["let{aa=bb}=0;let bb", "name_parse", "optional", "aa", 0]
 
                 test_cause("optional", name.id);
@@ -8399,13 +8398,13 @@ function jslint_phase4_walk(state) {
 // Warn variable is 'out-of-scope'.
 
 // test_cause:
-// ["(aa=aa)=>0", "name_lookup", "out_of_scope_a", "aa", 5]
-// ["let [aa]=aa", "name_lookup", "out_of_scope_a", "aa", 10]
-// ["let aa=()=>aa", "name_lookup", "out_of_scope_a", "aa", 12]
-// ["let aa=aa", "name_lookup", "out_of_scope_a", "aa", 8]
-// ["let aa=bb;let bb", "name_lookup", "out_of_scope_a", "bb", 8]
+// ["(aa=aa)=>0", "name_lookup", "temporal_dead_zone_a", "aa", 5]
+// ["let [aa]=aa", "name_lookup", "temporal_dead_zone_a", "aa", 10]
+// ["let aa=()=>aa", "name_lookup", "temporal_dead_zone_a", "aa", 12]
+// ["let aa=aa", "name_lookup", "temporal_dead_zone_a", "aa", 8]
+// ["let aa=bb;let bb", "name_lookup", "temporal_dead_zone_a", "bb", 8]
 
-            warn("out_of_scope_a", thing);
+            warn("temporal_dead_zone_a", thing);
         }
         return the_variable;
     }
@@ -9524,9 +9523,9 @@ function jslint_phase5_whitage(state) {
                 } else if (!name.assigned) {
 
 // test_cause:
-// ["let aa;aa();", "delve", "uninitialized_a", "aa", 5]
+// ["let aa;aa();", "delve", "unassigned_var_a", "aa", 5]
 
-                    warn("uninitialized_a", name);
+                    warn("unassigned_var_a", name);
                 }
             }
         });
@@ -10015,10 +10014,9 @@ function jslint_phase5_whitage(state) {
         no_space_only();
     }
 
-// uninitialized_and_unused();
-// Delve into the functions looking for variables that were not initialized
-// or used. If the file imports or exports, then its global object is also
-// delved.
+// unassigned_or_unused();
+// Delve into the functions looking for variables that were not assigned or
+// used. If the file imports or exports, then its global object is also delved.
 
 // PR-502 - tighten warning of unused variables to be always on.
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -104,6 +104,7 @@
     assertJsonEqual,
     assertOrThrow,
     assign,
+    assigned,
     assignment,
     async,
     b,
@@ -215,7 +216,6 @@
     indent2,
     index,
     indexOf,
-    init,
     isArray,
     isBlockCoverage,
     isHole,
@@ -4413,7 +4413,7 @@ function jslint_phase3_parse(state) {
                     false,              // readonly
                     the_token.name_list,        // name_list
                     left,               // name
-                    false               // init
+                    false               // assigned
                 );
             } else {
                 the_token.expression = [left, right];
@@ -5197,12 +5197,12 @@ function jslint_phase3_parse(state) {
         readonly,
         name_list,
         name,
-        init
+        assigned
     ) {
 
 // This function will:
 // 1. Push variable or function-parameter <name> to <name_list>.
-// 2. Set <name>.init = true, if its an assigned-variable,
+// 2. Set <name>.assigned = true, if its an assigned-variable,
 //    a function-parameter, or existing variable assigned new value.
 // 3. Declare <name> in <scope_declared>.context, if its a declared-variable,
 //    or function-parameter.
@@ -5212,40 +5212,40 @@ function jslint_phase3_parse(state) {
 //
 // 1.imp.1 - Mark 'declared', the import-name, during import-statement.
 // 1.imp.2 - Mark 'alive', the import-name, after import-statement.
-// 1.imp.3 - Mark 'init', the import-name, during import-statement.
+// 1.imp.3 - Mark 'assigned', the import-name, during import-statement.
 //
 // 2.fun.1 - Mark 'declared', the function-name, during function-declaration.
 // 2.fun.2 - Mark 'alive', the function-name, during function-declaration.
-// 2.fun.3 - Mark 'init', the function-name, during function-declaration.
+// 2.fun.3 - Mark 'assigned', the function-name, during function-declaration.
 //
 // 3.cat.1 - Mark 'declared', the catch-variable, before catch-block.
 // 3.cat.2 - Mark 'alive', the catch-variable, before catch-block.
-// 3.cat.3 - Mark 'init', the catch-variable, before catch-block.
+// 3.cat.3 - Mark 'assigned', the catch-variable, before catch-block.
 //
 // 3.glo.1 - Mark 'declared', the global-variable, immediately.
 // 3.glo.2 - Mark 'alive', the global-variable, immediately.
-// 3.glo.3 - Mark 'init', the global-variable, immediately.
+// 3.glo.3 - Mark 'assigned', the global-variable, immediately.
 //
 // 3.var.1 - Mark 'declared', the variable, during variable-declaration.
 // 3.var.2 - Mark 'alive', the variable, after variable-declaration.
-// 3.var.3 - Mark 'init', the variable, after assignment.
-// 3.var.3 - Mark 'init', the variable, during variable-declaration.
+// 3.var.3 - Mark 'assigned', the variable, after assignment.
+// 3.var.3 - Mark 'assigned', the variable, during variable-declaration.
 //
 // 4.par.1 - Mark 'declared', the function-parameter, during destructuring.
 // 4.par.1 - Mark 'declared', the function-parameter, if unwrapped.
 // 4.par.2 - Mark 'alive', the function-parameter, after destructuring.
-// 4.par.3 - Mark 'init', the function-parameter, if unwrapped.
+// 4.par.3 - Mark 'assigned', the function-parameter, if unwrapped.
 //
 // 5.lab.1 - Mark 'declared', the label-name, before control-flow-block.
 // 5.lab.2 - Mark 'alive', the label-name, before control-flow-block.
-// 5.lab.3 - Mark 'init', the label-name, before control-flow-block.
+// 5.lab.3 - Mark 'assigned', the label-name, before control-flow-block.
 
         const id = name.id;
         let earlier;
-        name_list.push(name);
-        name.init = init;
+        name.assigned = assigned;
         name.readonly = readonly;
         name.role = role;
+        name_list.push(name);
         if (role === "variable") {
             name.arity = "variable";
         }
@@ -5998,7 +5998,7 @@ function jslint_phase3_parse(state) {
                     readonly,           // readonly
                     sub_list,           // name_list
                     name,               // name
-                    true                // init
+                    true                // assigned
                 );
                 advance_and_signature_push(token_nxt.id);
                 return;
@@ -6009,7 +6009,7 @@ function jslint_phase3_parse(state) {
                 readonly,               // readonly
                 sub_list,               // name_list
                 name,                   // name
-                true                    // init
+                true                    // assigned
             );
             if (token_nxt.id === "=") {
                 optional = the_function_toplevel && token_now;
@@ -6151,9 +6151,9 @@ function jslint_phase3_parse(state) {
                 [],                     // name_list
                 name,                   // name
 
-// 2.fun.3 - Mark 'init', the function-name, during function-declaration.
+// 2.fun.3 - Mark 'assigned', the function-name, during function-declaration.
 
-                true                    // init
+                true                    // assigned
             );
 
 // 2.fun.2 - Mark 'alive', the function-name, during function-declaration.
@@ -6226,9 +6226,9 @@ function jslint_phase3_parse(state) {
                 the_function.name_list, // name_list
                 token_prv,              // name
 
-// 4.par.3 - Mark 'init', the function-parameter, if unwrapped.
+// 4.par.3 - Mark 'assigned', the function-parameter, if unwrapped.
 
-                true                    // init
+                true                    // assigned
             );
         } else {
             token_now.free = false;
@@ -7214,9 +7214,9 @@ function jslint_phase3_parse(state) {
                     the_import.name_list,       // name_list
                     name,               // name
 
-// 1.imp.3 - Mark 'init', the import-name, during import-statement.
+// 1.imp.3 - Mark 'assigned', the import-name, during import-statement.
 
-                    true                // init
+                    true                // assigned
                 );
             } else {
                 advance("{");
@@ -7253,9 +7253,9 @@ function jslint_phase3_parse(state) {
                             the_import.name_list,       // name_list
                             name,       // name
 
-// 1.imp.3 - Mark 'init', the import-name, during import-statement.
+// 1.imp.3 - Mark 'assigned', the import-name, during import-statement.
 
-                            true        // init
+                            true        // assigned
                         );
                         if (token_nxt.id !== ",") {
                             break;
@@ -7365,9 +7365,9 @@ function jslint_phase3_parse(state) {
             [],                 // name_list
             the_label,          // name
 
-// 5.lab.3 - Mark 'init', the label-name, before control-flow-block.
+// 5.lab.3 - Mark 'assigned', the label-name, before control-flow-block.
 
-            true                // init
+            true                // assigned
         );
 
 // 5.lab.2 - Mark 'alive', the label-name, before control-flow-block.
@@ -7657,9 +7657,9 @@ function jslint_phase3_parse(state) {
                         [],             // name_list
                         token_nxt,      // name
 
-// 3.cat.3 - Mark 'init', the catch-variable, before catch-block.
+// 3.cat.3 - Mark 'assigned', the catch-variable, before catch-block.
 
-                        true            // init
+                        true            // assigned
                     );
 
 // 3.cat.2 - Mark 'alive', the catch-variable, before catch-block.
@@ -7836,9 +7836,9 @@ function jslint_phase3_parse(state) {
                     the_variable.name_list,     // name_list
                     name,               // name
 
-// 3.var.3 - Mark 'init', the variable, during variable-declaration.
+// 3.var.3 - Mark 'assigned', the variable, during variable-declaration.
 
-                    Boolean(name.expression)    // init
+                    Boolean(name.expression)    // assigned
                 );
             } else {
 
@@ -8367,11 +8367,11 @@ function jslint_phase4_walk(state) {
 // 3.glo.2 - Mark 'alive', the global-variable, immediately.
 
                 alive: true,
+
+// 3.glo.3 - Mark 'assigned', the global-variable, immediately.
+
+                assigned: true,
                 id,
-
-// 3.glo.3 - Mark 'init', the global-variable, immediately.
-
-                init: true,
                 readonly: true,
                 role: "variable",
                 scope_declared: token_global
@@ -8412,9 +8412,9 @@ function jslint_phase4_walk(state) {
 
     function post_a_assignment(thing) {
 
-// Assignment using = sets the init property of a variable. No other assignment
-// operator can do this. A = token keeps that variable (or array of variables
-// in case of destructuring) in its name property.
+// Assignment using = sets the assigned property of a variable. No other
+// assignment operator can do this. A = token keeps that variable (or array of
+// variables in case of destructuring) in its name property.
 
         const lvalue = thing.expression[0];
         let right;
@@ -8459,9 +8459,9 @@ function jslint_phase4_walk(state) {
                 const the_variable = name_lookup(name);
                 if (the_variable && !the_variable.readonly) {
 
-// 3.var.3 - Mark 'init', the variable, after assignment.
+// 3.var.3 - Mark 'assigned', the variable, after assignment.
 
-                    the_variable.init = true;
+                    the_variable.assigned = true;
                     return;
                 }
 
@@ -9521,7 +9521,7 @@ function jslint_phase5_whitage(state) {
 // ["let aa=0;try{aa();}catch(bb){aa();}", "delve", "unused_a", "bb", 26]
 
                     warn("unused_a", name);
-                } else if (!name.init) {
+                } else if (!name.assigned) {
 
 // test_cause:
 // ["let aa;aa();", "delve", "uninitialized_a", "aa", 5]
@@ -10059,9 +10059,9 @@ function jslint_phase5_whitage(state) {
         }
         nr_comments_skipped = 0;
         delete left.alive;
+        delete left.assigned;
         delete left.calls;
         delete left.free;
-        delete left.init;
         delete left.open;
         delete left.used;
         left = right;

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -2028,10 +2028,11 @@ function replaceListReplace(replaceList, data) {
         /^\/\*jslint-disable\*\/\n\/\*\nshRollupFetch\n(\{\n[\S\s]*?\n\})([\S\s]*?)\n\*\/\n/m
     ).exec(await moduleFs.promises.readFile(process.argv[1], "utf8"));
     // JSON.parse match1 with comment
-    matchObj[1] = Object.assign({
+    matchObj[1] = {
         fetchList: [],
-        replaceList: []
-    }, JSON.parse(matchObj[1]));
+        replaceList: [],
+        ...JSON.parse(matchObj[1])
+    };
     fetchList = JSON.parse(JSON.stringify(matchObj[1].fetchList));
     // init repoDict, fetchList
     repoDict = {};
@@ -3426,9 +3427,10 @@ function sentinel() {}
     processArgv0,
     processArgv.slice(1),
     {
-     env: Object.assign({}, process.env, {
+     env: {
+      ...process.env,
       NODE_V8_COVERAGE: coverageDir
-     }),
+     },
      shell: (
       processArgv0.endsWith(".bat")
       || processArgv0.endsWith(".cmd")

--- a/test.mjs
+++ b/test.mjs
@@ -985,16 +985,17 @@ aa();
             ],
             scope: [
                 "(function aa(bb = aa) {\n    aa(bb);\n}());",
+                (`
+/*jslint variable*/
+if (String) {
+    let aa = 0;
+    aa();
+} else {
+    let aa = 0;
+    aa();
+}
+                `),
                 "function aa(bb = aa) {\n    aa(bb);\n}\naa();",
-                //!! (`
-//!! if (String) {
-    //!! let aa = 0;
-    //!! aa();
-//!! } else {
-    //!! let aa = 0;
-    //!! aa();
-//!! }
-                //!! `),
                 (`
 if (String) {
     var aa = 0; //jslint-ignore-line

--- a/test.mjs
+++ b/test.mjs
@@ -703,6 +703,12 @@ String.aa().getTime();
     aa(bb, cc, dd, ee, ff, gg);
 }());
                     `),
+                    (`
+/*jslint fart*/
+(({expr}) => {
+    aa(bb, cc, dd, ee, ff, gg);
+}());
+                    `),
                     "const {expr}",
                     "let {expr}",
                     "let [aa, bb, cc, dd, ee, ff, gg] = 0;\n{expr}"
@@ -1103,6 +1109,7 @@ aa();
 
         [{subscript: true}, "String[\"aa\"]();"],
         [{test_internal_error: true}, ""],
+        [{test_unknown_warning_code: true}, ""],
         [{this: true}, "String(this);"],
         [{trace: true}, ""],
         [{unordered: true}, (`
@@ -1139,11 +1146,12 @@ function aa() {
         jstestIt((
             `test option=${JSON.stringify(option_dict)} handling-behavior`
         ), function () {
-            let elemNow = JSON.stringify([
-                option_dict, source
-            ]);
-            let warningsLength = (
-                option_dict.test_internal_error
+            const elemNow = JSON.stringify([option_dict, source]);
+            const warningsLength = (
+                (
+                    option_dict.test_internal_error
+                    || option_dict.test_unknown_warning_code
+                )
                 ? 1
                 : 0
             );

--- a/test.mjs
+++ b/test.mjs
@@ -703,13 +703,13 @@ String.aa().getTime();
     aa(bb, cc, dd, ee, ff, gg);
 }());
                     `),
-                    //!! (`
-//!! (function zz() {
-    //!! for (const {expr} of zz) {
-        //!! aa(bb, cc, dd, ee, ff, gg);
-    //!! }
-//!! }());
-                    //!! `),
+                    (`
+(function for_loop() {
+    for (const {expr} of for_loop) {
+        aa(bb, cc, dd, ee, ff, gg);
+    }
+}());
+                    `),
                     (`
 /*jslint fart*/
 (({expr}) => {
@@ -720,7 +720,7 @@ String.aa().getTime();
                     "let {expr}",
                     "let [aa, bb, cc, dd, ee, ff, gg] = 0;\n{expr}"
                 ].map(function (source) {
-                    source = source.trim().replace("{expr}", String(`
+                    let expr = String(`
 [
     {
         cc,
@@ -734,7 +734,11 @@ String.aa().getTime();
         ...ff
     ]
 ]
-                    `).trim());
+                    `).trim();
+                    if ((/function for_loop/).test(source)) {
+                        expr = expr.replace((/\n/g), "\n    ");
+                    }
+                    source = source.trim().replace("{expr}", expr);
                     if (!(/\=>|function/).test(source)) {
                         source = (`
 ${source} = (function () {

--- a/test.mjs
+++ b/test.mjs
@@ -966,6 +966,15 @@ aa();
             scope: [
                 "(function aa(bb = aa) {\n    aa(bb);\n}());",
                 "function aa(bb = aa) {\n    aa(bb);\n}\naa();",
+                //!! (`
+//!! if (String) {
+    //!! let aa = 0;
+    //!! aa();
+//!! } else {
+    //!! let aa = 0;
+    //!! aa();
+//!! }
+                //!! `),
                 (`
 if (String) {
     var aa = 0; //jslint-ignore-line

--- a/test.mjs
+++ b/test.mjs
@@ -810,16 +810,30 @@ aa();
             ],
             for: [
                 (`
-/*jslint for*/
-function aa(bb) {
-    for (bb = 0; bb < 0; bb += 1) {
-        bb();
+function aa(bb, cc) {
+    for (; bb < 0; bb += 1) { //jslint-ignore-line
+        bb(cc);
     }
-    for (const bb in bb) { //jslint-ignore-line
-        bb();
+    for (bb = 0; bb < 0; bb += 1) { //jslint-ignore-line
+        bb(cc);
     }
-    for (const bb of bb) { //jslint-ignore-line
-        bb();
+    for (cc in bb) { //jslint-ignore-line
+        bb(cc);
+    }
+    for (cc of bb) { //jslint-ignore-line
+        cc();
+    }
+    for (const ii in bb) { //jslint-ignore-line
+        bb(cc, ii);
+    }
+    for (const ii of bb) {
+        bb(cc, ii);
+    }
+    for (let ii = 0; ii < 0; ii += 1) {
+        bb(cc, ii);
+    }
+    for (let ii of bb) {
+        bb(cc, ii);
     }
 }
 aa();
@@ -1082,17 +1096,6 @@ jstestDescribe((
 // PR-404 - Alias "evil" to jslint-directive "eval" for backwards-compat.
 
         [{eval: true, evil: true}, "new Function();\neval();"],
-        [
-            {for: true},
-            (`
-function aa(aa) {
-    for (aa = 0; aa < 0; aa += 1) {
-        aa();
-    }
-}
-aa();
-            `)
-        ],
         [{getset: true}, "String({get aa() {\n    return;\n}});"],
         [{getset: true}, "String({set aa(aa) {\n    return aa;\n}});"],
         [{indent2: true}, sourceJslintMjs.replace((/    /g), "  ")],

--- a/test.mjs
+++ b/test.mjs
@@ -703,6 +703,13 @@ String.aa().getTime();
     aa(bb, cc, dd, ee, ff, gg);
 }());
                     `),
+                    //!! (`
+//!! (function zz() {
+    //!! for (const {expr} of zz) {
+        //!! aa(bb, cc, dd, ee, ff, gg);
+    //!! }
+//!! }());
+                    //!! `),
                     (`
 /*jslint fart*/
 (({expr}) => {
@@ -885,8 +892,46 @@ String
             label: [
                 (`
 function aa() {
-bb:
-    while (true) {
+bb: do {
+        if (true) {
+            break bb;
+        }
+    } while (true);
+}
+aa();
+                `),
+                (`
+function aa() {
+bb: for (const ii of aa) {
+        if (ii) {
+            break bb;
+        }
+    }
+}
+aa();
+                `),
+                (`
+function aa() {
+bb: for (let ii = 0; ii < 0; ii += 1) {
+        if (ii) {
+            break bb;
+        }
+    }
+}
+aa();
+                `),
+                (`
+function aa() {
+bb: switch (aa) {
+    case 0:
+        break bb;
+    }
+}
+aa();
+                `),
+                (`
+function aa() {
+bb: while (true) {
         if (true) {
             break bb;
         }

--- a/test.mjs
+++ b/test.mjs
@@ -809,6 +809,12 @@ function aa(bb) {
     for (bb = 0; bb < 0; bb += 1) {
         bb();
     }
+    for (const bb in bb) { //jslint-ignore-line
+        bb();
+    }
+    for (const bb of bb) { //jslint-ignore-line
+        bb();
+    }
 }
 aa();
                 `)


### PR DESCRIPTION
Fixes #176.

#### A sorely missed feature, that happily is now implemented :)
```js
// for-of statement using const or let now passes jslint w/o warnings
(function for_loop() {
    for (const [ // full destructure support
        {
            cc,
            dd = 0,
            dd: ee,
            ee: [{bb}],
            ...aa
        },
        [
            gg,
            ...ff
        ]
    ] of for_loop) {
        aa(bb, cc, dd, ee, ff, gg);
    }

    // traditional for(;;) statement using let is now allowed
    for (let aa = 0; aa < 8; aa += 1) {
        String(aa);
    }
}());
```

#### under-the-hood, jslint's scoping system was significantly revamped
    - by adding block-level scoping for:
        - `const`, `let`, and `declared-function-name`.
    - in order to integrate normal variable-declaration-logic into for-loop variables.

#### a beneficial side-effect, is that `const` and `let` declarations can be declared inside the top of statement-blocks,
    - instead of top of function-block or script, e.g.:
```js
/*jslint beta*/
function foo() {
    var aa = 0; // var statement still required to be at top of function
    ...
    if (aa) {
        let bb = 1; // let statement can now be inside the top of a block
        ...
    } else {
        const bb = 2; // const statement can now be inside the top of a block
                      // and won't complain about name-collision from previous block
        ...
    }
}
```

#### following special variables / parameters / names are declared inside a hidden scope to avoid name-collision with normal variables:
    - catch-variable
    - for-variable
    - function-parameter
    - label-name

<img width="937" height="1184" alt="image" src="https://github.com/user-attachments/assets/698fd9be-c5c8-4e60-bc38-a7842e49cf72" />

This PR will:
- jslint-ecma - Add ES2015-feature for..of.

This PR will additionally:
- jslint - Disable directive-option /*jslint for*/, replacing it with for-loop specific warnings.
- jslint - Update scope-related warnings for variables, depending on whether they are let/const (scope_block) or var (scope_function).
- jslint - Change scope from scope_function to scope_block:
    - const-declaration
    - let-declaration
    - function-declaration
- jslint - Add implicit scope_block for:
    - do-while
    - for-loop
    - if-else
    - while-loop
- jslint - Add hidden scope_block for:
    - catch-variable
    - for-variable
    - function-parameter
    - label-name
- jslint - Restrict scope from scope_function to its own function-body:
    - named-function-expression
- jslint - Rename internal scope-variables to imporove readability of scope-logic:
    - 'blockage' to 'scope_block'
    - 'functionage' to 'scope_function'
- jslint - Add block-scope to internal-function jslint_phase3_parse().

