### PR TITLE
# v2026.7.30

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -19,8 +19,8 @@ shCiArtifactUploadCustom() {(set -e
     node --input-type=module --eval '
 import moduleFs from "fs";
 (async function () {
-    let cacheKey = Math.random().toString(36).slice(-4);
-    let fileDict = {};
+    const cacheKey = Math.random().toString(36).slice(-4);
+    const fileDict = {};
     await Promise.all([
         "index.html"
     ].map(async function (file) {
@@ -49,7 +49,7 @@ import moduleFs from "fs";
 import moduleFs from "fs";
 import moduleChildProcess from "child_process";
 (async function () {
-    let fileDict = {};
+    const fileDict = {};
     let screenshotCurl;
     await Promise.all([
         "README.md"
@@ -130,7 +130,7 @@ echo "\
     node --input-type=module --eval '
 import moduleChildProcess from "child_process";
 (async function () {
-    let {
+    const {
         GITHUB_BRANCH0,
         GITHUB_GITHUB_IO
     } = process.env;
@@ -192,7 +192,7 @@ shCiBaseCustom() {(set -e
 import jslint from "./jslint.mjs";
 import moduleFs from "fs";
 (async function () {
-    let fileDict = {};
+    const fileDict = {};
     let fileModified;
     let versionBeta;
     let versionMaster;
@@ -244,8 +244,8 @@ import moduleFs from "fs";
             file: "jslint.mjs",
             // update version
             src: fileDict["jslint.mjs"].replace((
-                /^let jslint_edition = ".*?";$/m
-            ), `let jslint_edition = "v${versionBeta}";`)
+                /^const jslint_edition = ".*?";$/m
+            ), `const jslint_edition = "v${versionBeta}";`)
         }, {
             file: "jslint_ci.sh",
             // update coverage-code
@@ -286,7 +286,7 @@ import moduleFs from "fs";
         file,
         src
     }) {
-        let src0 = fileDict[file];
+        const src0 = fileDict[file];
         if (src !== src0) {
             console.error(`update file ${file}`);
             fileModified = file;
@@ -423,19 +423,18 @@ function objectDeepCopyWithKeysSorted(obj) {
     await Promise.all(promiseList);
     Object.entries(dictAll).forEach(function ([dictName, dict]) {
         Object.keys(dict).forEach(function (name) {
-            let val;
             if (dictName !== "ecma_auto" && dictAll.ecma_auto[name]) {
                 delete dict[name];
             }
             if (dictName === "node_auto") {
-                val = ["----", "----"];
+                const value = ["----", "----"];
                 if (dict[name]) {
-                    val[0] = "node";
+                    value[0] = "node";
                 }
                 if (dictAll.browser_auto_node[name]) {
-                    val[1] = "brow";
+                    value[1] = "brow";
                 }
-                dict[name] = val.join(" ");
+                dict[name] = value.join(" ");
             }
         });
     });
@@ -460,11 +459,11 @@ function objectDeepCopyWithKeysSorted(obj) {
                 .trim()
                 .replace((
                     /^( *?".*?": )(".*?")/gm
-                ), function (ignore, name, val) {
+                ), function (ignore, name, value) {
                     return (
                         name
                         + " ".repeat(Math.max(0, 40 - name.length))
-                        + val
+                        + value
                     );
                 })
             + "$2"
@@ -494,7 +493,7 @@ shCiVscePackageJslintWrapperVscode() {(set -e
     node --input-type=module --eval '
 import moduleFs from "fs";
 (async function () {
-    let fileDict = {};
+    const fileDict = {};
     await Promise.all([
         "README.md"
     ].map(async function (file) {
@@ -637,7 +636,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2026.7.1"
+                "version": "2026.7.30"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - jslint-ecma - Add ES2018-feature Asynchronous Iteration.
 - jslint-ecma - Add ES2015-feature iterators.
 - jslint - Audit token-property '.free'.
-- jslint - Add warning and tdz for function-declaration inside block-scope.
 - jslint-ecma - Expand ES2015-feature-support for es-module-export-statement.
 - jslint - Relax warning expected_line_break_a_b for ternary-operator inside template-literal.
 - jslint - Add ability to auto-fix whitespace.
@@ -12,7 +11,7 @@
 - jslint - Add new warning requiring paren around plus-separated concatenations.
 - jslint - Try to improve parser to be able to parse jquery.js without stopping.
 
-# v2026.7.1-beta
+# v2026.7.30
 - jslint-ecma - Add ES2015-feature for..of.
 - jslint - Disable directive-option /*jslint for*/, replacing it with for-loop specific warnings.
 - jslint - Update scope-related warnings for variables, depending on whether they are let/const (scope_block) or var (scope_function).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2026.6.30)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2026.7.30)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/index.html) |
@@ -1068,7 +1068,7 @@ if (false) {
         - verify ci-success @ https://github.com/kaizhu256/jslint/actions
         - verify ci-success @ https://github.com/jslint-org/jslint/actions
 
-1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-v2026.6.30
+1. goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-v2026.7.30
     - click `Create pull request`
     - input `Add a title *` with: `# v20yy.mm.dd`
     - input `Add a description` with:

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -410,23 +410,23 @@
 
 // init debugInline
 const debugInline = (function () {
-    let __consoleError = function () {
-        return;
-    };
+    let consoleError = Object;
     function debug(...argList) {
 
 // This function will print <argList> to stderr and then return <argList>[0].
 
-        __consoleError("\n\ndebugInline");
-        __consoleError(...argList);
-        __consoleError("\n");
+        consoleError("\n\ndebugInline");
+        consoleError(...argList);
+        consoleError("\n");
+        if (consoleError === Object) {
+            consoleError = console.error;
+        }
         return argList[0];
     }
-    debug(); // Coverage-hack.
-    __consoleError = console.error; //jslint-ignore-line
     return debug;
 }());
-const jslint_charset_ascii = (
+debugInline(); // coverage-hack
+const jslint_charset_ascii = ( //jslint-ignore-line
     "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007"
     + "\b\t\n\u000b\f\r\u000e\u000f"
     + "\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017"
@@ -435,7 +435,7 @@ const jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-const jslint_edition = "v2026.7.1-beta";
+const jslint_edition = "v2026.7.30";
 const jslint_fudge = 1;                 // Fudge starting line and starting
                                         // ... column to 1.
 const jslint_global_dict_all = {
@@ -2980,7 +2980,7 @@ function jslint_phase2_lex(state) {
         body.replace(jslint_rgx_directive_part, function (
             match0,
             key,
-            val,
+            value,
             jj
         ) {
             if (ii !== jj) {
@@ -2996,12 +2996,12 @@ function jslint_phase2_lex(state) {
             ii += match0.length;
             switch (the_comment.directive) {
             case "global":
-                if (val) {
+                if (value) {
 
 // test_cause:
 // ["/*global aa:false*/", "lex_comment", "bad_option_a", "aa:false", 1]
 
-                    warn("bad_option_a", the_comment, key + ":" + val);
+                    warn("bad_option_a", the_comment, key + ":" + value);
                 }
                 global_dict[key] = "user-defined";
 
@@ -3011,7 +3011,7 @@ function jslint_phase2_lex(state) {
 
                 break;
             case "jslint":
-                if (!option_set_item(key, val !== "false")) {
+                if (!option_set_item(key, value !== "false")) {
 
 // test_cause:
 // ["/*jslint undefined*/", "lex_comment", "bad_option_a", "undefined", 1]
@@ -3873,7 +3873,7 @@ function jslint_phase2_lex(state) {
         return token_create(snippet);
     }
 
-    function option_set_item(key, val) {
+    function option_set_item(key, value) {
 
 // These are the options that are recognized in the option object or that may
 // appear in a /*jslint*/ directive. Most options will have a boolean value,
@@ -3910,25 +3910,25 @@ function jslint_phase2_lex(state) {
         case "variable":        // Allow unordered const and let declarations
                                 // ... that are not at top of scope_function.
         case "white":           // Allow messy whitespace.
-            option_dict[key] = val;
+            option_dict[key] = value;
             break;
 
 // PR-404 - Alias "evil" to jslint-directive "eval" for backwards-compat.
 
         case "evil":
-            return option_set_item("eval", val);
+            return option_set_item("eval", value);
 
 // PR-404 - Alias "nomen" to jslint-directive "name" for backwards-compat.
 
         case "name":
-            return option_set_item("nomen", val);
+            return option_set_item("nomen", value);
         default:
             return false;
         }
 
 // Initialize global-variables.
 
-        switch (val && key) {
+        switch (value && key) {
         case "browser":
         case "couch":
         case "devel":
@@ -4702,7 +4702,11 @@ function jslint_phase3_parse(state) {
                 test_cause("import");
                 break;
             default:
-                if (option_dict.beta && !option_dict.variable) {
+                if (
+                    (variable_prv.id !== "{" || the_variable.id === "var")
+                    && option_dict.beta
+                    && !option_dict.variable
+                ) {
 
 // test_cause:
 // ["String();const aa=0", "check", "var_on_top_a_b", "block", 10]
@@ -10794,11 +10798,11 @@ async function moduleFsInit() {
     }
 }
 
-function noop(val) {
+function noop(value) {
 
-// This function will do nothing except return <val>.
+// This function will do nothing except return <value>.
 
-    return val;
+    return value;
 }
 
 function objectDeepCopyWithKeysSorted(obj) {
@@ -10825,12 +10829,12 @@ function objectDeepCopyWithKeysSorted(obj) {
     return sorted;
 }
 
-function object_assign_from_list(dict, list, val) {
+function object_assign_from_list(dict, list, value) {
 
 // Assign each property-name from <list> to <dict>.
 
     list.forEach(function (key) {
-        dict[key] = val;
+        dict[key] = value;
     });
     return dict;
 }
@@ -10865,16 +10869,16 @@ function v8CoverageListMerge(processCovs) {
         return bb.endOffset - aa.endOffset;
     }
 
-    function dictKeyValueAppend(dict, key, val) {
+    function dictKeyValueAppend(dict, key, value) {
 
-// This function will append <val> to list <dict>[<key>].
+// This function will append <value> to list <dict>[<key>].
 
         let list = dict.get(key);
         if (list === undefined) {
             list = [];
             dict.set(key, list);
         }
-        list.push(val);
+        list.push(value);
     }
 
     function mergeTreeList(parentTrees) {

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -404,7 +404,7 @@ globalThis.assert(
 import moduleChildProcess from "child_process";
 import moduleFs from "fs";
 (async function () {
-    let fileDict = {};
+    const fileDict = {};
     let fileMain;
     let fileModified;
     let packageJson;
@@ -447,14 +447,14 @@ import moduleFs from "fs";
             file: fileMain,
             // update version
             src: fileDict[fileMain].replace((
-                /^let version = ".*?";$/m
-            ), `let version = "v${versionBeta}";`)
+                /^const version = ".*?";$/m
+            ), `const version = "v${versionBeta}";`)
         }
     ].map(async function ({
         file,
         src
     }) {
-        let src0 = fileDict[file];
+        const src0 = fileDict[file];
         if (src !== src0) {
             console.error(`update file ${file}`);
             fileModified = file;
@@ -650,14 +650,14 @@ import moduleAssert from "assert";
 import moduleFs from "fs";
 import moduleHttps from "https";
 (async function () {
-    let {
+    const {
         GITHUB_BRANCH0,
         GITHUB_GITHUB_IO,
         GITHUB_REPOSITORY,
         UPSTREAM_GITHUB_IO,
         UPSTREAM_REPOSITORY
     } = process.env;
-    let dict = {};
+    const dict = {};
     Array.from(
         await moduleFs.promises.readdir(".")
     ).forEach(async function (file) {
@@ -673,8 +673,8 @@ import moduleHttps from "https";
         data.replace((
             /\bhttps?:\/\/.+?([\s")\]]|\W?$)(<!--no-validate-->)?/gm
         ), function (url, removeLast, noValidate) {
+            const timeStart = Date.now();
             let req;
-            let timeStart = Date.now();
             if (removeLast && removeLast !== "/") {
                 url = url.slice(0, -1);
             }
@@ -1135,18 +1135,23 @@ shGithubPrCreate() {(set -e
 # This function will create-and-push a github-pull-commit to origin/alpha.
     node --input-type=module --eval '
 // init debugInline
-(function () {
-    let consoleError = console.error;
-    globalThis.debugInline = globalThis.debugInline || function (...argList) {
+const debugInline = (function () {
+    let consoleError = Object;
+    function debug(...argList) {
 
 // This function will print <argList> to stderr and then return <argList>[0].
 
         consoleError("\n\ndebugInline");
         consoleError(...argList);
         consoleError("\n");
+        if (consoleError === Object) {
+            consoleError = console.error;
+        }
         return argList[0];
-    };
+    }
+    return debug;
 }());
+debugInline(); // coverage-hack
 import moduleAssert from "assert";
 import moduleChildProcess from "child_process";
 import moduleFs from "fs";
@@ -1610,7 +1615,7 @@ import moduleRepl from "repl";
                     + "}).sort().join(\u0027\\n\u0027))\n"
                 );
                 break;
-            // syntax-sugar - print String(val)
+            // syntax-sugar - print String(value)
             case "print":
                 script = "console.error(String(" + match2 + "))\n";
                 break;
@@ -1706,11 +1711,11 @@ shJsonNormalize() {(set -e
 # 3. write normalized json-data back to file $1
     node --input-type=module --eval '
 import moduleFs from "fs";
-function noop(val) {
+function noop(value) {
 
-// This function will do nothing except return <val>.
+// This function will do nothing except return <value>.
 
-    return val;
+    return value;
 }
 function objectDeepCopyWithKeysSorted(obj) {
 
@@ -2514,13 +2519,13 @@ function v8CoverageListMerge(processCovs) {
   return bb.endOffset - aa.endOffset;
  }
 
- function dictKeyValueAppend(dict, key, val) {
+ function dictKeyValueAppend(dict, key, value) {
   let list = dict.get(key);
   if (list === undefined) {
    list = [];
    dict.set(key, list);
   }
-  list.push(val);
+  list.push(value);
  }
 
  function mergeTreeList(parentTrees) {

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "shCiArtifactUpload": 1,
     "shCiPublishNpm": 1,
     "type": "module",
-    "version": "2026.7.1-beta"
+    "version": "2026.7.30"
 }

--- a/test.mjs
+++ b/test.mjs
@@ -1034,8 +1034,8 @@ aa();
             ],
             scope: [
                 "(function aa(bb = aa) {\n    aa(bb);\n}());",
+                "function aa(bb = aa) {\n    aa(bb);\n}\naa();",
                 (`
-/*jslint variable*/
 if (String) {
     let aa = 0;
     aa();
@@ -1044,7 +1044,6 @@ if (String) {
     aa();
 }
                 `),
-                "function aa(bb = aa) {\n    aa(bb);\n}\naa();",
                 (`
 if (String) {
     var aa = 0; //jslint-ignore-line


### PR DESCRIPTION
- jslint-ecma - Add ES2015-feature for..of.
- jslint - Disable directive-option /*jslint for*/, replacing it with for-loop specific warnings.
- jslint - Update scope-related warnings for variables, depending on whether they are let/const (scope_block) or var (scope_function).
- jslint - Change warning 'out_of_scope_a' to 'temporal_dead_zone_a'.
- jslint - Change warning 'uninitialized_a' to 'unassigned_var_a'.
- jslint - Change scope from scope_function to scope_block:
    - const-declaration
    - let-declaration
    - function-declaration
- jslint - Add implicit scope_block for:
    - do-while
    - for-loop
    - if-else
    - while-loop
- jslint - Add hidden scope_block for:
    - catch-variable
    - for-variable
    - function-parameter
    - label-name
- jslint - Restrict scope from scope_function to its own function-body:
    - named-function-expression
- jslint - Rename internal scope-variables to imporove readability of scope-logic:
    - 'blockage' to 'scope_block'
    - 'functionage' to 'scope_function'
- jslint - Add block-scope to internal-function jslint_phase3_parse().
- jslint - Expand built-in-globals for browser, ecma, and node - auto-generated from online-sources.
- jslint-ci - Add automated ci for shellcheck to lint shell-scripts.
- jslint-regression - Cleanup indent for multiline-method-chaining.
- jslint-regression - Fix jslint crashing before warning about dangling ')' or ']'.
- jslint-parse - Fix jslint unable to continue parsing 'async aa => 0'.
- jslint-parse - Fix jslint unable to continue parsing 'function aa(){}0'.
- jslint-regression - Fix long-running regression where 'let x = x;' doesn't warn about temporal-dead-zone.
- jslint-warning - Tighten warning of unused variables to be always on, regardless of module / nodejs mode.
- jslint - Wrap all property-updates 'name.init = true/false' with calls to:
    name_declare()      - 'let aa=0'
    post_a_assignment() - 'aa=0'